### PR TITLE
Add security considerations for Actor Reference example

### DIFF
--- a/motoko/actor_reference/README.md
+++ b/motoko/actor_reference/README.md
@@ -90,3 +90,7 @@ General background:
 - [Developer's Guide](https://sdk.dfinity.org/developers-guide)
 - [Language Guide](https://sdk.dfinity.org/language-guide)
 - [Interface Computer Interface Specification, The IC management canister](https://sdk.dfinity.org/docs/interface-spec/index.html#ic-management-canister)
+
+# Security Considerations and Security Best Practices
+
+If you base your application on this example, we recommend you familiarize yourself with and adhere to the [Security Best Practices](https://internetcomputer.org/docs/current/references/security/) for developing on the Internet Computer. This example may not implement all the best practices.


### PR DESCRIPTION
This adds a reference to the security best practices for the Actor Reference example. The example does not really have a strong relation to security concerns, but a general reference still makes sense IMO. 