### PR TITLE
change parameters on the classes example to better suit playground

### DIFF
--- a/motoko/classes/Makefile
+++ b/motoko/classes/Makefile
@@ -20,7 +20,7 @@ upgrade: build
 .PHONY: test
 .SILENT: test
 test: install
-	dfx canister call Test run '()' \
+	dfx canister call test run '()' \
 		| grep '()' && echo 'PASS'
 
 .PHONY: clean

--- a/motoko/classes/dfx.json
+++ b/motoko/classes/dfx.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "canisters": {
-    "Map": {
+    "map": {
       "type": "motoko",
       "main": "src/map/Map.mo"
     },
-    "Test": {
+    "test": {
       "type": "motoko",
       "main": "src/test/Test.mo"
     }

--- a/motoko/classes/src/test/Test.mo
+++ b/motoko/classes/src/test/Test.mo
@@ -1,11 +1,11 @@
 import Debug "mo:base/Debug";
-import Map "canister:Map";
+import Map "canister:map";
 
 actor Test {
 
   public func run() : async () {
     var i = 0;
-    while (i < 24) {
+    while (i < 16) {
       let t = debug_show(i);
       assert (null == (await Map.get(i)));
       Debug.print("putting: " # debug_show(i, t));


### PR DESCRIPTION
* Change canister name to suit playground naming convention
* Reduce test iterations, so that we can generate profiling graph