### PR TITLE
checkin declarations

### DIFF
--- a/motoko/exchange_rate/cleanup.sh
+++ b/motoko/exchange_rate/cleanup.sh
@@ -21,7 +21,6 @@ fi
 
 # Remove copied and generated UI assets
 rm -rf src/frontend
-rm -rf src/declarations
 rm rollup.config.js
 rm -rf node_modules
 

--- a/motoko/exchange_rate/package-lock.json
+++ b/motoko/exchange_rate/package-lock.json
@@ -262,9 +262,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -301,9 +301,9 @@
       }
     },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -347,9 +347,9 @@
       ]
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
       "engines": {
         "node": "*"
       }
@@ -1095,6 +1095,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
       "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -1230,6 +1231,7 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true
     },
     "node_modules/string_decoder": {
@@ -1265,9 +1267,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.0.tgz",
-      "integrity": "sha512-QwR6zwpcdpz5OqybIHlghM+qP2qKbzsKQuU9npgAmnI6zoTDIcjbcseUZA0AJGbotorltpQ0f413euKK4w+Piw==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.54.0.tgz",
+      "integrity": "sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==",
       "dev": true,
       "engines": {
         "node": ">= 8"
@@ -1304,9 +1306,9 @@
       "dev": true
     },
     "node_modules/terser": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -1566,9 +1568,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "version": "18.11.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
+      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
       "dev": true
     },
     "@types/resolve": {
@@ -1596,9 +1598,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -1622,9 +1624,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -2308,9 +2310,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.53.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.53.0.tgz",
-      "integrity": "sha512-QwR6zwpcdpz5OqybIHlghM+qP2qKbzsKQuU9npgAmnI6zoTDIcjbcseUZA0AJGbotorltpQ0f413euKK4w+Piw==",
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.54.0.tgz",
+      "integrity": "sha512-tdrgeJU0hob0ZWAMoKXkhcxXA7dpTg6lZGxUeko5YqvPdJBiyRspGsCwV27kIrbrqPP2WUoSV9ca0gnLlw8YzQ==",
       "dev": true
     },
     "svelte-fa": {
@@ -2341,9 +2343,9 @@
       "dev": true
     },
     "terser": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.1.tgz",
-      "integrity": "sha512-K1faMUvpm/FBxjBXud0LWVAGxmvoPbZbfTCYbSgaaYQaIXI3/TdI7a7ZGA73Zrou6Q8Zmz3oeUTsp/dj+ag2Xw==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",

--- a/motoko/exchange_rate/package.json
+++ b/motoko/exchange_rate/package.json
@@ -7,8 +7,6 @@
     "Canister"
   ],
   "scripts": {
-    "prebuild": "dfx generate exchange_rate",
-    "prestart": "dfx generate exchange_rate",
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv src/frontend/public --no-clear --port 5555"

--- a/rust/exchange_rate/package.json
+++ b/rust/exchange_rate/package.json
@@ -7,8 +7,6 @@
     "Canister"
   ],
   "scripts": {
-    "prebuild": "dfx generate exchange_rate",
-    "prestart": "dfx generate exchange_rate",
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv src/frontend/public --no-clear --port 5555"

--- a/rust/exchange_rate/src/declarations/exchange_rate_assets/exchange_rate_assets.did
+++ b/rust/exchange_rate/src/declarations/exchange_rate_assets/exchange_rate_assets.did
@@ -1,0 +1,147 @@
+type BatchId = nat;
+type ChunkId = nat;
+type Key = text;
+type Time = int;
+
+type CreateAssetArguments = record {
+  key: Key;
+  content_type: text;
+  max_age: opt nat64;
+  headers: opt vec HeaderField;
+};
+
+// Add or change content for an asset, by content encoding
+type SetAssetContentArguments = record {
+  key: Key;
+  content_encoding: text;
+  chunk_ids: vec ChunkId;
+  sha256: opt blob;
+};
+
+// Remove content for an asset, by content encoding
+type UnsetAssetContentArguments = record {
+  key: Key;
+  content_encoding: text;
+};
+
+// Delete an asset
+type DeleteAssetArguments = record {
+  key: Key;
+};
+
+// Reset everything
+type ClearArguments = record {};
+
+type BatchOperationKind = variant {
+  CreateAsset: CreateAssetArguments;
+  SetAssetContent: SetAssetContentArguments;
+
+  UnsetAssetContent: UnsetAssetContentArguments;
+  DeleteAsset: DeleteAssetArguments;
+
+  Clear: ClearArguments;
+};
+
+type HeaderField = record { text; text; };
+
+type HttpRequest = record {
+  method: text;
+  url: text;
+  headers: vec HeaderField;
+  body: blob;
+};
+
+type HttpResponse = record {
+  status_code: nat16;
+  headers: vec HeaderField;
+  body: blob;
+  streaming_strategy: opt StreamingStrategy;
+};
+
+type StreamingCallbackHttpResponse = record {
+  body: blob;
+  token: opt StreamingCallbackToken;
+};
+
+type StreamingCallbackToken = record {
+  key: Key;
+  content_encoding: text;
+  index: nat;
+  sha256: opt blob;
+};
+
+type StreamingStrategy = variant {
+  Callback: record {
+    callback: func (StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
+    token: StreamingCallbackToken;
+  };
+};
+
+service: {
+
+  get: (record {
+    key: Key;
+    accept_encodings: vec text;
+  }) -> (record {
+    content: blob; // may be the entirety of the content, or just chunk index 0
+    content_type: text;
+    content_encoding: text;
+    sha256: opt blob; // sha256 of entire asset encoding, calculated by dfx and passed in SetAssetContentArguments
+    total_length: nat; // all chunks except last have size == content.size()
+  }) query;
+
+  // if get() returned chunks > 1, call this to retrieve them.
+  // chunks may or may not be split up at the same boundaries as presented to create_chunk().
+  get_chunk: (record {
+    key: Key;
+    content_encoding: text;
+    index: nat;
+    sha256: opt blob;  // sha256 of entire asset encoding, calculated by dfx and passed in SetAssetContentArguments
+  }) -> (record { content: blob }) query;
+
+  list : (record {}) -> (vec record {
+    key: Key;
+    content_type: text;
+    encodings: vec record {
+      content_encoding: text;
+      sha256: opt blob; // sha256 of entire asset encoding, calculated by dfx and passed in SetAssetContentArguments
+      length: nat; // Size of this encoding's blob. Calculated when uploading assets.
+      modified: Time;
+    };
+  }) query;
+
+  certified_tree : (record {}) -> (record {
+    certificate: blob;
+    tree: blob;
+  }) query;
+
+  create_batch : (record {}) -> (record { batch_id: BatchId });
+
+  create_chunk: (record { batch_id: BatchId; content: blob }) -> (record { chunk_id: ChunkId });
+
+  // Perform all operations successfully, or reject
+  commit_batch: (record { batch_id: BatchId; operations: vec BatchOperationKind }) -> ();
+
+  create_asset: (CreateAssetArguments) -> ();
+  set_asset_content: (SetAssetContentArguments) -> ();
+  unset_asset_content: (UnsetAssetContentArguments) -> ();
+
+  delete_asset: (DeleteAssetArguments) -> ();
+
+  clear: (ClearArguments) -> ();
+
+  // Single call to create an asset with content for a single content encoding that
+  // fits within the message ingress limit.
+  store: (record {
+    key: Key;
+    content_type: text;
+    content_encoding: text;
+    content: blob;
+    sha256: opt blob
+  }) -> ();
+
+  http_request: (request: HttpRequest) -> (HttpResponse) query;
+  http_request_streaming_callback: (token: StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
+
+  authorize: (principal) -> ();
+}

--- a/rust/exchange_rate/src/declarations/exchange_rate_assets/exchange_rate_assets.did.d.ts
+++ b/rust/exchange_rate/src/declarations/exchange_rate_assets/exchange_rate_assets.did.d.ts
@@ -1,0 +1,135 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+
+export type BatchId = bigint;
+export type BatchOperationKind = { 'CreateAsset' : CreateAssetArguments } |
+  { 'UnsetAssetContent' : UnsetAssetContentArguments } |
+  { 'DeleteAsset' : DeleteAssetArguments } |
+  { 'SetAssetContent' : SetAssetContentArguments } |
+  { 'Clear' : ClearArguments };
+export type ChunkId = bigint;
+export type ClearArguments = {};
+export interface CreateAssetArguments {
+  'key' : Key,
+  'content_type' : string,
+  'headers' : [] | [Array<HeaderField>],
+  'max_age' : [] | [bigint],
+}
+export interface DeleteAssetArguments { 'key' : Key }
+export type HeaderField = [string, string];
+export interface HttpRequest {
+  'url' : string,
+  'method' : string,
+  'body' : Uint8Array,
+  'headers' : Array<HeaderField>,
+}
+export interface HttpResponse {
+  'body' : Uint8Array,
+  'headers' : Array<HeaderField>,
+  'streaming_strategy' : [] | [StreamingStrategy],
+  'status_code' : number,
+}
+export type Key = string;
+export interface SetAssetContentArguments {
+  'key' : Key,
+  'sha256' : [] | [Uint8Array],
+  'chunk_ids' : Array<ChunkId>,
+  'content_encoding' : string,
+}
+export interface StreamingCallbackHttpResponse {
+  'token' : [] | [StreamingCallbackToken],
+  'body' : Uint8Array,
+}
+export interface StreamingCallbackToken {
+  'key' : Key,
+  'sha256' : [] | [Uint8Array],
+  'index' : bigint,
+  'content_encoding' : string,
+}
+export type StreamingStrategy = {
+    'Callback' : {
+      'token' : StreamingCallbackToken,
+      'callback' : [Principal, string],
+    }
+  };
+export type Time = bigint;
+export interface UnsetAssetContentArguments {
+  'key' : Key,
+  'content_encoding' : string,
+}
+export interface _SERVICE {
+  'authorize' : ActorMethod<[Principal], undefined>,
+  'certified_tree' : ActorMethod<
+    [{}],
+    { 'certificate' : Uint8Array, 'tree' : Uint8Array }
+  >,
+  'clear' : ActorMethod<[ClearArguments], undefined>,
+  'commit_batch' : ActorMethod<
+    [{ 'batch_id' : BatchId, 'operations' : Array<BatchOperationKind> }],
+    undefined
+  >,
+  'create_asset' : ActorMethod<[CreateAssetArguments], undefined>,
+  'create_batch' : ActorMethod<[{}], { 'batch_id' : BatchId }>,
+  'create_chunk' : ActorMethod<
+    [{ 'content' : Uint8Array, 'batch_id' : BatchId }],
+    { 'chunk_id' : ChunkId }
+  >,
+  'delete_asset' : ActorMethod<[DeleteAssetArguments], undefined>,
+  'get' : ActorMethod<
+    [{ 'key' : Key, 'accept_encodings' : Array<string> }],
+    {
+      'content' : Uint8Array,
+      'sha256' : [] | [Uint8Array],
+      'content_type' : string,
+      'content_encoding' : string,
+      'total_length' : bigint,
+    }
+  >,
+  'get_chunk' : ActorMethod<
+    [
+      {
+        'key' : Key,
+        'sha256' : [] | [Uint8Array],
+        'index' : bigint,
+        'content_encoding' : string,
+      },
+    ],
+    { 'content' : Uint8Array }
+  >,
+  'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  'http_request_streaming_callback' : ActorMethod<
+    [StreamingCallbackToken],
+    [] | [StreamingCallbackHttpResponse]
+  >,
+  'list' : ActorMethod<
+    [{}],
+    Array<
+      {
+        'key' : Key,
+        'encodings' : Array<
+          {
+            'modified' : Time,
+            'sha256' : [] | [Uint8Array],
+            'length' : bigint,
+            'content_encoding' : string,
+          }
+        >,
+        'content_type' : string,
+      }
+    >
+  >,
+  'set_asset_content' : ActorMethod<[SetAssetContentArguments], undefined>,
+  'store' : ActorMethod<
+    [
+      {
+        'key' : Key,
+        'content' : Uint8Array,
+        'sha256' : [] | [Uint8Array],
+        'content_type' : string,
+        'content_encoding' : string,
+      },
+    ],
+    undefined
+  >,
+  'unset_asset_content' : ActorMethod<[UnsetAssetContentArguments], undefined>,
+}

--- a/rust/exchange_rate/src/declarations/exchange_rate_assets/exchange_rate_assets.did.js
+++ b/rust/exchange_rate/src/declarations/exchange_rate_assets/exchange_rate_assets.did.js
@@ -1,0 +1,167 @@
+export const idlFactory = ({ IDL }) => {
+  const ClearArguments = IDL.Record({});
+  const BatchId = IDL.Nat;
+  const Key = IDL.Text;
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const CreateAssetArguments = IDL.Record({
+    'key' : Key,
+    'content_type' : IDL.Text,
+    'headers' : IDL.Opt(IDL.Vec(HeaderField)),
+    'max_age' : IDL.Opt(IDL.Nat64),
+  });
+  const UnsetAssetContentArguments = IDL.Record({
+    'key' : Key,
+    'content_encoding' : IDL.Text,
+  });
+  const DeleteAssetArguments = IDL.Record({ 'key' : Key });
+  const ChunkId = IDL.Nat;
+  const SetAssetContentArguments = IDL.Record({
+    'key' : Key,
+    'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'chunk_ids' : IDL.Vec(ChunkId),
+    'content_encoding' : IDL.Text,
+  });
+  const BatchOperationKind = IDL.Variant({
+    'CreateAsset' : CreateAssetArguments,
+    'UnsetAssetContent' : UnsetAssetContentArguments,
+    'DeleteAsset' : DeleteAssetArguments,
+    'SetAssetContent' : SetAssetContentArguments,
+    'Clear' : ClearArguments,
+  });
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+  });
+  const StreamingCallbackToken = IDL.Record({
+    'key' : Key,
+    'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'index' : IDL.Nat,
+    'content_encoding' : IDL.Text,
+  });
+  const StreamingCallbackHttpResponse = IDL.Record({
+    'token' : IDL.Opt(StreamingCallbackToken),
+    'body' : IDL.Vec(IDL.Nat8),
+  });
+  const StreamingStrategy = IDL.Variant({
+    'Callback' : IDL.Record({
+      'token' : StreamingCallbackToken,
+      'callback' : IDL.Func(
+          [StreamingCallbackToken],
+          [IDL.Opt(StreamingCallbackHttpResponse)],
+          ['query'],
+        ),
+    }),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'streaming_strategy' : IDL.Opt(StreamingStrategy),
+    'status_code' : IDL.Nat16,
+  });
+  const Time = IDL.Int;
+  return IDL.Service({
+    'authorize' : IDL.Func([IDL.Principal], [], []),
+    'certified_tree' : IDL.Func(
+        [IDL.Record({})],
+        [
+          IDL.Record({
+            'certificate' : IDL.Vec(IDL.Nat8),
+            'tree' : IDL.Vec(IDL.Nat8),
+          }),
+        ],
+        ['query'],
+      ),
+    'clear' : IDL.Func([ClearArguments], [], []),
+    'commit_batch' : IDL.Func(
+        [
+          IDL.Record({
+            'batch_id' : BatchId,
+            'operations' : IDL.Vec(BatchOperationKind),
+          }),
+        ],
+        [],
+        [],
+      ),
+    'create_asset' : IDL.Func([CreateAssetArguments], [], []),
+    'create_batch' : IDL.Func(
+        [IDL.Record({})],
+        [IDL.Record({ 'batch_id' : BatchId })],
+        [],
+      ),
+    'create_chunk' : IDL.Func(
+        [IDL.Record({ 'content' : IDL.Vec(IDL.Nat8), 'batch_id' : BatchId })],
+        [IDL.Record({ 'chunk_id' : ChunkId })],
+        [],
+      ),
+    'delete_asset' : IDL.Func([DeleteAssetArguments], [], []),
+    'get' : IDL.Func(
+        [IDL.Record({ 'key' : Key, 'accept_encodings' : IDL.Vec(IDL.Text) })],
+        [
+          IDL.Record({
+            'content' : IDL.Vec(IDL.Nat8),
+            'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'content_type' : IDL.Text,
+            'content_encoding' : IDL.Text,
+            'total_length' : IDL.Nat,
+          }),
+        ],
+        ['query'],
+      ),
+    'get_chunk' : IDL.Func(
+        [
+          IDL.Record({
+            'key' : Key,
+            'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'index' : IDL.Nat,
+            'content_encoding' : IDL.Text,
+          }),
+        ],
+        [IDL.Record({ 'content' : IDL.Vec(IDL.Nat8) })],
+        ['query'],
+      ),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'http_request_streaming_callback' : IDL.Func(
+        [StreamingCallbackToken],
+        [IDL.Opt(StreamingCallbackHttpResponse)],
+        ['query'],
+      ),
+    'list' : IDL.Func(
+        [IDL.Record({})],
+        [
+          IDL.Vec(
+            IDL.Record({
+              'key' : Key,
+              'encodings' : IDL.Vec(
+                IDL.Record({
+                  'modified' : Time,
+                  'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+                  'length' : IDL.Nat,
+                  'content_encoding' : IDL.Text,
+                })
+              ),
+              'content_type' : IDL.Text,
+            })
+          ),
+        ],
+        ['query'],
+      ),
+    'set_asset_content' : IDL.Func([SetAssetContentArguments], [], []),
+    'store' : IDL.Func(
+        [
+          IDL.Record({
+            'key' : Key,
+            'content' : IDL.Vec(IDL.Nat8),
+            'sha256' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+            'content_type' : IDL.Text,
+            'content_encoding' : IDL.Text,
+          }),
+        ],
+        [],
+        [],
+      ),
+    'unset_asset_content' : IDL.Func([UnsetAssetContentArguments], [], []),
+  });
+};
+export const init = ({ IDL }) => { return []; };

--- a/rust/exchange_rate/src/declarations/exchange_rate_assets/index.d.ts
+++ b/rust/exchange_rate/src/declarations/exchange_rate_assets/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './exchange_rate_assets.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const exchange_rate_assets: ActorSubclass<_SERVICE>;

--- a/rust/exchange_rate/src/declarations/exchange_rate_assets/index.js
+++ b/rust/exchange_rate/src/declarations/exchange_rate_assets/index.js
@@ -1,0 +1,37 @@
+import { Actor, HttpAgent } from "@dfinity/agent";
+
+// Imports and re-exports candid interface
+import { idlFactory } from "./exchange_rate_assets.did.js";
+export { idlFactory } from "./exchange_rate_assets.did.js";
+
+// CANISTER_ID is replaced by webpack based on node environment
+export const canisterId = process.env.EXCHANGE_RATE_ASSETS_CANISTER_ID;
+
+export const createActor = (canisterId, options = {}) => {
+  const agent = options.agent || new HttpAgent({ ...options.agentOptions });
+
+  if (options.agent && options.agentOptions) {
+    console.warn(
+      "Detected both agent and agentOptions passed to createActor. Ignoring agentOptions and proceeding with the provided agent."
+    );
+  }
+
+  // Fetch root key for certificate validation during development
+  if (process.env.DFX_NETWORK !== "ic") {
+    agent.fetchRootKey().catch((err) => {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    });
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor(idlFactory, {
+    agent,
+    canisterId,
+    ...options.actorOptions,
+  });
+};
+
+export const exchange_rate_assets = createActor(canisterId);


### PR DESCRIPTION
`"prestart": "dfx generate exchange_rate"` Only works if canister already exists. If we check-in the declarations for both examples it is easier to deploy. 
