### PR TITLE
Update to 0.5.7

### DIFF
--- a/motoko/hello-world/src/main.mo
+++ b/motoko/hello-world/src/main.mo
@@ -1,4 +1,4 @@
-import Prelude "mo:stdlib/prelude"
+import Prelude "mo:base/Prelude"
 
 actor HelloWorld {
   public func main() {

--- a/motoko/phone-book/src/phonebook/main.mo
+++ b/motoko/phone-book/src/phonebook/main.mo
@@ -1,5 +1,5 @@
-import List "mo:stdlib/list";
-import AssocList "mo:stdlib/assocList";
+import List "mo:base/List";
+import AssocList "mo:base/AssocList";
 
 type Name = Text;
 type Phone = Nat;

--- a/motoko/phone-book/src/phonebook/public/index.jsx
+++ b/motoko/phone-book/src/phonebook/public/index.jsx
@@ -14,14 +14,14 @@ class Phonebook extends React.Component {
     let desc = document.getElementById("newEntryDesc").value;
     let phone = document.getElementById("newEntryPhone").value;
 
-    phonebook.insert(name, desc, parseInt(phone, 10));
+    phonebook.insert(name, desc, parseInt(phone.replace(/\W+/g,''), 10));
   }
 
   async lookup() {
     let name = document.getElementById("lookupName").value;
     phonebook.lookup(name).then(opt_entry => {
       let [entry] = opt_entry;
-      if (entry === null) {
+      if (entry === null || entry === undefined) {
         entry = { name: "", description: "", phone: ""};
       }
       document.getElementById("newEntryName").value = entry.name;
@@ -37,12 +37,12 @@ class Phonebook extends React.Component {
         <div>
           Insert or update new phonebook entry:
           <table>
-            <tr><td>Name:</td><td><input id="newEntryName"></input></td></tr>
+            <tr><td>Name:</td><td><input required id="newEntryName"></input></td></tr>
             <tr><td>Description:</td><td><input id="newEntryDesc"></input></td></tr>
-            <tr><td>Phone:</td><td><input id="newEntryPhone" type="number"></input></td></tr>
+            <tr><td>Phone:</td><td><input required id="newEntryPhone" type="tel" pattern="[0-9]{10}"></input></td></tr>
           </table>
           <button onClick={() => this.doInsert()}>Insert or Update</button>
-        </div> 
+        </div>
         <div>
           Lookup Name: <input id="lookupName"></input> <button onClick={
             () => this.lookup()

--- a/motoko/pubsub/dfx.json
+++ b/motoko/pubsub/dfx.json
@@ -8,9 +8,6 @@
     }
   },
   "defaults": {
-    "build": {
-      "output": "canisters/"
-    },
     "start": {
       "address": "127.0.0.1",
       "port": 8000,

--- a/motoko/pubsub/src/pub/main.mo
+++ b/motoko/pubsub/src/pub/main.mo
@@ -1,6 +1,6 @@
 // Publisher
 
-import Array "mo:stdlib/Array";
+import Array "mo:base/Array";
 
 type Counter = { topic: Text; value: Nat; };
 type Subscriber = { topic: Text; callback: shared Counter -> (); };


### PR DESCRIPTION
**Overview**
Why do we need this feature? What are we trying to accomplish?
This allows someone to use `dfx` at version 0.5.7, where the `stdlib` was renamed to `base` and the namespaces are now Title Case.

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?
It's better to have demos working with the latest `dfx` sdk version.

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
If people attempt to run the examples with a previous version of `dfx`, the canisters would not build.