### PR TITLE
Add dist/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .dfx/
 build/
+dist/
 node_modules/


### PR DESCRIPTION
This directory is produced by Node.JS during `dfx deploy`, and should be ignored.

It is on the `.gitignore` produced by `dfx new` as well ([see e.g. here](https://github.com/johnkruger37/learn-internetcomputer/blob/main/.gitignore)).