### PR TITLE
Bump the bitcoin version to 0.28.1

### DIFF
--- a/rust/basic_bitcoin/Cargo.lock
+++ b/rust/basic_bitcoin/Cargo.lock
@@ -123,9 +123,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.27.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a41df6ad9642c5c15ae312dd3d074de38fd3eb7cc87ad4ce10f90292a83fe4d"
+checksum = "05bba324e6baf655b882df672453dbbc527bc938cadd27750ae510aaccc3a66a"
 dependencies = [
  "bech32",
  "bitcoin_hashes",
@@ -780,18 +780,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
 dependencies = [
  "cc",
 ]

--- a/rust/basic_bitcoin/dfx.json
+++ b/rust/basic_bitcoin/dfx.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "dfx": "0.11.1-beta.2",
+  "dfx": "0.11.1",
   "canisters": {
     "basic_bitcoin": {
       "type": "custom",

--- a/rust/basic_bitcoin/src/basic_bitcoin/Cargo.toml
+++ b/rust/basic_bitcoin/src/basic_bitcoin/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hex = "0.4.3"
-bitcoin = "0.27.1"
+bitcoin = "0.28.1"
 bs58 = "0.4.0"
 candid = "0.7.4"
 ic-btc-types = { git = "https://github.com/dfinity/ic", rev = "0546cc21bc9260b934e93a2beccd669b5f292ff4" }


### PR DESCRIPTION
The PR bumps the bitcoin version to 0.28.1.
This version is better suited for follow-up development work.

In addition, there is a minor change: The version in the transaction is changed from 2 to 1, which is the commonly used version number.
