### PR TITLE
ROSETTA-1-176 add Ledger get_blocks_pb example

### DIFF
--- a/rust/get-ledger-blocks/Cargo.toml
+++ b/rust/get-ledger-blocks/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "get-ledger-blocks"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ic-agent = "0.10.1"
+prost = "0.9.0"
+structopt = "0.3.25"
+tokio = { version = "1.14.0", features = ["macros"] }
+url = "2.2.2"
+
+[build-dependencies]
+prost-build = "0.9.0"

--- a/rust/get-ledger-blocks/README.md
+++ b/rust/get-ledger-blocks/README.md
@@ -1,0 +1,10 @@
+# Fetching blocks from the Ledger example
+
+The Ledger exposes an endpoint `get_blocks_pb` that can be used to get a range of blocks encoded with
+protocol buffers. This example shows how to query this endpoint and how to decode the response received
+from the Ledger. The steps are the following:
+
+1. create a request and encode it as protobuf message
+2. send a `get_blocks_pb` request with the encoded request as argument
+3. decode the response as protobuf message. This returns a rust list of protobuf encoded blocks
+4. optionally decode each block in the response list

--- a/rust/get-ledger-blocks/build.rs
+++ b/rust/get-ledger-blocks/build.rs
@@ -1,0 +1,11 @@
+use prost_build::Config;
+
+fn main() {
+    println!("cargo:rerun-if-changed=protos/ledger.proto");
+    std::fs::create_dir_all("src/gen").unwrap();
+    Config::new()
+        .out_dir("src/gen")
+        .default_package_filename("ledger")
+        .compile_protos(&["protos/ledger.proto"], &["protos"])
+        .unwrap();
+}

--- a/rust/get-ledger-blocks/protos/ledger.proto
+++ b/rust/get-ledger-blocks/protos/ledger.proto
@@ -1,0 +1,95 @@
+syntax = "proto3";
+
+message GetBlockRequest {
+  uint64 start = 1;
+  uint64 length = 2;
+}
+
+message EncodedBlock {
+  bytes block = 1;
+}
+
+message EncodedBlocks {
+  repeated EncodedBlock blocks = 1;
+}
+
+message GetBlocksResponse {
+  oneof get_blocks_content {
+    EncodedBlocks blocks = 1;
+    string error = 2;
+  }
+}
+
+message Block {
+  Hash parent_hash = 1;
+  TimeStamp timestamp = 2;
+  Transaction transaction = 3;
+}
+
+message Hash {
+  bytes hash = 1;
+}
+
+message Tokens {
+  uint64 e8s = 1;
+}
+
+message BlockHeight {
+  uint64 height = 1;
+}
+
+message Account {
+  AccountIdentifier identifier = 1;
+  Tokens balance = 2;
+}
+
+message Transaction {
+  oneof transfer {
+    Burn burn = 1;
+    Mint mint = 2;
+    Send send = 3;
+  }
+  Memo memo = 4;
+  BlockHeight created_at = 5; // obsolete
+  TimeStamp created_at_time = 6;
+}
+
+message Send {
+  AccountIdentifier from = 1;
+  AccountIdentifier to = 2;
+  Tokens amount = 3;
+  Tokens max_fee = 4;
+}
+
+message Mint {
+  AccountIdentifier to = 2;
+  Tokens amount = 3;
+}
+
+message Burn {
+  AccountIdentifier from = 1;
+  Tokens amount = 3;
+}
+
+
+message AccountIdentifier {
+  // Can contain either:
+  //  * the 32 byte identifier (4 byte checksum + 28 byte hash)
+  //  * the 28 byte hash
+  bytes hash = 1;
+
+}
+
+message Subaccount {
+  bytes sub_account = 1;
+
+}
+
+message Memo {
+  uint64 memo = 1;
+
+}
+
+message TimeStamp {
+  uint64 timestamp_nanos = 1;
+}

--- a/rust/get-ledger-blocks/src/main.rs
+++ b/rust/get-ledger-blocks/src/main.rs
@@ -1,0 +1,70 @@
+use std::error::Error;
+use ic_agent::Agent;
+use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
+use ic_agent::ic_types::Principal;
+use prost::Message;
+use structopt::StructOpt;
+use url::Url;
+use ledger::GetBlockRequest;
+use crate::ledger::get_blocks_response::GetBlocksContent;
+use crate::ledger::{Block, GetBlocksResponse};
+
+pub mod ledger {
+    include!("gen/ledger.rs");
+}
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "get-ledger-blocks", about = "An example of how to get blocks from the ledger")]
+struct Opt {
+    #[structopt(short, long)]
+    url: Url,
+
+    #[structopt(short, long)]
+    ledger_id: String,
+
+    #[structopt(short, long)]
+    start: u64,
+
+    #[structopt(short = "L", long)]
+    length: u64
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let opt = Opt::from_args();
+    let transport = ReqwestHttpReplicaV2Transport::create(opt.url).unwrap();
+    let agent = Agent::builder()
+        .with_transport(transport)
+        .build()
+        .unwrap();
+    let ledger_principal_id = Principal::from_text(opt.ledger_id).unwrap();
+
+    // create the request and encode it as protobuf message
+    let req = GetBlockRequest {
+        start: opt.start,
+        length: opt.length
+    }.encode_to_vec();
+
+    // call get_blocks_pb on the Ledger with the encoded request as argument
+    let res = agent.query(&ledger_principal_id, "get_blocks_pb")
+        .with_arg(req)
+        .call()
+        .await?;
+
+    // decode the response as protobuf message
+    let res = GetBlocksResponse::decode(res.as_slice()).unwrap().get_blocks_content.unwrap();
+
+    // check if the response is an error or the encoded blocks
+    let encoded_blocks = match res {
+        GetBlocksContent::Blocks(blocks) => blocks.blocks,
+        GetBlocksContent::Error(e) => panic!("Error fetching blocks {}", e),
+    };
+
+    // decode each encoded block into a block
+    let blocks: Vec<Block> = encoded_blocks.iter().map(|b| Block::decode(b.block.as_slice()).unwrap()).collect();
+
+    for block in blocks {
+        println!("{:?}", block);
+    }
+    Ok(())
+}


### PR DESCRIPTION
This is an example of how to get the Ledger blocks via the get_blocks_pb. It can be used as template by other devs to understand how they can fetch the blocks using protocol buffers instead of candid.