### PR TITLE
Use fragment for delegation callback

### DIFF
--- a/motoko/ios-notifications/dapp-demo/src/www/src/auth.ts
+++ b/motoko/ios-notifications/dapp-demo/src/www/src/auth.ts
@@ -188,10 +188,8 @@ export class Auth {
           throw new Error("Missing delegations");
         }
 
-        authCallback.searchParams.set(
-          Auth.restoreKey,
-          Buffer.from(delegations, "ascii").toString("base64")
-        );
+        const base64Delegation = Buffer.from(delegations, "ascii").toString("base64");
+        authCallback.hash = `${Auth.restoreKey}=${base64Delegation}`;
 
         // apple universal links require the user to tap to trigger the native app to handle the url
         document.write(

--- a/motoko/ios-notifications/ios-dapp-demo/DAppExample/LoginSession.swift
+++ b/motoko/ios-notifications/ios-dapp-demo/DAppExample/LoginSession.swift
@@ -51,7 +51,7 @@ public class LoginSession: NSObject, ObservableObject, ASWebAuthenticationPresen
     }
     
     public func identityCallbackHook(successURL: URL) {
-        let delegationsValue = NSURLComponents(string: (successURL.absoluteString))?.queryItems?.filter({$0.name == self.restoreKey}).first?.value ?? ""
+        let delegationsValue = successURL.fragment()?.split(separator: self.restoreKey + "=")[0] ?? "";
 
         DispatchQueue.main.async {
             let restoreAuthScript = """


### PR DESCRIPTION
**Overview**
Update example ios notifications app to use fragment for the delegation callback.
