### PR TITLE
Update the ledger transfer example

### DIFF
--- a/motoko/ledger-transfer/README.md
+++ b/motoko/ledger-transfer/README.md
@@ -12,10 +12,7 @@ Verify the following before running this demo:
 
 ## Demo
 
-1. Start a local internet computer
-   ```
-   dfx start
-   ```
+1. Follow the [Ledger: Deploying locally](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/ledger_canister#deploying-locally) guide to install the ICP ledger canister locally.
 
 1. Open a new terminal window
 
@@ -23,12 +20,6 @@ Verify the following before running this demo:
    ```
    dfx build
    ```
-
-1. Install the ledger canister
-   ```
-dfx canister install --mode reinstall --argument '(record {send_whitelist=vec{}; minting_account="051b05839339f89053454a4b9865ea0452a4bffe2b1cd41f4982bad10c1e637c"; transaction_window = null; max_message_size_bytes = null; archive _options = null; initial_values = vec {record{"bdc4ee05d42cd0669786899f256c8fd7217fa71177bd1fa7b9534f568680a938"; record {e8s=100_000_000_000}}};})' ledger
-   ```
-
 
 1. Figure out the address of your canister
    ```

--- a/motoko/ledger-transfer/dfx.json
+++ b/motoko/ledger-transfer/dfx.json
@@ -7,7 +7,7 @@
     },
     "ledger": {
       "type": "custom",
-      "candid": "ledger.did",
+      "candid": "ledger.public.did",
       "wasm": "ledger.wasm"
     }
   },

--- a/motoko/ledger-transfer/ledger.public.did
+++ b/motoko/ledger-transfer/ledger.public.did
@@ -1,7 +1,7 @@
 // This is the official Ledger interface that is guaranteed to be backward compatible.
 
 // Amount of tokens, measured in 10^-8 of a token.
-type Token = record {
+type Tokens = record {
      e8s : nat64;
 };
 
@@ -10,9 +10,9 @@ type TimeStamp = record {
     timestamp_nanos: nat64;
 };
 
-// Address is a 32-byte array.
+// AccountIdentifier is a 32-byte array.
 // The first 4 bytes is big-endian encoding of a CRC32 checksum of the last 28 bytes.
-type Address = blob;
+type AccountIdentifier = blob;
 
 // Subaccount is an arbitrary 32-byte byte array.
 // Ledger uses subaccounts to compute the source address, which enables one
@@ -32,17 +32,17 @@ type TransferArgs = record {
     // See comments for the `Memo` type.
     memo: Memo;
     // The amount that the caller wants to transfer to the destination address.
-    amount: Token;
+    amount: Tokens;
     // The amount that the caller pays for the transaction.
     // Must be 10000 e8s.
-    fee: Token;
+    fee: Tokens;
     // The subaccount from which the caller wants to transfer funds.
     // If null, the ledger uses the default (all zeros) subaccount to compute the source address.
     // See comments for the `SubAccount` type.
     from_subaccount: opt SubAccount;
-    // The destination address.
+    // The destination account.
     // If the transfer is successful, the balance of this address increases by `amount`.
-    to: Address;
+    to: AccountIdentifier;
     // The point in time when the caller created this request.
     // If null, the ledger uses current IC time as the timestamp.
     created_at_time: opt TimeStamp;
@@ -51,9 +51,9 @@ type TransferArgs = record {
 type TransferError = variant {
     // The fee that the caller specified in the transfer request was not the one that ledger expects.
     // The caller can change the transfer fee to the `expected_fee` and retry the request.
-    BadFee : record { expected_fee : Token; };
+    BadFee : record { expected_fee : Tokens; };
     // The account specified by the caller doesn't have enough funds.
-    InsufficientFunds : record { balance: Token; };
+    InsufficientFunds : record { balance: Tokens; };
     // The request is too old.
     // The ledger only accepts requests created within 24 hours window.
     // This is a non-recoverable error.
@@ -73,7 +73,7 @@ type TransferResult = variant {
 
 // Arguments for the `account_balance` call.
 type AccountBalanceArgs = record {
-    account: Address;
+    account: AccountIdentifier;
 };
 
 service : {
@@ -82,6 +82,6 @@ service : {
   // When successful, returns the index of the block containing the transaction.
   transfer : (TransferArgs) -> (TransferResult);
 
-  // Returns the amount of Token on the specified account.
-  account_balance : (AccountBalanceArgs) -> (Token) query;
+  // Returns the amount of Tokens on the specified account.
+  account_balance : (AccountBalanceArgs) -> (Tokens) query;
 }

--- a/motoko/ledger-transfer/src/ledger_transfer/main.mo
+++ b/motoko/ledger-transfer/src/ledger_transfer/main.mo
@@ -59,7 +59,7 @@ actor Self {
   };
 
   // Returns current balance on the default account of this canister.
-  public func canisterBalance() : async Ledger.Token {
+  public func canisterBalance() : async Ledger.Tokens {
     await Ledger.account_balance({ account = myAccountId() })
   };
 


### PR DESCRIPTION
This change update the ledger_transfer Motoko example to be compatible
with the latest interface of the ICP ledger canister.

The README is also updated to point to the recently added ledger local
installation guide.