### PR TITLE
Add makefile example

### DIFF
--- a/motoko/makefile/Makefile
+++ b/motoko/makefile/Makefile
@@ -1,0 +1,59 @@
+.PHONY: default canister build install call
+
+src := $(wildcard src/*/*.mo) $(wildcard src/*.mo)
+
+c ?= $(shell basename $(CURDIR))
+canister ?= $(c)
+
+m ?= ''
+method ?= $(m)
+
+a ?= ''
+args ?= $(a)
+
+install_mode ?= reinstall
+
+# commands
+
+default:
+	$(MAKE) call $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+canister: .dfx/local/canister_ids.json
+
+# If first target is 'call', rest of targets will be stored as $CALL_ARGS
+# so they can be forwarded as positional args.
+# via https://stackoverflow.com/a/14061796
+ifeq (call,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "call"
+  CALL_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(CALL_ARGS):;@:)
+endif
+call: .dfx/installed/$(canister)
+	@if [ -z $(method) ]; then\
+		echo "provide a method=yourMethodName parameter";\
+		exit 1;\
+	fi
+	dfx canister call $(canister) $(method) "$(CALL_ARGS)"
+
+build: canister
+	dfx build
+
+# files
+
+.dfx/local/canister_ids.json:
+	dfx canister create --all
+
+.dfx/local/canisters/$(canister)/$(canister).wasm: $(wildcard src/$(canister)/*.mo)
+	$(MAKE) build
+	touch $@
+
+.dfx/installed:
+	mkdir -p $@
+
+.dfx/installed/$(canister): .dfx/installed .dfx/built .dfx/local/canisters/$(canister)/$(canister).wasm
+	dfx canister install $(canister) --mode="$(install_mode)"
+	touch $@
+
+.dfx/built: $(src)
+	$(MAKE) build
+	touch $@

--- a/motoko/makefile/Makefile
+++ b/motoko/makefile/Makefile
@@ -1,5 +1,8 @@
 .PHONY: default canister build install call
 
+# Usage:
+# make call method={actorMethod} [arg]
+
 src := $(wildcard src/*/*.mo) $(wildcard src/*.mo)
 
 c ?= $(shell basename $(CURDIR))

--- a/motoko/makefile/README.md
+++ b/motoko/makefile/README.md
@@ -1,0 +1,73 @@
+## Makefile Example
+
+[![Build Status](https://travis-ci.org/dfinity-lab/examples.svg?branch=master)](https://travis-ci.org/dfinity-lab/examples?branch=master)
+
+Shows how to use a Makefile to encode dependencies between `dfx build`, `dfx canister create`, `dfx canister install`, and `dfx canister call`.
+
+### Prerequisites
+
+Before building the example application, verify the following:
+
+* You have downloaded and installed the DFINITY Canister SDK as described in [Download and install](https://sdk.dfinity.org/docs/quickstart/quickstart.html#download-and-install).
+* You have stopped any Internet Computer network processes running on the local computer.
+
+### Demo
+
+Start a local internet computer.
+
+```bash
+dfx start
+```
+
+Execute the following commands in another tab.
+
+```bash
+make call method=say message
+```
+
+Observe the following output.
+
+```
+dfx build
+Building canisters...
+touch .dfx/built
+dfx canister install makefile --mode="reinstall"
+Installing code for canister makefile, with canister_id 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q
+touch .dfx/installed/makefile
+dfx canister call makefile say "message"
+("message v7")
+```
+
+Run the same command again. It will have cached quite a bit, and the output will come much quicker:
+
+```
+▶ make call method=say message
+
+dfx canister call makefile say "message"
+("message v7")
+```
+
+Make a change to [src/main.mo](src/main.mo), e.g. increment the version number from 'v7' to 'v8'. Then re-run the command.
+
+```
+▶ make call method=say message
+
+/Library/Developer/CommandLineTools/usr/bin/make build
+dfx build
+Building canisters...
+touch .dfx/built
+dfx canister install makefile --mode="reinstall"
+Installing code for canister makefile, with canister_id 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q
+touch .dfx/installed/makefile
+dfx canister call makefile say "message"
+("message v8")
+```
+
+The source code was rebuilt and run, and the new 'v8' substring is included in the stdout.
+
+```
+▶ make call method=say message
+
+dfx canister call makefile say "message"
+("message v8")
+```

--- a/motoko/makefile/dfx.json
+++ b/motoko/makefile/dfx.json
@@ -1,0 +1,7 @@
+{
+  "canisters": {
+    "makefile": {
+      "main": "src/main.mo"
+    }
+  }
+}

--- a/motoko/makefile/src/main.mo
+++ b/motoko/makefile/src/main.mo
@@ -1,0 +1,6 @@
+actor Echo {
+  public func say(phrase: Text) : async Text {
+    let x = phrase # " v8";
+    x
+  }
+}


### PR DESCRIPTION
**Overview**

Demonstrate a reasonable way of using gnu `make` with a dfx project.

Other projects already have Makefiles, but they are quite [basic](https://github.com/dfinity/examples/blob/master/motoko/echo/Makefile). 

**Requirements**

* Add a new example called 'makefile'
* In this project, the Makefile should be more advanced.
* I should be able to run `make call method={actorMethod} [arg]` to create the canister, build the src code, install to cansiter, and then call the canister.
* As much as possible, try to cache artifacts between calls using make dependencies

**Considered Solutions**

Just this one.

**Recommended Solution**

Fairly straightforward use of `make`, though I'm not an expert.

**Considerations**

It is a new example to 'maintain' over time.
But it should be useful as a place to go copypasta a good starting point Makefile for any new dfx project.
* I tested this by pasting into one of the 'hello' tutorial projects, and:
  ```
  ▶ make call method=greet ben
  dfx canister call hello greet "ben"
  ("Hello (v17), ben!")
  ```
If it's useful enough, maybe it even makes it into the core project scaffold's Makefile (output of `dfx new`).
