### PR TITLE
Add tokens_transfer example

### DIFF
--- a/rust/tokens_transfer/Cargo.toml
+++ b/rust/tokens_transfer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tokens_transfer"
+version = "0.1.0"
+edition = "2018"
+
+## See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["cdylib"]
+
+[build-dependencies]
+candid = "0.7.4"
+
+[dependencies]
+candid = "0.7.4"
+ic-cdk = { git = "https://github.com/dfinity/cdk-rs.git", branch = "roman-ledger-types" }
+ic-cdk-macros = { git = "https://github.com/dfinity/cdk-rs.git", branch = "roman-ledger-types" }
+ic-ledger-types = { git = "https://github.com/dfinity/cdk-rs.git", branch = "roman-ledger-types" }
+ic-types = "0.2.1"
+serde = "1.0.126"
+serde_derive = "1.0.126"
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/rust/tokens_transfer/README.md
+++ b/rust/tokens_transfer/README.md
@@ -1,0 +1,76 @@
+# Tokens Transfer
+
+Tokens Transfer is a canister that can transfer token from its account to other accounts.
+It is an example of a canister that uses the Ledger canister.
+
+
+## Interface
+
+1. `balance`: takes no arguments and return the balance of the canister
+2. `transfer`: takes in input the amount of tokens to transfer, the account (and optionally the subaccount) to which to transfer the tokens and returns either success or an error in case e.g. the tokens transfer canister doesn't have enough tokens to do the transfer. In case of success, a unique identifier of the transaction is returned. This identifier will be stored in the memo of the transaction in the Ledger.
+
+
+## Initialization
+
+The canister expects three arguments:
+1. `ledger_canister_id`: the canister id of the ledger canister
+2. `subaccount`: the optional subaccount of the canister account from which tokens will be withdrawn
+3. `transaction_fee`: a constant representing the transaction fee of the ledger
+
+
+## Test Locally
+
+1. start the local replicate with `dfx start`
+2. deploy the Ledger canister locally. Add some tokens to your account (`dfx identity get-principal`) in the initialization parameters of the Ledger canister.
+```bash
+# MINTING_ACCOUNT_ID_HEX and ACCOUNT_ID_HEX are the hex representation
+# of the minting principal and your principal respectively
+read -r -d '' ARGS <<EOM
+(record {
+     minting_account="${MINTING_PRINCIPAL_HEX}";
+     initial_values=vec { record { "${YOUR_PRINCIPAL_HEX}"; record { e8s=10_000_000_000 } }; };
+     send_whitelist=vec {};
+ }, )
+EOM
+dfx deploy --argument "${ARGS}" ledger
+```
+3. deploy the Tokens Transfer canister locally. Point to the ledger in the initialization parameters (`dfx canister id ledger`).
+```bash
+LEDGER_ID="$(dfx canister id ledger)"
+read -r -d '' ARGS <<EOM
+(record {
+  ledger_canister_id=principal "${LEDGER_ID}";
+  transaction_fee=record { e8s=10_000 };
+  subaccount=null
+}, )
+EOM
+dfx deploy --argument "${ARGS}" tokens_transfer
+```
+4. transfer some funds to the Tokens Transfer canister
+```bash
+# TOKENS_TRANSFER_PRINCIPAL_ID_BYTES is the vec nat8 representation of the tokens transfer canister
+read -r -d '' ARGS <<EOM
+(record {
+  to=${TOKENS_TRANSFER_PRINCIPAL_ID_BYTES};
+  amount=record { e8s=10_000 };
+  fee=record { e8s=10_000 };
+  memo=0:nat64;
+}, )
+EOM
+dfx canister call ledger transfer "${ARGS}"
+```
+5. verify that the Tokens Transfer canister has received the tokens
+```bash
+dfx canister call tokens_transfer balance
+```
+6. transfer some of the tokens from the Tokens Transfer canister back to the original account
+```bash
+# YOUR_PRINCIPAL is the value returned by dfx identity get-principal
+read -r -d '' ARGS <<EOM
+(record {
+  amount=record { e8s=5 };
+  to_account=principal "${YOUR_PRINCIPAL}"
+},)
+EOM
+dfx canister call tokens_transfer transfer '${ARGS}'
+```

--- a/rust/tokens_transfer/dfx.json
+++ b/rust/tokens_transfer/dfx.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "canisters": {
+    "tokens-transfer": {
+      "build": [
+        "cargo build --target wasm32-unknown-unknown --package tokens_transfer --release"
+      ],
+      "candid": "src/tokens_transfer.did",
+      "wasm": "target/wasm32-unknown-unknown/release/tokens_transfer.wasm",
+      "type": "custom"
+    }
+  }
+}

--- a/rust/tokens_transfer/src/candid_util.rs
+++ b/rust/tokens_transfer/src/candid_util.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+use candid::types::subtype::{Gamma, subtype};
+use candid::types::Type;
+
+pub fn check_candid_interface_compatibility(expected: &Path, actual: &Path) {
+    let (mut env1, t1) =
+        candid::pretty_check_file(actual).expect("failed to check generated candid interface");
+    let (env2, t2) =
+        candid::pretty_check_file(expected).expect(&format!("failed to open expected candid file {:?}", expected));
+
+    let (t1_ref, t2) = match (t1.as_ref().unwrap(), t2.unwrap()) {
+        (Type::Class(_, s1), Type::Class(_, s2)) => (s1.as_ref(), *s2),
+        (Type::Class(_, s1), s2 @ Type::Service(_)) => (s1.as_ref(), s2),
+        (s1 @ Type::Service(_), Type::Class(_, s2)) => (s1, *s2),
+        (t1, t2) => (t1, t2),
+    };
+
+    let mut gamma = Gamma::new();
+    let t2 = env1.merge_type(env2, t2);
+    let mk_error = || {
+        std::fs::read_to_string(actual).map(|actual_interface|
+            format!("ledger canister interface is not compatible with \
+                  the ledger.did file. Generated candid interface:\n{}\n\n",
+                    actual_interface))
+            .unwrap_or(format!("Unable to read actual candid interface from file {:?}", actual))
+    };
+    subtype(&mut gamma, &env1, t1_ref, &t2).unwrap_or_else(|_| panic!("{}", mk_error()));
+}

--- a/rust/tokens_transfer/src/errors.rs
+++ b/rust/tokens_transfer/src/errors.rs
@@ -1,0 +1,29 @@
+use candid::CandidType;
+use ic_cdk::api::call::RejectionCode;
+use ic_types::PrincipalError;
+use serde::{Deserialize, Serialize};
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum TransferError {
+    AccountError(String),
+    CallError(String),
+    LedgerError(String),
+}
+
+impl From<PrincipalError> for TransferError {
+    fn from(e: PrincipalError) -> Self {
+        TransferError::AccountError(format!("{}", e))
+    }
+}
+
+impl From<(RejectionCode, String)> for TransferError {
+    fn from(e: (RejectionCode, String)) -> Self {
+        TransferError::CallError(format!("rejection_code:{:?} error:{}", e.0, e.1))
+    }
+}
+
+impl From<ic_ledger_types::TransferError> for TransferError {
+    fn from(e: ic_ledger_types::TransferError) -> Self {
+        TransferError::LedgerError(format!("{}", e))
+    }
+}

--- a/rust/tokens_transfer/src/lib.rs
+++ b/rust/tokens_transfer/src/lib.rs
@@ -1,0 +1,127 @@
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use candid::{candid_method, CandidType};
+
+use ic_cdk::api::call::call;
+use ic_cdk_macros::*;
+use ic_ledger_types::{AccountBalanceArgs, AccountIdentifier, BlockIndex, DEFAULT_SUBACCOUNT, MAINNET_LEDGER_CANISTER_ID, Memo, Subaccount, Tokens};
+use ic_types::Principal;
+use serde::{Deserialize, Serialize};
+
+#[cfg(test)] use std::path::PathBuf;
+#[cfg(test)] use std::io::Write;
+use ic_cdk::id;
+
+use crate::errors::TransferError;
+
+#[cfg(test)] mod candid_util;
+mod errors;
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, Hash, PartialEq)]
+pub struct Conf {
+    ledger_canister_id: Principal,
+    subaccount: Option<Subaccount>,
+    transaction_fee: Tokens
+}
+
+impl Default for Conf {
+    fn default() -> Self {
+        Conf {
+            ledger_canister_id: MAINNET_LEDGER_CANISTER_ID,
+            subaccount: None,
+            transaction_fee: Tokens::from_e8s(10_000),
+        }
+    }
+}
+
+thread_local! {
+    static CONF: RefCell<Conf> = RefCell::new(Conf::default());
+}
+
+#[init]
+#[candid_method(init)]
+fn init(conf: Conf) {
+    CONF.with(|c| c.replace(conf));
+}
+
+#[query]
+#[candid_method(query)]
+async fn balance() -> Tokens {
+    ic_cdk::println!("Querying the balance");
+
+    let account_balance_args = CONF.with(|conf| {
+        AccountBalanceArgs {
+            account: AccountIdentifier::new(&id(), &conf.borrow().subaccount.unwrap_or(DEFAULT_SUBACCOUNT))
+        }
+    });
+    ledger_balance(&account_balance_args).await
+}
+
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, Hash)]
+pub struct TransferArgs {
+    amount: Tokens,
+    to_account: Principal,
+    to_subaccount: Option<Subaccount>,
+}
+
+// returns the memo as transaction id
+#[update]
+#[candid_method(update)]
+async fn transfer(args: TransferArgs) -> Result<Memo, TransferError> {
+    ic_cdk::println!("Transferring {} tokens to account {} subaccount {:?}", &args.amount, &args.to_account, &args.to_subaccount);
+    let to_subaccount = args.to_subaccount.unwrap_or(DEFAULT_SUBACCOUNT);
+    let memo = CONF.with(|conf| {
+        Memo(hash_transfer_input(&args, conf.borrow().deref()))
+    });
+    let transfer_args = CONF.with(|conf| {
+        let conf = conf.borrow();
+        ic_ledger_types::TransferArgs {
+            memo,
+            amount: args.amount,
+            fee: conf.transaction_fee,
+            from_subaccount: conf.subaccount,
+            to: AccountIdentifier::new(&args.to_account, &to_subaccount),
+            created_at_time: None,
+        }
+    });
+    ledger_transfer(&transfer_args).await?;
+    Ok(memo)
+}
+
+fn hash_transfer_input(args: &TransferArgs, conf: &Conf) -> u64 {
+    let mut hasher = DefaultHasher::default();
+    std::time::SystemTime::now().hash(&mut hasher);
+    id().hash(&mut hasher);
+    args.hash(&mut hasher);
+    conf.hash(&mut hasher);
+    hasher.finish()
+}
+
+
+// utility functions
+
+async fn ledger_balance(balance_args: &ic_ledger_types::AccountBalanceArgs) -> Tokens {
+    let ledger_canister_id = CONF.with(|conf| conf.borrow().ledger_canister_id);
+    let res: (ic_ledger_types::Tokens, ) = call(ledger_canister_id, "account_balance", (balance_args, )).await.expect("call to ledger failed");
+    res.0
+}
+
+async fn ledger_transfer(transfer_args: &ic_ledger_types::TransferArgs) -> Result<BlockIndex, TransferError> {
+    let ledger_canister_id = CONF.with(|conf| conf.borrow().ledger_canister_id);
+    let res: (ic_ledger_types::TransferResult, ) = call(ledger_canister_id, "transfer", (transfer_args, )).await?;
+    Ok(res.0?)
+}
+
+//
+
+#[test]
+fn check_candid_interface_compatibility() {
+    candid::export_service!();
+    let actual_interface = __export_service();
+    let mut actual = tempfile::NamedTempFile::new().expect("Failed to create a temporary file");
+    write!(actual, "{}", actual_interface).unwrap();
+    let expected = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src").join("tokens_transfer.did");
+    candid_util::check_candid_interface_compatibility(&expected, &actual.path());
+}

--- a/rust/tokens_transfer/src/tokens_transfer.did
+++ b/rust/tokens_transfer/src/tokens_transfer.did
@@ -1,0 +1,33 @@
+type Tokens = record {
+    e8s: nat64
+};
+
+type Conf = record {
+  transaction_fee : Tokens;
+  subaccount : opt vec nat8;
+  ledger_canister_id : principal;
+};
+
+type TransferArgs = record {
+    amount: Tokens;
+    to_account: principal;
+    to_subaccount: opt blob
+};
+
+type Memo = nat64;
+
+type TransferError = variant {
+    AccountError: text;
+    CallError: text;
+    LedgerError: text;
+};
+
+type TransferResult = variant {
+    Ok: Memo;
+    Err: TransferError;
+};
+
+service : (Conf) -> {
+    balance: () -> (Tokens) query;
+    transfer: (TransferArgs) -> (TransferResult);
+}


### PR DESCRIPTION
**Overview**
This PR adds an simple example of Ledger usage. The Tokens Transfer canister allows to check the canister balance and transfer tokens from its account to other accounts.
