### PR TITLE
Add security best practices link to docs for factorial and hello examples

### DIFF
--- a/motoko/factorial/README.md
+++ b/motoko/factorial/README.md
@@ -16,6 +16,10 @@ Verify the following before running this demo:
 *  You have stopped any Internet Computer or other network process that would
    create a port conflict on 8000.
 
+## Security Considerations and Security Best Practices
+
+If you base your application on this example, we recommend you familiarize yourself with and adhere to the [Security Best Practices](https://internetcomputer.org/docs/current/references/security/) for developing on the Internet Computer. This example may not implement all the best practices.
+
 ## Demo
 
 1. Start a local internet computer.

--- a/motoko/hello/README.md
+++ b/motoko/hello/README.md
@@ -14,6 +14,10 @@ This example is based on the default project created by running `dfx new hello` 
 
 A version of this example with a Rust implementation of canister `hello` can be found [here](../../rust/hello/README.md).
 
+## Security Considerations and Security Best Practices
+
+If you base your application on this example, we recommend you familiarize yourself with and adhere to the [Security Best Practices](https://internetcomputer.org/docs/current/references/security/) for developing on the Internet Computer. This example may not implement all the best practices.
+
 ## Interface
 
 Canister `hello` is defined as a Motoko actor:

--- a/rust/hello/README.md
+++ b/rust/hello/README.md
@@ -15,6 +15,10 @@ This example is based on the default project created by running
 
 A version of this example with a Motoko implementation of canister `hello` can be found [here](../../motoko/hello/README.md).
 
+## Security Considerations and Security Best Practices
+
+If you base your application on this example, we recommend you familiarize yourself with and adhere to the [Security Best Practices](https://internetcomputer.org/docs/current/references/security/) for developing on the Internet Computer. This example may not implement all the best practices.
+
 ## Interface
 
 Canister `hello` is defined as a Rust library:


### PR DESCRIPTION
Add security best practices link to docs for factorial and hello examples. 

Since the examples are almost trivial this is just a link to the best practices without listing specific examples relevant for these apps. 