### PR TITLE
Fixed Docker deployment for encrypted_notes_dapp

### DIFF
--- a/motoko/encrypted-notes-dapp/Dockerfile
+++ b/motoko/encrypted-notes-dapp/Dockerfile
@@ -6,7 +6,7 @@ FROM node:17-slim as encrypted_notes_base
 # build-essential only necessary if you need to build the Rust canister.
 RUN \
     apt -yq update && \
-    apt -yqq install --no-install-recommends curl rsync ca-certificates
+    apt -yqq install --no-install-recommends curl rsync ca-certificates libdigest-sha-perl
 
 # Install dfx; the version is picked up from the DFX_VERSION environment variable
 # Lowercase [dfx_version] is an argument of this Dockerfile (with a default value)

--- a/motoko/encrypted-notes-dapp/Dockerfile
+++ b/motoko/encrypted-notes-dapp/Dockerfile
@@ -11,9 +11,9 @@ RUN \
 # Install dfx; the version is picked up from the DFX_VERSION environment variable
 # Lowercase [dfx_version] is an argument of this Dockerfile (with a default value)
 # Uppercase [DFX_VERSION] is an environment variable for expected by the DFX installation script
-ARG dfx_version=0.8.4
+ARG dfx_version=0.9.3
 ENV DFX_VERSION=${dfx_version}
-RUN sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+RUN sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ENV NODE_OPTIONS=--openssl-legacy-provider
 EXPOSE 8080 8000 3000 35729
 WORKDIR /canister

--- a/motoko/encrypted-notes-dapp/README.md
+++ b/motoko/encrypted-notes-dapp/README.md
@@ -16,6 +16,7 @@
 - [Troubleshooting](#troubleshooting)
   - [Building/deployment problems](#buildingdeployment-problems)
   - [Login problems](#login-problems)
+  - [SSL certificate problems](#ssl-certificate-problems)
 - [dfx.json file structure](#dfxjson-file-structure)
 - [Local memory model](#local-memory-model)
 - [Further Reading](#further-reading)
@@ -267,6 +268,10 @@ Possible Remedies:
 
 ### Login problems
 Some errors like `Could not initialize crypto service` might occur due to browser caching issues. Redeployment of the dapp can cause such problems. In this case clear browser's _Local Storage_ and _IndexedDB_.
+
+### SSL certificate problems
+
+Some browsers may block local resources based on invalid SSL certificates. If while testing a locally deployed version of the Encrypted Notes dapp you observe certificate issues in your browser's console, please change the browser settings to _ignore certificates for resources loaded from localhost_. For example, this can be done in Google Chrome via [chrome://flags/#allow-insecure-localhost](chrome://flags/#allow-insecure-localhost).
 
 ## dfx.json file structure
 `dfx.json` is the configuration of the project when deploying to either the local replica or to the IC, it assists in the creation of the `.dfx` directory (which contains `canister_ids.json` — which merely maps canister by name to their id on both local replica and the IC). There are various configuration options here and this is not exhaustive. This will primarily discuss target types for canisters (which all exist under the `canisters` key).


### PR DESCRIPTION
* Upgrade DFX version to 0.9.3
* Use `sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"` instead of `sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"`
* Add `libdigest-sha-perl` dependency (since DFX now requires `shasum`)
* Improve README.md