### PR TITLE
Cleanup encrypted notes sample dapp motoko canister

### DIFF
--- a/motoko/encrypted-notes-dapp/package-lock.json
+++ b/motoko/encrypted-notes-dapp/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "ic-notes",
-  "version": "0.0.1",
+  "name": "encrypted-notes-dapp",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ic-notes",
-      "version": "0.0.1",
+      "name": "encrypted-notes-dapp",
+      "version": "0.2.0",
       "dependencies": {
         "@dfinity/agent": "^0.10.1",
         "@dfinity/auth-client": "^0.10.1",

--- a/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
+++ b/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
@@ -503,7 +503,7 @@ shared({ caller = initializer }) actor class() {
         Debug.print("Starting pre-upgrade hook...");
         stable_notesByUser := Iter.toArray(notesByUser.entries());
         stable_users := UserStore.serializeAll(users);
-        Debug.print("Pre-upgrade finished successfully.");
+        Debug.print("pre-upgrade finished.");
     };
 
     // The work required after a canister upgrade ends.
@@ -515,6 +515,6 @@ shared({ caller = initializer }) actor class() {
 
         users := UserStore.deserialize(stable_users, stable_notesByUser.size());
         stable_notesByUser := [];
-        Debug.print("Post-upgrade finished successfully.");
+        Debug.print("post-upgrade finished.");
     };
 };

--- a/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
+++ b/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
@@ -513,7 +513,7 @@ shared({ caller = initializer }) actor class() {
         Debug.print("Starting pre-upgrade hook...");
         stable_notesByUser := Iter.toArray(notesByUser.entries());
         stable_users := UserStore.serializeAll(users);
-        Debug.print("pre-upgrade finished.");
+        Debug.print("Pre-upgrade finished.");
     };
 
     // The work required after a canister upgrade ends.
@@ -525,6 +525,6 @@ shared({ caller = initializer }) actor class() {
 
         users := UserStore.deserialize(stable_users, stable_notesByUser.size());
         stable_notesByUser := [];
-        Debug.print("post-upgrade finished.");
+        Debug.print("Post-upgrade finished.");
     };
 };

--- a/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
+++ b/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
@@ -83,12 +83,6 @@ shared({ caller = initializer }) actor class() {
     // See also: [pre_upgrade], [post_upgrade]
     private stable var stable_users: [UserStore.StableUserStoreEntry] = [];
 
-    // The following function will soon become part of Motoko
-    // See https://github.com/dfinity/motoko-base/blob/master/src/Principal.mo
-  //  private func isAnonymous(caller: Principal): Bool {
-    //    Principal.equal(caller, Principal.fromText("2vxsx-fae"))
-    //};
-
     // The following invariant is preserved by [register_device].
     //
     // All the functions of this canister's public API are available only to 
@@ -314,7 +308,7 @@ shared({ caller = initializer }) actor class() {
                 let new_store = UserStore.UserStore(caller, 10);
                 new_store.device_list.put(alias, pk);
                 users.put(caller, new_store);
-                // 2) a new [[EncryptedNote]] array in [notesByUser]
+                // 2) a new [[EncryptedNote]] list in [notesByUser]
                 notesByUser.put(principalName, List.nil());
                 
                 // finally, indicate accept

--- a/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
+++ b/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
@@ -187,8 +187,8 @@ shared({ caller = initializer }) actor class() {
         let userNotes : List.List<EncryptedNote> = Option.get(notesByUser.get(principalName), List.nil<EncryptedNote>());
 
         // check that user is not going to exceed limits
-        //assert userNotes.size() < MAX_NOTES_PER_USER;
-        //TODO 
+        assert List.size(userNotes) < MAX_NOTES_PER_USER;
+        
         let newNote: EncryptedNote = {
             id = nextNoteId; 
             encrypted_text = encrypted_text


### PR DESCRIPTION
- Replace array for notesByUser with list to get rid of warning about append performance and adjust all comments
- Remove functions that are now part of the library (Principal.isAnonymous) 
- Remove hack for array private type