### PR TITLE
Fixing issue #33, swap favorite-cities with favorite_cities

### DIFF
--- a/motoko/favorite_cities/README.md
+++ b/motoko/favorite_cities/README.md
@@ -20,7 +20,7 @@ Execute the following commands in another tab.
 ```bash
 dfx build
 dfx canister install --all
-dfx canister call favorite-cities location_pretty '(vec {"San Francisco";"Paris";"Rome"})'
+dfx canister call favorite_cities location_pretty '(vec {"San Francisco";"Paris";"Rome"})'
 ```
 
 Observe the following result.


### PR DESCRIPTION
**Overview**
README says to use favorite-cities when the canister is named favorite_cities

**Requirements**
Follow the README.

**Considered Solutions**
Fix the typo.

**Recommended Solution**
Rename the container reference typo in the README from favorite-cities to favorite_cities

**Considerations**
No impact.
