### PR TITLE
fix outdated II installation instructions

### DIFF
--- a/motoko/defi/scripts/install.sh
+++ b/motoko/defi/scripts/install.sh
@@ -44,7 +44,7 @@ dfx canister call GoldenDIP20 setFee "(420)"
 
 ### === DEPLOY INTERNET IDENTITY =====
 
-II_ENV=development dfx deploy internet_identity --no-wallet --argument '(null)'
+II_FETCH_ROOT_KEY=1 dfx deploy internet_identity --no-wallet --argument '(null)'
 
 ## === INSTALL FRONTEND / BACKEND ==== 
 

--- a/rust/nft-wallet/README.md
+++ b/rust/nft-wallet/README.md
@@ -20,7 +20,7 @@ If you prefer to manually deploy
 dfx start --background
 cd internet-identity
 npm install
-II_ENV=development dfx deploy
+II_FETCH_ROOT_KEY=1 dfx deploy
 cd ..
 ./deploy.sh
 ```

--- a/rust/nft-wallet/start.sh
+++ b/rust/nft-wallet/start.sh
@@ -3,6 +3,6 @@ set -e
 git submodule update --init --recursive
 rm -rf .dfx/ ./internet-identity/.dfx/
 dfx start --background --clean --host 127.0.0.1:8000
-II_ENV=development dfx deploy internet_identity --no-wallet --argument '(null)'
+II_FETCH_ROOT_KEY=1 dfx deploy internet_identity --no-wallet --argument '(null)'
 npm install
 ./deploy.sh --no-wallet --argument null

--- a/svelte/svelte-motoko-starter/README.md
+++ b/svelte/svelte-motoko-starter/README.md
@@ -111,7 +111,7 @@ When the repository is cloned, switch to its directory and install it:
 ```
 cd internet-identity
 npm install
-II_ENV=development dfx deploy --no-wallet --argument '(null)'
+II_FETCH_ROOT_KEY=1 dfx deploy --no-wallet --argument '(null)'
 ```
 
 This will take several minutes to complete.


### PR DESCRIPTION
**Overview**
As reported on [this forum post](https://forum.dfinity.org/t/error-when-deploying-svelte-examples-from-dfinity-samples-bank/16983/22), installation instructions for II are outdated in the examples.