### PR TITLE
Update Motoko threshold-ecdsa example

### DIFF
--- a/motoko/threshold-ecdsa/README.md
+++ b/motoko/threshold-ecdsa/README.md
@@ -54,10 +54,10 @@ found 0 vulnerabilities
 $ ./test.sh
 USAGE: ./test.sh <message to sign and verify>
 
-$ ./test.sh "Hello World!"
-sha256=d2a84f4b8b650937ec8f73cd8be2c74add5a911ba64df27458ed8229da804a26
-public_key=03ec3675640ad25bbc2b84e8d21c35ce8d885be68e0d7a0447705c39021e53705e
-signature=afacff613eb2af5ce7dd2db3564585a2f25122a04b08476f0df19371bd7681c068945ca56971d6fa896f137ffb4ea2e4add9eb3c67561fea4ea7a97c1186211d
+$ ./test.sh "Hello World"
+message=Hello World
+signature_hex=334fa100f68367aa2892d75b614c2915ae573895922cc5e6a196984d65df25753e756cb1ae4d406dcebccdd23151545b960c2a9c92f35e885ccdd188fd513bb0
+public_key_hex=02d98815741cae65d8bde06739e083584d3d83962ba623d8edd813656156f4c18a
 verified =  true
 ```
 

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/Hex.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/Hex.mo
@@ -1,0 +1,105 @@
+/**
+ * Module      : Hex.mo
+ * Description : Hexadecimal encoding and decoding routines.
+ * Copyright   : 2022 Dfinity
+ * License     : Apache 2.0>
+ */
+
+import Array "mo:base/Array";
+import Iter "mo:base/Iter";
+import Option "mo:base/Option";
+import Nat8 "mo:base/Nat8";
+import Char "mo:base/Char";
+import Result "mo:base/Result";
+import Text "mo:base/Text";
+import Prim "mo:⛔";
+
+module {
+
+  private type Result<Ok, Err> = Result.Result<Ok, Err>;
+
+  private let base : Nat8 = 0x10;
+
+  private let symbols = [
+    '0', '1', '2', '3', '4', '5', '6', '7',
+    '8', '9', 'A', 'B', 'C', 'D', 'E', 'F',
+  ];
+
+  /**
+   * Define a type to indicate that the decoder has failed.
+   */
+  public type DecodeError = {
+    #msg : Text;
+  };
+
+  /**
+   * Encode an array of unsigned 8-bit integers in hexadecimal format.
+   */
+  public func encode(array : [Nat8]) : Text {
+    let encoded = Array.foldLeft<Nat8, Text>(array, "", func (accum, w8) {
+      accum # encodeW8(w8);
+    });
+    // encode as lowercase
+    return Text.map(encoded, Prim.charToLower);
+  };
+
+  /**
+   * Encode an unsigned 8-bit integer in hexadecimal format.
+   */
+  private func encodeW8(w8 : Nat8) : Text {
+    let c1 = symbols[Nat8.toNat(w8 / base)];
+    let c2 = symbols[Nat8.toNat(w8 % base)];
+    Char.toText(c1) # Char.toText(c2);
+  };
+
+  /**
+   * Decode an array of unsigned 8-bit integers in hexadecimal format.
+   */
+  public func decode(text : Text) : Result<[Nat8], DecodeError> {
+    // Transform to uppercase for uniform decoding
+    let upper = Text.map(text, Prim.charToUpper);
+    let next = upper.chars().next;
+    func parse() : Result<Nat8, DecodeError> {
+      Option.get<Result<Nat8, DecodeError>>(
+        do ? {
+          let c1 = next()!;
+          let c2 = next()!;
+          Result.chain<Nat8, Nat8, DecodeError>(decodeW4(c1), func (x1) {
+            Result.chain<Nat8, Nat8, DecodeError>(decodeW4(c2), func (x2) {
+                #ok (x1 * base + x2);
+            })
+          })
+        },
+        #err (#msg "Not enough input!"),
+      );
+    };
+    var i = 0;
+    let n = upper.size() / 2 + upper.size() % 2;
+    let array = Array.init<Nat8>(n, 0);
+    while (i != n) {
+      switch (parse()) {
+        case (#ok w8) {
+          array[i] := w8;
+          i += 1;
+        };
+        case (#err err) {
+          return #err err;
+        };
+      };
+    };
+    #ok (Array.freeze<Nat8>(array));
+  };
+
+  /**
+   * Decode an unsigned 4-bit integer in hexadecimal format.
+   */
+  private func decodeW4(char : Char) : Result<Nat8, DecodeError> {
+    for (i in Iter.range(0, 15)) {
+      if (symbols[i] == char) {
+        return #ok (Nat8.fromNat(i));
+      };
+    };
+    let str = "Unexpected character: " # Char.toText(char);
+    #err (#msg str);
+  };
+};

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/SHA256.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/SHA256.mo
@@ -1,0 +1,200 @@
+/**
+ * Module      : SHA256.mo
+ * Description : Cryptographic hash function.
+ * Copyright   : 2020 DFINITY Stiftung
+ * License     : Apache 2.0 with LLVM Exception
+ * Maintainer  : Enzo Haussecker <enzo@dfinity.org>
+ * Stability   : Stable
+ */
+
+import Array "mo:base/Array";
+import Iter "mo:base/Iter";
+import Nat "mo:base/Nat";
+import Nat8 "mo:base/Nat8";
+import Nat32 "mo:base/Nat32";
+import Nat64 "mo:base/Nat64";
+
+module {
+
+  private let K : [Nat32] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+  ];
+
+  private let S : [Nat32] = [
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ];
+
+  // Calculate a SHA256 hash.
+  public func sha256(data : [Nat8]) : [Nat8] {
+    let digest = Digest();
+    digest.write(data);
+    return digest.sum();
+  };
+
+  public class Digest() {
+
+    private let s = Array.thaw<Nat32>(S);
+
+    private let x = Array.init<Nat8>(64, 0);
+
+    private var nx = 0;
+
+    private var len : Nat64 = 0;
+
+    public func reset() {
+      for (i in Iter.range(0, 7)) {
+        s[i] := S[i];
+      };
+      nx := 0;
+      len := 0;
+    };
+
+    public func write(data : [Nat8]) {
+      var p = data;
+      len +%= Nat64.fromIntWrap(p.size());
+      if (nx > 0) {
+        let n = Nat.min(p.size(), 64 - nx);
+        for (i in Iter.range(0, n - 1)) {
+          x[nx + i] := p[i];
+        };
+        nx += n;
+        if (nx == 64) {
+          let buf = Array.freeze<Nat8>(x);
+          block(buf);
+          nx := 0;
+        };
+        p := Array.tabulate<Nat8>(p.size() - n, func (i) {
+          return p[n + i];
+        });
+      };
+      if (p.size() >= 64) {
+        let n = Nat64.toNat(Nat64.fromIntWrap(p.size()) & (^ 63));
+        let buf = Array.tabulate<Nat8>(n, func (i) {
+          return p[i];
+        });
+        block(buf);
+        p := Array.tabulate<Nat8>(p.size() - n, func (i) {
+          return p[n + i];
+        });
+      };
+      if (p.size() > 0) {
+        for (i in Iter.range(0, p.size() - 1)) {
+          x[i] := p[i];
+        };
+        nx := p.size();
+      };
+    };
+
+    public func sum() : [Nat8] {
+      var m = 0;
+      var n = len;
+      var t = Nat64.toNat(n) % 64;
+      var buf : [var Nat8] = [var];
+      if (56 > t) {
+        m := 56 - t;
+      } else {
+        m := 120 - t;
+      };
+      n := n << 3;
+      buf := Array.init<Nat8>(m, 0);
+      if (m > 0) {
+        buf[0] := 0x80;
+      };
+      write(Array.freeze<Nat8>(buf));
+      buf := Array.init<Nat8>(8, 0);
+      for (i in Iter.range(0, 7)) {
+        let j : Nat64 = 56 -% 8 *% Nat64.fromIntWrap(i);
+        buf[i] := Nat8.fromIntWrap(Nat64.toNat(n >> j));
+      };
+      write(Array.freeze<Nat8>(buf));
+      let hash = Array.init<Nat8>(32, 0);
+      for (i in Iter.range(0, 7)) {
+        for (j in Iter.range(0, 3)) {
+          let k : Nat32 = 24 -% 8 *% Nat32.fromIntWrap(j);
+          hash[4 * i + j] := Nat8.fromIntWrap(Nat32.toNat(s[i] >> k));
+        };
+      };
+      return Array.freeze<Nat8>(hash);
+    };
+
+    private func block(data : [Nat8]) {
+      var p = data;
+      var w = Array.init<Nat32>(64, 0);
+      while (p.size() >= 64) {
+        var j = 0;
+        for (i in Iter.range(0, 15)) {
+          j := i * 4;
+          w[i] :=
+            Nat32.fromIntWrap(Nat8.toNat(p[j + 0])) << 24 |
+            Nat32.fromIntWrap(Nat8.toNat(p[j + 1])) << 16 |
+            Nat32.fromIntWrap(Nat8.toNat(p[j + 2])) << 08 |
+            Nat32.fromIntWrap(Nat8.toNat(p[j + 3])) << 00;
+        };
+        var v1 : Nat32 = 0;
+        var v2 : Nat32 = 0;
+        var t1 : Nat32 = 0;
+        var t2 : Nat32 = 0;
+        for (i in Iter.range(16, 63)) {
+          v1 := w[i - 02];
+          v2 := w[i - 15];
+          t1 := rot(v1, 17) ^ rot(v1, 19) ^ (v1 >> 10);
+          t2 := rot(v2, 07) ^ rot(v2, 18) ^ (v2 >> 03);
+          w[i] :=
+              t1 +% w[i - 07] +%
+              t2 +% w[i - 16];
+        };
+        var a = s[0];
+        var b = s[1];
+        var c = s[2];
+        var d = s[3];
+        var e = s[4];
+        var f = s[5];
+        var g = s[6];
+        var h = s[7];
+        for (i in Iter.range(0, 63)) {
+          t1 := rot(e, 06) ^ rot(e, 11) ^ rot(e, 25);
+          t1 +%= (e & f) ^ (^ e & g) +% h +% K[i] +% w[i];
+          t2 := rot(a, 02) ^ rot(a, 13) ^ rot(a, 22);
+          t2 +%= (a & b) ^ (a & c) ^ (b & c);
+          h := g;
+          g := f;
+          f := e;
+          e := d +% t1;
+          d := c;
+          c := b;
+          b := a;
+          a := t1 +% t2;
+        };
+        s[0] +%= a;
+        s[1] +%= b;
+        s[2] +%= c;
+        s[3] +%= d;
+        s[4] +%= e;
+        s[5] +%= f;
+        s[6] +%= g;
+        s[7] +%= h;
+        p := Array.tabulate<Nat8>(p.size() - 64, func (i) {
+          return p[i + 64];
+        });
+      };
+    };
+  };
+
+  private let rot : (Nat32, Nat32) -> Nat32 = Nat32.bitrotRight;
+};

--- a/motoko/threshold-ecdsa/test.sh
+++ b/motoko/threshold-ecdsa/test.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
 export LC_ALL=C
-function tohex() {
-    printf \ "$(echo "$2" | sed -e 's/^[^"]*"//' -e 's/".*//g' -e 's/%/%%/g' -e 's/\\/\\x/g')" | sed -e 's/^ //' | od -N$1 -An -tx1 | tr -d '[:space:]'
+function get_text_in_double_quotes() {
+    printf "$(echo "$1" | sed -e 's/^[^"]*"//' -e 's/".*//g')"
 }
 
 test -z "$1" && echo "USAGE: $0 <message to sign and verify>" && exit 1
 
-sha256=$(echo "$1" | shasum -a 256 | sed -e 's/ .*//g')
-echo sha256="$sha256"
+message="$1"
+echo message="$message"
 
-public_key=$(tohex 33 "$(dfx canister call ecdsa_example_motoko public_key | grep public_key)")
-echo public_key="$public_key"
+signature_hex=$(get_text_in_double_quotes "$(dfx canister call ecdsa_example_motoko sign "$message" | grep signature)")
+echo signature_hex="$signature_hex"
 
-args="(blob \"$(echo $sha256 | sed -e 's/\(..\)/\\\1/g')\")"
-signature=$(tohex 64 "$(dfx canister call ecdsa_example_motoko sign "$args" | grep signature)")
-echo signature=$signature
+public_key_hex=$(get_text_in_double_quotes "$(dfx canister call ecdsa_example_motoko public_key | grep public_key)")
+echo public_key_hex="$public_key_hex"
 
 node <<END
-let { ecdsaVerify } = require("secp256k1");
-let public_key = new Uint8Array(Buffer.from("${public_key}", "hex"));
-let hash = new Uint8Array(Buffer.from("${sha256}", "hex"));
-let signature = new Uint8Array(Buffer.from("${signature}", "hex"));
-let verified = ecdsaVerify(signature, hash, public_key);
+const secp256k1 = require("secp256k1");
+const crypto = require('crypto');
+let signature = new Uint8Array(Buffer.from("${signature_hex}", "hex"));
+let public_key = new Uint8Array(Buffer.from("${public_key_hex}", "hex"));
+let message_hash = new Uint8Array(crypto.createHash('sha256').update('${message}','utf-8').digest());
+let verified = secp256k1.ecdsaVerify(signature, message_hash, public_key);
 console.log("verified = ", verified)
 END


### PR DESCRIPTION
Update the Motoko threshold-ecdsa example as follows:

* Use hex encoding (instead of candid blobs) as input and output representation for all types except the message
* Take the message in sign in raw form and hash it directly in the canister (instead of outside)
* Adapt the test.sh-script accordingly
* Adapt the README accordingly