### PR TITLE
fix: CI now tests deployment of the Rust basic_bitcoin example.

### DIFF
--- a/.github/workflows/rust-basic-bitcoin-example.yml
+++ b/.github/workflows/rust-basic-bitcoin-example.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Rust Basic Bitcoin Darwin
         run: |
           pushd rust/basic_bitcoin
-          make
+          make deploy
           popd
   rust-basic-bitcoin-linux:
     runs-on: ubuntu-20.04

--- a/.github/workflows/rust-basic-bitcoin-example.yml
+++ b/.github/workflows/rust-basic-bitcoin-example.yml
@@ -23,6 +23,7 @@ jobs:
           brew install llvm
       - name: Rust Basic Bitcoin Darwin
         run: |
+          dfx start --background
           pushd rust/basic_bitcoin
           make deploy
           popd
@@ -34,6 +35,7 @@ jobs:
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Basic Bitcoin Linux
         run: |
+          dfx start --background
           pushd rust/basic_bitcoin
           make
           popd

--- a/rust/basic_bitcoin/Makefile
+++ b/rust/basic_bitcoin/Makefile
@@ -1,10 +1,11 @@
 .PHONY: all
-all: build
+all: deploy
 
-.PHONY: build
-.SILENT: build
-build:
-	./src/basic_bitcoin/build.sh
+.PHONY: deploy
+.SILENT: deploy
+deploy:
+	dfx deploy basic_bitcoin --argument '(variant { Regtest })'
+
 .PHONY: clean
 .SILENT: clean
 clean:


### PR DESCRIPTION
Problem:
The CI only tested that `basic_bitcoin` compiles successfully, but didn't verify that the wasm can be deployed successfully. This resulted in bugs like #435 from slipping through the cracks.

Solution:
Harden CI to test that deploying the `basic_bitcoin` example.