### PR TITLE
fix: rust/nft-wallet tutorial does not work properly

### DIFF
--- a/rust/nft-wallet/deploy.sh
+++ b/rust/nft-wallet/deploy.sh
@@ -14,7 +14,7 @@ PATH="$PATH:$PWD/target/bin"
 if ! command -v icx-asset &> /dev/null ; then
     echo 'icx-asset is not installed; installing it locally. Install it globally to skip this step'
     echo 'This may take a while'
-    cargo install --root target icx-asset --version 0.12.1 2> /dev/null
+    cargo install --root target icx-asset --version 0.20.0 2> /dev/null
 fi
 identity=$(dfx identity whoami)
 pemfile="$HOME/.config/dfx/identity/${identity:-default}/identity.pem"

--- a/rust/nft-wallet/dfx.json
+++ b/rust/nft-wallet/dfx.json
@@ -8,8 +8,13 @@
     },
     "internet_identity": {
       "type": "custom",
-      "candid": "internet-identity/internet_identity.did",
-      "wasm": "internet-identity/internet_identity.wasm"
+      "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm",
+      "remote": {
+        "id": {
+          "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
+        }
+      }
     }
   }
 }

--- a/rust/nft-wallet/frontend/src/components/Authenticator.svelte
+++ b/rust/nft-wallet/frontend/src/components/Authenticator.svelte
@@ -7,7 +7,7 @@
     let _isAuthorized = nftAgent.isAuthorized();
     async function getCommand() {
         const principal = await nftAgent.getPrincipal();
-        return `dfx canister --no-wallet${nftAgent.isMainnet() ? ' --network ic' : ''} call '${nftAgent.getCanisterId()}' set_authorized '(principal "${principal}", true)'`;
+        return `dfx canister ${nftAgent.isMainnet() ? ' --network ic' : ''} call '${nftAgent.getCanisterId()}' set_authorized '(principal "${principal}", true)'`;
     }
     function retry() {
         _isAuthenticated = nftAgent.isAuthenticated();

--- a/rust/nft-wallet/rust-toolchain.toml
+++ b/rust/nft-wallet/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.58.1"
+channel = "1.68.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
**Overview**
Why do we need this feature? What are we trying to accomplish?

I request this PR to fix #484 issue. (This `rust/nft-wallet` is related to #214 )

- [x] fix: Http 413 Payload Too Large error, #267 
- [x] fix: failed to compile icx-asset v0.12.1 error
- [x] fix: the trait bound ic_agent::export::Principal: CandidType is not satisfied
- [x] fix: invalid flag --no-wallet

**Requirements**
What requirements are necessary to consider this problem solved?

```bash
cd rust/nft-wallet
sh start.sh

check <nftwallet canister id>.localhost:8000
```
<img width="1726" alt="Screen Shot 2023-03-26 at 5 23 14 PM" src="https://user-images.githubusercontent.com/37536298/227764017-bea0f1ad-80ba-4dae-b44e-7ca0de488ffb.png">


**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
