### PR TITLE
Change 'Mokoto' to 'Motoko' in example documentation. 

### DIFF
--- a/rust/counter/README.md
+++ b/rust/counter/README.md
@@ -1,6 +1,6 @@
 # Counter
 
-This is a Rust port of the Mokoto Counter example. 
+This is a Rust port of the Motoko Counter example.
 
 This example demonstrates a counter application. It uses an orthogonally
 persistent `counter` variable to store an arbitrary precision natural number
@@ -10,7 +10,7 @@ Canisters in Rust are single-threaded, thus it is safe (and simplest) to
 declare global state variable within a `thread_local!` block
 and wrapping `COUNTER` in a `RefCell` pointer.
 
-This is the equivalent of the `stable` keyword in Mokoto, and the value of 
+This is the equivalent of the `stable` keyword in Motoko, and the value of
 such variables will automatically be preserved whenever the canister code is
 upgraded.
 

--- a/svelte/svelte-motoko-starter/README.md
+++ b/svelte/svelte-motoko-starter/README.md
@@ -9,7 +9,7 @@ This repository is meant to give [Svelte](https://svelte.dev/) developers an eas
 This template contains
 
 - a Svelte frontend app under `src/frontend` to be hosted on-chain, with support for authentication using Internet Identity
-- a Mokoto dapp under `src/backend` to serve as a backend to the Svelte frontend
+- a Motoko dapp under `src/backend` to serve as a backend to the Svelte frontend
 
 You can see a deployed version of this template here: https://zixfv-4yaaa-aaaam-aaatq-cai.ic0.app/
 
@@ -23,7 +23,7 @@ Coupled with super fast execution the Internet Computer provides the worlds firs
 
 Dapps on the Internet Computer live in canisters, which are special smart contracts that run WebAssembly, and can respond to regular HTTP requests, among other capabilities.
 
-This repository uses Svelte for the frontend running in the browser, and the backend dapp is written in Mokoto, it serves as the business logic of your dapp.
+This repository uses Svelte for the frontend running in the browser, and the backend dapp is written in Motoko, it serves as the business logic of your dapp.
 
 You will build and deploy the following _canisters_:
 


### PR DESCRIPTION
Change 'Mokoto' to 'Motoko' in example documentation. 
I'm assuming that was a typo.