### PR TITLE
update to 0.7.0-beta.5

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -17,7 +17,7 @@ sudo installer -pkg node.pkg -store -target /
 rm node.pkg
 
 # Install DFINITY SDK.
-version=0.7.0-beta.4
+version=0.7.0-beta.5
 curl --location --output install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -12,7 +12,7 @@ sudo apt-get install --yes nodejs
 rm install-node.sh
 
 # Install DFINITY SDK.
-version=0.7.0-beta.4
+version=0.7.0-beta.5
 wget --output-document install-dfx.sh "https://sdk.dfinity.org/install.sh"
 DFX_VERSION=$version bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh

--- a/motoko/calc/dfx.json
+++ b/motoko/calc/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/counter/dfx.json
+++ b/motoko/counter/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/echo/dfx.json
+++ b/motoko/echo/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/factorial/dfx.json
+++ b/motoko/factorial/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/hello-world/dfx.json
+++ b/motoko/hello-world/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/hello_cycles/Makefile
+++ b/motoko/hello_cycles/Makefile
@@ -25,16 +25,16 @@ test: install
 	echo $(WALLET)
 	echo $(HELLO_CYCLES)
 	dfx canister call hello_cycles wallet_balance \
-		| grep '(10_000_000_000_000)' && echo 'PASS'
+		| grep '(11_000_000_000_000)' && echo 'PASS'
 	dfx canister status hello_cycles
 	dfx canister call $(WALLET) wallet_send '(record { canister = principal "$(HELLO_CYCLES)"; amount = (2000000000000:nat64); } )'
 	dfx canister call hello_cycles wallet_balance \
-		| grep '(10_000_010_000_000)' && echo 'PASS'
+		| grep '(11_000_010_000_000)' && echo 'PASS'
 	echo  '(func "$(WALLET)"."wallet_receive", 5000000 : nat)'
 	dfx canister call hello_cycles transfer '(func "$(WALLET)"."wallet_receive", 5000000)' \
 		| grep '0' && echo 'PASS'
 	dfx canister call hello_cycles wallet_balance \
-	 	| grep '(10_000_005_000_000)' && echo 'PASS'
+	 	| grep '(11_000_005_000_000)' && echo 'PASS'
 
 .PHONY: clean
 .SILENT: clean

--- a/motoko/hello_cycles/dfx.json
+++ b/motoko/hello_cycles/dfx.json
@@ -10,7 +10,7 @@
       "packtool": ""
     }
   },
-  "dfx": "0.7.0-beta.4",
+  "dfx": "0.7.0-beta.5",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/motoko/life/dfx.json
+++ b/motoko/life/dfx.json
@@ -23,7 +23,7 @@
       "packtool": ""
     }
   },
-  "dfx": "0.7.0-beta.4",
+  "dfx": "0.7.0-beta.5",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/motoko/life/package-lock.json
+++ b/motoko/life/package-lock.json
@@ -4,6 +4,33 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@dfinity/agent": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.8.5.tgz",
+      "integrity": "sha512-lpAj71Sw/kK3SRdyUIAJbIK7S2CBe3ItLBhEeHgMA3O21M9SDl162dY8q+whhx8ygyuh/i5K7QI2SaAFDv5yqg==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer": "^0.2.0",
+        "bignumber.js": "^9.0.0",
+        "borc": "^2.1.1",
+        "buffer": "^5.4.3",
+        "buffer-pipe": "0.0.4",
+        "js-sha256": "0.9.0",
+        "simple-cbor": "^0.4.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -304,6 +331,12 @@
         "array-filter": "^1.0.0"
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -315,11 +348,55 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "dev": true
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "braces": {
       "version": "3.0.2",
@@ -357,6 +434,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "buffer-pipe": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
+      "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -517,6 +603,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -1105,6 +1197,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "dev": true
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -1122,6 +1220,12 @@
         "supports-color": "^7.0.0"
       }
     },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1138,6 +1242,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "dev": true,
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
     },
     "json5": {
       "version": "2.2.0",
@@ -1705,6 +1818,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "simple-cbor": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
       "dev": true
     },
     "source-list-map": {

--- a/motoko/life/package-lock.json
+++ b/motoko/life/package-lock.json
@@ -4,33 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@dfinity/agent": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.8.4.tgz",
-      "integrity": "sha512-HJOni30wMdtSEn0B4Kl0dnHp7ge29s4TQKcOIHe4sVFphLNFJfiysR8VI8vttntnB3Ah5qRsq+y9rl1ao9v2og==",
-      "dev": true,
-      "requires": {
-        "base64-arraybuffer": "^0.2.0",
-        "bignumber.js": "^9.0.0",
-        "borc": "^2.1.1",
-        "buffer": "^5.4.3",
-        "buffer-pipe": "0.0.4",
-        "js-sha256": "0.9.0",
-        "simple-cbor": "^0.4.1"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -331,12 +304,6 @@
         "array-filter": "^1.0.0"
       }
     },
-    "base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "dev": true
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -348,55 +315,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
-    "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "dev": true
-    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "braces": {
       "version": "3.0.2",
@@ -434,15 +357,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
-    },
-    "buffer-pipe": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
-      "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2"
-      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -603,12 +517,6 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
-      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -1197,12 +1105,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "dev": true
-    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -1220,12 +1122,6 @@
         "supports-color": "^7.0.0"
       }
     },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1242,15 +1138,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "dev": true,
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
     },
     "json5": {
       "version": "2.2.0",
@@ -1820,12 +1707,6 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
-    "simple-cbor": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
-      "dev": true
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -1992,9 +1873,9 @@
       }
     },
     "ts-loader": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
-      "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.2.0.tgz",
+      "integrity": "sha512-ebXBFrNyMSmbWgjnb3WBloUBK+VSx1xckaXsMXxlZRDqce/OPdYBVN5efB0W3V0defq0Gcy4YuzvPGqRgjj85A==",
       "requires": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^4.0.0",

--- a/motoko/life/package.json
+++ b/motoko/life/package.json
@@ -7,7 +7,7 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.8.4",
+    "@dfinity/agent": "0.8.5",
     "assert": "2.0.0",
     "buffer": "6.0.3",
     "css-loader": "^5.2.4",
@@ -25,7 +25,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ts-loader": "^8.1.0",
+    "ts-loader": "^8.2.0",
     "typescript": "^4.2.4"
   }
 }

--- a/motoko/phone-book/dfx.json
+++ b/motoko/phone-book/dfx.json
@@ -17,5 +17,5 @@
       "type": "assets"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/phone-book/package-lock.json
+++ b/motoko/phone-book/package-lock.json
@@ -4,6 +4,33 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@dfinity/agent": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.8.5.tgz",
+      "integrity": "sha512-lpAj71Sw/kK3SRdyUIAJbIK7S2CBe3ItLBhEeHgMA3O21M9SDl162dY8q+whhx8ygyuh/i5K7QI2SaAFDv5yqg==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer": "^0.2.0",
+        "bignumber.js": "^9.0.0",
+        "borc": "^2.1.1",
+        "buffer": "^5.4.3",
+        "buffer-pipe": "0.0.4",
+        "js-sha256": "0.9.0",
+        "simple-cbor": "^0.4.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -305,10 +332,22 @@
         "array-filter": "^1.0.0"
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "dev": true
     },
     "boolbase": {
@@ -316,6 +355,33 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
     },
     "braces": {
       "version": "3.0.2",
@@ -354,6 +420,15 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
+    },
+    "buffer-pipe": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
+      "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.2"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -481,6 +556,12 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -1031,6 +1112,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "dev": true
+    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -1047,6 +1134,12 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1065,6 +1158,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "dev": true,
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -1523,6 +1625,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "simple-cbor": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
       "dev": true
     },
     "source-list-map": {

--- a/motoko/phone-book/package-lock.json
+++ b/motoko/phone-book/package-lock.json
@@ -4,33 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@dfinity/agent": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.8.4.tgz",
-      "integrity": "sha512-HJOni30wMdtSEn0B4Kl0dnHp7ge29s4TQKcOIHe4sVFphLNFJfiysR8VI8vttntnB3Ah5qRsq+y9rl1ao9v2og==",
-      "dev": true,
-      "requires": {
-        "base64-arraybuffer": "^0.2.0",
-        "bignumber.js": "^9.0.0",
-        "borc": "^2.1.1",
-        "buffer": "^5.4.3",
-        "buffer-pipe": "0.0.4",
-        "js-sha256": "0.9.0",
-        "simple-cbor": "^0.4.1"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
-      }
-    },
     "@discoveryjs/json-ext": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
@@ -332,22 +305,10 @@
         "array-filter": "^1.0.0"
       }
     },
-    "base64-arraybuffer": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
-      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
-      "dev": true
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
-    },
-    "bignumber.js": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "dev": true
     },
     "boolbase": {
@@ -355,33 +316,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "borc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
-      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "^9.0.0",
-        "buffer": "^5.5.0",
-        "commander": "^2.15.0",
-        "ieee754": "^1.1.13",
-        "iso-url": "~0.4.7",
-        "json-text-sequence": "~0.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
-      }
     },
     "braces": {
       "version": "3.0.2",
@@ -420,15 +354,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
-    },
-    "buffer-pipe": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
-      "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.2"
-      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -556,12 +481,6 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
-    },
-    "delimit-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
-      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs=",
-      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -1112,12 +1031,6 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
-    "iso-url": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
-      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
-      "dev": true
-    },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -1134,12 +1047,6 @@
         "merge-stream": "^2.0.0",
         "supports-color": "^7.0.0"
       }
-    },
-    "js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==",
-      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1158,15 +1065,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
-    },
-    "json-text-sequence": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
-      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
-      "dev": true,
-      "requires": {
-        "delimit-stream": "0.1.0"
-      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -1627,12 +1525,6 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
-    "simple-cbor": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
-      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w==",
-      "dev": true
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -1780,9 +1672,9 @@
       }
     },
     "ts-loader": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.1.0.tgz",
-      "integrity": "sha512-yjgM84n/NhzPbcAvvjGFihJxkXmwaUOQLcJezJqT9l/eD0CRcF6zu/dL21NTr4iyW47Rs4lJZawN/d3lSX07sw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.1.1.tgz",
+      "integrity": "sha512-u91MdIE4rtN/06Q881uUzVeMoYy+CdFXoanCQXVGRubKKxgLjqQ/H9nkDbp6klkiPv3t18KLjZbEofkJodM3ow==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/motoko/phone-book/package.json
+++ b/motoko/phone-book/package.json
@@ -7,20 +7,20 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.8.4",
+    "@dfinity/agent": "0.8.5",
     "assert": "2.0.0",
     "buffer": "6.0.3",
     "events": "3.3.0",
     "html-webpack-plugin": "5.3.1",
     "process": "0.11.10",
-    "stream-browserify": "3.0.0",
-    "terser-webpack-plugin": "5.1.1",
-    "util": "0.12.3",
-    "webpack": "5.35.0",
-    "webpack-cli": "4.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "ts-loader": "^9.1.0",
-    "typescript": "^4.2.4"
+    "stream-browserify": "3.0.0",
+    "terser-webpack-plugin": "5.1.1",
+    "ts-loader": "^9.1.1",
+    "typescript": "^4.2.4",
+    "util": "0.12.3",
+    "webpack": "5.35.0",
+    "webpack-cli": "4.6.0"
   }
 }

--- a/motoko/pub-sub/dfx.json
+++ b/motoko/pub-sub/dfx.json
@@ -7,5 +7,5 @@
       "main": "src/sub/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/quicksort/dfx.json
+++ b/motoko/quicksort/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/simple-to-do/dfx.json
+++ b/motoko/simple-to-do/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }

--- a/motoko/superheroes/dfx.json
+++ b/motoko/superheroes/dfx.json
@@ -24,7 +24,7 @@
       "packtool": ""
     }
   },
-  "dfx": "0.7.0-beta.4",
+  "dfx": "0.7.0-beta.5",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/motoko/superheroes/package-lock.json
+++ b/motoko/superheroes/package-lock.json
@@ -303,9 +303,9 @@
       }
     },
     "@dfinity/agent": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.8.4.tgz",
-      "integrity": "sha512-HJOni30wMdtSEn0B4Kl0dnHp7ge29s4TQKcOIHe4sVFphLNFJfiysR8VI8vttntnB3Ah5qRsq+y9rl1ao9v2og==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.8.5.tgz",
+      "integrity": "sha512-lpAj71Sw/kK3SRdyUIAJbIK7S2CBe3ItLBhEeHgMA3O21M9SDl162dY8q+whhx8ygyuh/i5K7QI2SaAFDv5yqg==",
       "dev": true,
       "requires": {
         "base64-arraybuffer": "^0.2.0",

--- a/motoko/superheroes/package.json
+++ b/motoko/superheroes/package.json
@@ -21,7 +21,7 @@
     "build": "webpack"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.8.4",
+    "@dfinity/agent": "0.8.5",
     "assert": "2.0.0",
     "buffer": "6.0.3",
     "events": "3.3.0",

--- a/motoko/whoami/dfx.json
+++ b/motoko/whoami/dfx.json
@@ -4,5 +4,5 @@
       "main": "src/Main.mo"
     }
   },
-  "dfx": "0.7.0-beta.4"
+  "dfx": "0.7.0-beta.5"
 }


### PR DESCRIPTION
Update all (motoko) samples to work with dfx 0.7.0-beta.5
- bump dfx in dfx.json and agent-js in packages.json
- npm update where necessary
- add superheroes/package-lock.json (other package-lock files are checked in, so I guess this one should be too)
- adjust hello_cycles Makefile test target since we now go to 11T cycles on install 