### PR TITLE
fix(docs): getting started url

### DIFF
--- a/motoko/calc/README.md
+++ b/motoko/calc/README.md
@@ -14,7 +14,7 @@ The `div` function also includes code to prevent the program from attempting to 
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/counter/README.md
+++ b/motoko/counter/README.md
@@ -13,7 +13,7 @@ This program supports the following types of function calls:
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/echo/README.md
+++ b/motoko/echo/README.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/factorial/README.md
+++ b/motoko/factorial/README.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/favorite_cities/README.md
+++ b/motoko/favorite_cities/README.md
@@ -5,7 +5,7 @@ In this example, the `[Text]` notation indicates an array of a collection of UTF
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/hello-world/README.md
+++ b/motoko/hello-world/README.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/pubsub/README.md
+++ b/motoko/pubsub/README.md
@@ -18,7 +18,7 @@ Note: There are many obvious improvements (keying subscribers by topic in Publis
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ### Demo
 

--- a/motoko/simple_to_do/README.md
+++ b/motoko/simple_to_do/README.md
@@ -14,7 +14,7 @@ This project is implemented using the following Motoko source code files:
 
 ## Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/docs/developers-guide/getting-started.html).
 
 ## Demo
 


### PR DESCRIPTION
**Overview**
The links to `getting-started` resources are currently broken across examples.

**Requirements**
Just updating the links to the new location