### PR TITLE
add project-specific network to btc examples

### DIFF
--- a/motoko/basic_bitcoin/dfx.json
+++ b/motoko/basic_bitcoin/dfx.json
@@ -17,5 +17,10 @@
       "packtool": "",
       "args": ""
     }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:4943"
+    }
   }
 }

--- a/rust/basic_bitcoin/dfx.json
+++ b/rust/basic_bitcoin/dfx.json
@@ -12,12 +12,19 @@
   "defaults": {
     "bitcoin": {
       "enabled": true,
-      "nodes": ["127.0.0.1:18444"],
+      "nodes": [
+        "127.0.0.1:18444"
+      ],
       "log_level": "info"
     },
     "build": {
       "packtool": "",
       "args": ""
+    }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:4943"
     }
   }
 }


### PR DESCRIPTION
**Overview**
dfx.json says that bitcoin is enabled for the BTC examples, but this setting won't trigger if there is no project-specific network defined
