### PR TITLE
Fix number of cycles sent to sign in threshold ECDSA examples

### DIFF
--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
@@ -37,7 +37,7 @@ actor {
     assert(message_hash.size() == 32);
     let caller = Principal.toBlob(msg.caller);
     try {
-      Cycles.add(10_000_000_000);
+      Cycles.add(21_600_000_000);
       let { signature } = await ic.sign_with_ecdsa({
           message_hash;
           derivation_path = [ caller ];

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
@@ -37,7 +37,7 @@ actor {
     assert(message_hash.size() == 32);
     let caller = Principal.toBlob(msg.caller);
     try {
-      Cycles.add(21_600_000_000);
+      Cycles.add(21_538_461_600);
       let { signature } = await ic.sign_with_ecdsa({
           message_hash;
           derivation_path = [ caller ];

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
@@ -37,7 +37,7 @@ actor {
     assert(message_hash.size() == 32);
     let caller = Principal.toBlob(msg.caller);
     try {
-      Cycles.add(21_538_461_600);
+      Cycles.add(25_000_000_000);
       let { signature } = await ic.sign_with_ecdsa({
           message_hash;
           derivation_path = [ caller ];

--- a/rust/threshold-ecdsa/src/ecdsa_example_rust/src/lib.rs
+++ b/rust/threshold-ecdsa/src/ecdsa_example_rust/src/lib.rs
@@ -97,7 +97,7 @@ async fn sign(message: Vec<u8>) -> Result<SignatureReply, String> {
         key_id,
     };
     let (res,): (SignWithECDSAReply,) =
-        ic_cdk::api::call::call_with_payment(ic, "sign_with_ecdsa", (request,), 21_538_461_600)
+        ic_cdk::api::call::call_with_payment(ic, "sign_with_ecdsa", (request,), 25_000_000_000)
             .await
             .map_err(|e| format!("Failed to call sign_with_ecdsa {}", e.1))?;
 

--- a/rust/threshold-ecdsa/src/ecdsa_example_rust/src/lib.rs
+++ b/rust/threshold-ecdsa/src/ecdsa_example_rust/src/lib.rs
@@ -97,7 +97,7 @@ async fn sign(message: Vec<u8>) -> Result<SignatureReply, String> {
         key_id,
     };
     let (res,): (SignWithECDSAReply,) =
-        ic_cdk::api::call::call_with_payment(ic, "sign_with_ecdsa", (request,), 10_000_000_000)
+        ic_cdk::api::call::call_with_payment(ic, "sign_with_ecdsa", (request,), 21_538_461_600)
             .await
             .map_err(|e| format!("Failed to call sign_with_ecdsa {}", e.1))?;
 


### PR DESCRIPTION
**Overview**
The number of cycles attached to signing cals in the threshold ECDSA examples is not sufficient. The current amount of cycles sent is `10_000_000_000`, however the number of cycles needs to be higher than `21_538_461_538`

**Requirements**
NA

**Considered Solutions**
NA

**Recommended Solution**
Increase the number of cycles attached to sign request.

**Considerations**
NA