### PR TITLE
fix: EXC-1329 the `basic_bitcoin` wasm is too large.

### DIFF
--- a/rust/basic_bitcoin/dfx.json
+++ b/rust/basic_bitcoin/dfx.json
@@ -5,7 +5,7 @@
       "type": "custom",
       "package": "basic_bitcoin",
       "candid": "src/basic_bitcoin/basic_bitcoin.did",
-      "wasm": "target/wasm32-unknown-unknown/release/basic_bitcoin.wasm",
+      "wasm": "target/wasm32-unknown-unknown/release/basic_bitcoin.wasm.gz",
       "build": "src/basic_bitcoin/build.sh"
     }
   },

--- a/rust/basic_bitcoin/src/basic_bitcoin/build.sh
+++ b/rust/basic_bitcoin/src/basic_bitcoin/build.sh
@@ -16,5 +16,7 @@ else
   cargo build --target $TARGET --release
 fi
 
+gzip -n -f "../../target/$TARGET/release/basic_bitcoin.wasm"
+
 popd
 


### PR DESCRIPTION
Prior to this commit, deploying the rust `basic_bitcoin` example failed with:

```
The replica returned an HTTP Error: Http Error: status 413 Payload Too Large, content type "application/cbor", content: Request 0x6a3ef24c0be4f7d988c107bcca95066d87e63f280ed38e0fe55976c444bc08d6 is too large. Message byte size 2841795 is larger than the max allowed 2097152.
    Time: 0h:00m:19s
```

The binary is now gzipped, reducing its size to be below the limit.

Closes EXC-1329