### PR TITLE
fix: use correct casing for secp256k1 in bitcoin example

### DIFF
--- a/motoko/basic_bitcoin/dfx.json
+++ b/motoko/basic_bitcoin/dfx.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "dfx": "0.11.2",
   "canisters": {
     "basic_bitcoin": {
       "main": "src/basic_bitcoin/src/Main.mo"

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/EcdsaApi.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/EcdsaApi.mo
@@ -24,7 +24,7 @@ module {
         canister_id = null;
         derivation_path;
         key_id = {
-            curve = #Secp256k1;
+            curve = #secp256k1;
             name = key_name;
         };
     });
@@ -38,7 +38,7 @@ module {
         message_hash;
         derivation_path;
         key_id = {
-            curve = #Secp256k1;
+            curve = #secp256k1;
             name = key_name;
         };
     });

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/Types.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/Types.mo
@@ -17,7 +17,7 @@ module Types {
     };
 
     public type EcdsaCurve = {
-        #Secp256k1;
+        #secp256k1;
     };
 
     public type SignWithECDSAReply = {


### PR DESCRIPTION
Fix the bug reported in https://forum.dfinity.org/t/got-error-in-calling-bitcoin-integration-function-get-p2pkh-address/15378