### PR TITLE
fix: sets all rollup configs to use bundled json in iife format

### DIFF
--- a/motoko/defi/src/frontend/rollup.config.js
+++ b/motoko/defi/src/frontend/rollup.config.js
@@ -73,8 +73,10 @@ export default {
   input: "src/main.js",
   output: {
     sourcemap: true,
+    format: "iife",
     name: "app",
-    dir: "../frontend_assets/build",
+    file: "../frontend_assets/build/main.js",
+		inlineDynamicImports: true,
   },
   plugins: [
     svelte({

--- a/motoko/encrypted-notes-dapp/rollup.config.js
+++ b/motoko/encrypted-notes-dapp/rollup.config.js
@@ -80,7 +80,10 @@ export default (config) => {
     output: {
       sourcemap: true,
       name: 'app',
-      dir: 'src/frontend/public/build',
+      format: 'iife',
+      
+      file: 'src/frontend/public/build/main.js',
+      inlineDynamicImports: true,
     },
     plugins: [
       svelte({

--- a/motoko/exchange_rate/rollup.config.js
+++ b/motoko/exchange_rate/rollup.config.js
@@ -71,7 +71,9 @@ export default {
 	output: {
 		sourcemap: true,
 		name: 'app',
-		dir: 'src/frontend/public/build'
+		format: 'iife',
+		file: 'src/frontend/public/build/main.js',
+		inlineDynamicImports: true,
 	},
 	plugins: [
 		svelte({

--- a/rust/defi/src/frontend/rollup.config.js
+++ b/rust/defi/src/frontend/rollup.config.js
@@ -75,7 +75,8 @@ export default {
     sourcemap: true,
     format: "iife",
     name: "app",
-    dir: "../frontend_assets/build",
+    file: "../frontend_assets/build/main.js",
+    inlineDynamicImports: true,
   },
   plugins: [
     svelte({

--- a/rust/exchange_rate/rollup.config.js
+++ b/rust/exchange_rate/rollup.config.js
@@ -71,7 +71,9 @@ export default {
 	output: {
 		sourcemap: true,
 		name: 'app',
-		dir: 'src/frontend/public/build'
+		format: 'iife',
+		file: 'src/frontend/public/build/main.js',
+		inlineDynamicImports: true,
 	},
 	plugins: [
 		svelte({

--- a/rust/nft-wallet/frontend/rollup.config.js
+++ b/rust/nft-wallet/frontend/rollup.config.js
@@ -21,7 +21,9 @@ export default {
   output: {
     sourcemap: true,
     name: "app",
-    dir: "public/build",
+    format: "iife",
+    file: "public/build/main.js",
+		inlineDynamicImports: true,
   },
   plugins: [
     svelte({

--- a/svelte/svelte-motoko-starter/src/frontend/rollup.config.js
+++ b/svelte/svelte-motoko-starter/src/frontend/rollup.config.js
@@ -98,7 +98,9 @@ export default {
   output: {
     sourcemap: !production,
     name: "app",
-    dir: "public/build",
+    format: "iife",
+    file: "public/build/main.js",
+		inlineDynamicImports: true,
   },
   plugins: [
     svelte({


### PR DESCRIPTION
**Overview**
The current build `dir` strategy shows a blank page on local deployments. This strategy is more how it used to be, with the addition of the `inlineDynamicImports` flag