### PR TITLE
Use the transform to strip data instead of adding data

### DIFF
--- a/rust/exchange_rate/src/main.rs
+++ b/rust/exchange_rate/src/main.rs
@@ -254,6 +254,7 @@ fn keep_only_bucket_start_time_and_closing_price(body: &[u8]) -> Vec<u8> {
     res
 }
 
+/// Strips all data that is not needed from the original response.
 #[query]
 fn transform(raw: TransformArgs) -> HttpResponse {
     let mut res = HttpResponse {

--- a/rust/exchange_rate/src/main.rs
+++ b/rust/exchange_rate/src/main.rs
@@ -219,7 +219,7 @@ async fn get_rate(job: Timestamp) {
                 let str_body = String::from_utf8(response.body)
                     .expect("Remote service response is not UTF-8 encoded.");
                 for bucket in str_body.split("\n") {
-                    let ts_and_rate: Vec<String> = *bucket.split(" ").collect::<String>();
+                    let ts_and_rate: Vec<String> = *bucket.split_ascii_whitespace().collect::<String>();
                     assert!(ts_and_rate.len() == 2);
                     fetched.insert(ts_and_rate[0].parse::<u64>().unwrap(), ts_and_rate[1].parse::<f32>().unwrap());
                 }


### PR DESCRIPTION
The MR fixes a problem with the current dapp. The intent of the transform function is to strip data from the original response so less data is added to the block. The current implementation does the opposite - adding data.

Manually inspected the change given the frontend is now working.