### PR TITLE
Claudio/id quick

### DIFF
--- a/motoko/whoami/src/Main.mo
+++ b/motoko/whoami/src/Main.mo
@@ -1,4 +1,7 @@
-shared (install) actor class WhoAmI(someone : Principal) {
+import Principal "mo:base/Principal";
+
+shared (install) actor class WhoAmI(someone : Principal) = 
+  this { // Bind the optional `this` argument (any name will do)
 
   // Return the principal identifier of the wallet canister that installed this
   // canister.
@@ -21,4 +24,10 @@ shared (install) actor class WhoAmI(someone : Principal) {
   public func id() : async Principal {
     return await whoami();
   };
+
+  // Return the principal identifier of this canister via the optional `this` binding
+  // This is much quicker than `id()` above, since it avoids the latency of `await whoami()`
+  public func idQuick() : async Principal {
+    return Principal.fromActor(this);
+  }
 };

--- a/motoko/whoami/src/Main.mo
+++ b/motoko/whoami/src/Main.mo
@@ -25,9 +25,9 @@ shared (install) actor class WhoAmI(someone : Principal) =
     return await whoami();
   };
 
-  // Return the principal identifier of this canister via the optional `this` binding
-  // This is much quicker than `id()` above, since it avoids the latency of `await whoami()`
+  // Return the principal identifier of this canister via the optional `this` binding.
+  // This is much quicker than `id()` above, since it avoids the latency of `await whoami()`.
   public func idQuick() : async Principal {
     return Principal.fromActor(this);
-  }
+  };
 };


### PR DESCRIPTION
**Overview**

Suggest a faster alternative to obtain the principal of the current actor (avoiding a self send).

**Requirements**
None

**Considered Solutions**
Just this one.

**Recommended Solution**

Use `Principal.fromActor(this)`.

**Considerations**

Improves performance considerably, avoid latency of await.
