### PR TITLE
Fixing bug in mock signer

### DIFF
--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/BitcoinWallet.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/BitcoinWallet.mo
@@ -218,7 +218,7 @@ public func build_transaction(
 
   // A mock for rubber-stamping ECDSA signatures.
   func mock_signer(_key_name : Text, _derivation_path : [Blob], _message_hash : Blob) : async Blob {
-      Blob.fromArray(Array.freeze(Array.init<Nat8>(64, 1)))
+      Blob.fromArray(Array.freeze(Array.init<Nat8>(64, 255)))
   };
 
   func public_key_bytes_to_public_key(public_key_bytes : [Nat8]) : PublicKey {

--- a/rust/basic_bitcoin/src/basic_bitcoin/src/bitcoin_wallet.rs
+++ b/rust/basic_bitcoin/src/basic_bitcoin/src/bitcoin_wallet.rs
@@ -300,7 +300,7 @@ fn public_key_to_p2pkh_address(network: Network, public_key: &[u8]) -> String {
 
 // A mock for rubber-stamping ECDSA signatures.
 async fn mock_signer(_key_name: String, _derivation_path: Vec<Vec<u8>>, _message_hash: Vec<u8>) -> Vec<u8> {
-    vec![1; 64]
+    vec![255; 64]
 }
 
 // Converts a SEC1 ECDSA signature to the DER format.


### PR DESCRIPTION
Bug: It is possible that the current mock signer creates a mock signature that results in a transaction that is 1 byte smaller than the transactions signed with the proper ECDSA signing mechanism.
As a result, if we specify a low fee such as 1 sat/b, the current code sets the fee to `b-1` sat for a transaction of size `b` bytes, which causes the transaction to be rejected.

This PR fixes this problem by returning a mock signature with all bits set, both for the Rust and the Motoko version of the basic Bitcoin dapp.