### PR TITLE
Fix/tokens transfer

### DIFF
--- a/rust/tokens_transfer/Cargo.toml
+++ b/rust/tokens_transfer/Cargo.toml
@@ -15,7 +15,6 @@ candid = "0.7.4"
 ic-cdk = "0.3.3"
 ic-cdk-macros = "0.3.3"
 ic-ledger-types = "0.1.0"
-ic-types = "0.2.1"
 serde = "1.0.126"
 serde_derive = "1.0.126"
 

--- a/rust/tokens_transfer/README.md
+++ b/rust/tokens_transfer/README.md
@@ -51,7 +51,7 @@ dfx deploy --argument "${ARGS}" tokens_transfer
 read -r -d '' ARGS <<EOM
 (record {
   to=${TOKENS_TRANSFER_ACCOUNT_ID_BYTES};
-  amount=record { e8s=10_000 };
+  amount=record { e8s=100_000 };
   fee=record { e8s=10_000 };
   memo=0:nat64;
 }, )

--- a/rust/tokens_transfer/README.md
+++ b/rust/tokens_transfer/README.md
@@ -48,6 +48,8 @@ dfx deploy --argument "${ARGS}" tokens_transfer
 4. transfer some funds to the Tokens Transfer canister
 ```bash
 # TOKENS_TRANSFER_ACCOUNT_ID_BYTES is the vec nat8 representation of the tokens transfer canister
+TOKENS_TRANSFER_ACCOUNT_ID="$(dfx ledger account-id --of-canister tokens_transfer)"
+TOKENS_TRANSFER_ACCOUNT_ID_BYTES="$(python3 -c 'print("vec{" + ";".join([str(b) for b in bytes.fromhex("'$TOKENS_TRANSFER_ACCOUNT_ID'")]) + "}")')" 
 read -r -d '' ARGS <<EOM
 (record {
   to=${TOKENS_TRANSFER_ACCOUNT_ID_BYTES};

--- a/rust/tokens_transfer/dfx.json
+++ b/rust/tokens_transfer/dfx.json
@@ -9,5 +9,10 @@
       "wasm": "target/wasm32-unknown-unknown/release/tokens_transfer.wasm",
       "type": "custom"
     }
+  },
+  "defaults": {
+    "replica": {
+      "subnet_type": "system"
+    }
   }
 }

--- a/rust/tokens_transfer/dfx.json
+++ b/rust/tokens_transfer/dfx.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "canisters": {
-    "tokens-transfer": {
+    "tokens_transfer": {
       "build": [
         "cargo build --target wasm32-unknown-unknown --package tokens_transfer --release"
       ],

--- a/rust/tokens_transfer/src/lib.rs
+++ b/rust/tokens_transfer/src/lib.rs
@@ -1,10 +1,9 @@
 use std::cell::RefCell;
 use std::hash::Hash;
-use candid::{candid_method, CandidType};
+use candid::{candid_method, CandidType, Principal};
 
 use ic_cdk_macros::*;
 use ic_ledger_types::{AccountIdentifier, BlockIndex, DEFAULT_SUBACCOUNT, MAINNET_LEDGER_CANISTER_ID, Memo, Subaccount, Tokens};
-use ic_types::Principal;
 use serde::{Deserialize, Serialize};
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug, Hash, PartialEq)]


### PR DESCRIPTION
Tokens transfer example had a few issues
- Canister had the wrong name in `dfx.json`
- Cargo complained about `ic_types::Principal`
- Developers didn't know how to get `TOKENS_TRANSFER_ACCOUNT_ID_BYTES`
- Ledger canister is too big for application subnet (default since dfx v 0.10)
- Amount transferred to the tokens_transfer canister was not enough

@MarioDfinity would be nice if you could have a look.
