### PR TITLE
Update dfx version from 0.5.2 to 0.5.7 for issue #35

### DIFF
--- a/motoko/calc/dfx.json
+++ b/motoko/calc/dfx.json
@@ -17,6 +17,6 @@
       "serve_root": "canisters/calc/assets"
     }
   },
-  "dfx": "0.5.2",
+  "dfx": "0.5.7",
   "version": 1
 }


### PR DESCRIPTION
**Overview**
The calc example references dfx 0.5.2. Trying to follow the README with the latest SDK 0.5.7 installed results in an error

**Requirements**
Update the dfx.json to 0.5.7 to reflect the latest version of the SDK.

**Considered Solutions**
Discovering how to forcefully install the older 0.5.2 SDK version.
Updating the dfx.json version to 0.5.7

**Recommended Solution**
Update the dfx.json version to 0.5.7

**Considerations**
No impact.
