### PR TITLE
Motoko dip-721-nft-container example : wrong array list order access ?

### DIFF
--- a/motoko/dip-721-nft-container/src/Main.mo
+++ b/motoko/dip-721-nft-container/src/Main.mo
@@ -31,7 +31,7 @@ shared actor class Dip721NFT(custodian: Principal, init : Types.Dip721NonFungibl
   };
 
   public query func ownerOfDip721(token_id: Types.TokenId) : async Types.OwnerResult {
-    let item = List.get(nfts, Nat64.toNat(token_id));
+    let item = List.find(nfts, func(token: Types.Nft) : Bool { token.id == token_id });
     switch (item) {
       case (null) {
         return #Err(#InvalidTokenId);
@@ -55,7 +55,7 @@ shared actor class Dip721NFT(custodian: Principal, init : Types.Dip721NonFungibl
   };
 
   func transferFrom(from: Principal, to: Principal, token_id: Types.TokenId, caller: Principal) : Types.TxReceipt {
-    let item = List.get(nfts, Nat64.toNat(token_id));
+    let item = List.find(nfts, func(token: Types.Nft) : Bool { token.id == token_id });
     switch (item) {
       case null {
         return #Err(#InvalidTokenId);
@@ -111,7 +111,7 @@ shared actor class Dip721NFT(custodian: Principal, init : Types.Dip721NonFungibl
   };
 
   public query func getMetadataDip721(token_id: Types.TokenId) : async Types.MetadataResult {
-    let item = List.get(nfts, Nat64.toNat(token_id));
+    let item = List.find(nfts, func(token: Types.Nft) : Bool { token.id == token_id });
     switch (item) {
       case null {
         return #Err(#InvalidTokenId);


### PR DESCRIPTION
**Overview**
I suspect a problem in the array access of this Motoko dip-721-nft-container example with ```List.get``` used.

My front-end was giving the wrong owner to a specific token id ( first of the list instead of the last ).

**Requirements**
Token ownership was fix after this change.

**Considered Solutions**
Retrieve the right item using explicit to token id match.

**Recommended Solution**
Retrieve the right item using explicit to token id match.

**Considerations**
I do not know the performance issue of this fix using ```List.find``` instead of .```List.get```
