### PR TITLE
fix: path in svelte-motoko-starter

### DIFF
--- a/svelte/svelte-motoko-starter/README.md
+++ b/svelte/svelte-motoko-starter/README.md
@@ -57,7 +57,7 @@ Make sure you have [node.js](https://nodejs.org/) installed.
 To clone this template without downloading the entire repository, run the following command:
 
 ```
-npx degit dfinity/examples/svelte-motoko-starter svelte-motoko-starter
+npx degit dfinity/examples/svelte/svelte-motoko-starter svelte-motoko-starter
 ```
 
 ### DFX


### PR DESCRIPTION
Fix the path to copy the svelte-motoko-starter repo
