### PR TITLE
fix `run:` CLI comments in GH workflow for `hosting-photo-storage-example`

### DIFF
--- a/.github/workflows/hosting-photo-storage-example.yml
+++ b/.github/workflows/hosting-photo-storage-example.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Provision Darwin
-        run: bash .github/workflows/provision-darwin.sh
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Hosting Photo Storage Darwin
         run: |
           pushd hosting/photo-storage

--- a/.github/workflows/hosting-photo-storage-example.yml
+++ b/.github/workflows/hosting-photo-storage-example.yml
@@ -18,15 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
+        run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Photo Storage Darwin
         run: |
           pushd hosting/photo-storage
-        # verify frontend deps install and build
+          # verify frontend deps install and build
           npm install
           npm run build
-        # verify that frontend asset canister deploys
+          # verify that frontend asset canister deploys
           dfx start --background
           dfx deploy
           popd
@@ -39,10 +38,10 @@ jobs:
       - name: Hosting Photo Storage Linux
         run: |
           pushd hosting/photo-storage
-        # verify frontend deps install and build
+          # verify frontend deps install and build
           npm install
           npm run build
-        # verify that frontend asset canister deploys
+          # verify that frontend asset canister deploys
           dfx start --background
           dfx deploy
           popd


### PR DESCRIPTION
I got this error:
```
[Invalid workflow file: .github/workflows/hosting-photo-storage-example.yml#L21](https://github.com/dfinity/examples/actions/runs/3958056577/workflow)
You have an error in your yaml syntax on line 21
```

Yaml verifiers say the problem is with the CLI lines that are not aligned (and start with `#`).
> All mapping items must start at the same column at line 25, column 1
> Implicit keys need to be on a single line at line 26, column 11
> Implicit map keys need to be followed by map values at line 26, column 11
> All mapping items must start at the same column at line 41, column 1
> Implicit keys need to be on a single line at line 42, column 11
> Implicit map keys need to be followed by map values at line 42, column 11