### PR TITLE
Update the link to the quick start download and install section

### DIFF
--- a/motoko/calc/README.md
+++ b/motoko/calc/README.md
@@ -14,7 +14,10 @@ The `div` function also includes code to prevent the program from attempting to 
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/counter/README.md
+++ b/motoko/counter/README.md
@@ -13,7 +13,10 @@ This program supports the following types of function calls:
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/echo/README.md
+++ b/motoko/echo/README.md
@@ -4,7 +4,10 @@
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/factorial/README.md
+++ b/motoko/factorial/README.md
@@ -4,7 +4,10 @@
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/favorite_cities/README.md
+++ b/motoko/favorite_cities/README.md
@@ -5,7 +5,10 @@ In this example, the `[Text]` notation indicates an array of a collection of UTF
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/hello-world/README.md
+++ b/motoko/hello-world/README.md
@@ -4,7 +4,10 @@
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/phone-book/README.md
+++ b/motoko/phone-book/README.md
@@ -13,7 +13,10 @@ This project is implemented using the following source code files:
 
 ## Prerequisites
 
-You have downloaded and installed the SDK as described in the [Quick Start](https://sdk.dfinity.org/docs/quickstart/quickstart.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ## Demo
 

--- a/motoko/pubsub/README.md
+++ b/motoko/pubsub/README.md
@@ -18,7 +18,10 @@ Note: There are many obvious improvements (keying subscribers by topic in Publis
 
 ### Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ### Demo
 

--- a/motoko/simple_to_do/README.md
+++ b/motoko/simple_to_do/README.md
@@ -14,7 +14,10 @@ This project is implemented using the following Motoko source code files:
 
 ## Prerequisites
 
-You have downloaded and installed the SDK as described in [Getting started](https://sdk.dfinity.org/developers-guide/getting-started.html).
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
 
 ## Demo
 


### PR DESCRIPTION
**Overview**
Getting started isn't a section anymore. Update the link in all of the examples.
