### PR TITLE
fix: Add metadata section to Rust basic bitcoin example

### DIFF
--- a/rust/basic_bitcoin/dfx.json
+++ b/rust/basic_bitcoin/dfx.json
@@ -5,8 +5,13 @@
       "type": "custom",
       "package": "basic_bitcoin",
       "candid": "src/basic_bitcoin/basic_bitcoin.did",
-      "wasm": "target/wasm32-unknown-unknown/release/basic_bitcoin.wasm.gz",
-      "build": "src/basic_bitcoin/build.sh"
+      "wasm": "target/wasm32-unknown-unknown/release/basic_bitcoin.wasm",
+      "build": "src/basic_bitcoin/build.sh",
+      "metadata": [
+        {
+          "name": "candid:service"
+        }
+      ]
     }
   },
   "defaults": {

--- a/rust/basic_bitcoin/src/basic_bitcoin/build.sh
+++ b/rust/basic_bitcoin/src/basic_bitcoin/build.sh
@@ -16,7 +16,5 @@ else
   cargo build --target $TARGET --release
 fi
 
-gzip -n -f "../../target/$TARGET/release/basic_bitcoin.wasm"
-
 popd
 


### PR DESCRIPTION
This PR adds a metadata section containing the candid service definition to the Rust basic bitcoin example. This is needed to ensure that we can retrieve the candid UI of the canister as described in the [documentation](https://internetcomputer.org/docs/current/samples/deploying-your-first-bitcoin-dapp).