### PR TITLE
Stefan/context update

### DIFF
--- a/rust/exchange_rate/src/main.rs
+++ b/rust/exchange_rate/src/main.rs
@@ -246,11 +246,6 @@ fn keep_bucket_start_time_and_closing_price(body: &[u8], context: &Vec<u8>) -> V
     let rates_array: Vec<Vec<Value>> = serde_json::from_slice(body).unwrap();
     let bucket_start_time_index = context[0] as usize;
     let closing_price_index = context[1] as usize;
-    ic_cdk::api::print(format!(
-        "TEST: {} {}",
-        bucket_start_time_index,
-        closing_price_index
-    ));
     let mut res = vec![];
     for rate in rates_array {
         let bucket_start_time = rate[bucket_start_time_index].as_u64().expect("Couldn't parse the time.");

--- a/rust/exchange_rate/src/main.rs
+++ b/rust/exchange_rate/src/main.rs
@@ -5,6 +5,7 @@ use ic_cdk::api::management_canister::http_request::{
 };
 use ic_cdk::storage;
 use ic_cdk_macros::{self, heartbeat, post_upgrade, pre_upgrade, query, update};
+use serde::{Serialize, Deserialize};
 use serde_json::{self, Value};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
@@ -39,6 +40,11 @@ pub const DATA_POINTS_PER_API: u64 = 200;
 // Each field of this sub-arry takes less than 10 bytes. Then,
 // 10 (bytes per field) * 6 (fields per timestamp) * 200 (timestamps)
 pub const MAX_RESPONSE_BYTES: u64 = 10 * 6 * DATA_POINTS_PER_API;
+
+#[derive(Serialize, Deserialize)]
+struct Context {
+    indexes: Vec<u8>,
+}
 
 thread_local! {
     pub static FETCHED: RefCell<HashMap<Timestamp, Rate>>  = RefCell::new(HashMap::new());
@@ -206,12 +212,15 @@ async fn get_rate(job: Timestamp) {
 
     let bucket_start_time_index = 0;
     let closing_price_index = 4;
+    let context = Context {
+        indexes: vec![bucket_start_time_index, closing_price_index]
+    };
     let request = CanisterHttpRequestArgument {
         url: url,
         method: HttpMethod::GET,
         body: None,
         max_response_bytes: Some(MAX_RESPONSE_BYTES),
-        transform: Some(TransformContext::new(transform, vec![bucket_start_time_index, closing_price_index])),
+        transform: Some(TransformContext::new(transform, serde_json::to_vec(&context).unwrap())),
         headers: request_headers,
     };
     match http_request(request).await {
@@ -244,8 +253,10 @@ async fn get_rate(job: Timestamp) {
 fn keep_bucket_start_time_and_closing_price(body: &[u8], context: &Vec<u8>) -> Vec<u8> {
     //ic_cdk::api::print(format!("Got decoded result: {}", body));
     let rates_array: Vec<Vec<Value>> = serde_json::from_slice(body).unwrap();
-    let bucket_start_time_index = context[0] as usize;
-    let closing_price_index = context[1] as usize;
+
+    let context: Context = serde_json::from_slice(context).unwrap();
+    let bucket_start_time_index = context.indexes[0] as usize;
+    let closing_price_index = context.indexes[1] as usize;
     let mut res = vec![];
     for rate in rates_array {
         let bucket_start_time = rate[bucket_start_time_index].as_u64().expect("Couldn't parse the time.");
@@ -321,7 +332,11 @@ mod tests {
     ]
 ]
         ";
-        let res = keep_bucket_start_time_and_closing_price(body.as_bytes());
+        let context = Context {
+            indexes: vec![0, 4],
+        };
+        let serialized_context = serde_json::to_vec(&context).unwrap();
+        let res = keep_bucket_start_time_and_closing_price(body.as_bytes(), &serialized_context);
         let expected = "1652454300 9.51\n1652454240 9.52\n1652454180 9.56\n";
         assert_eq!(res, expected.as_bytes().to_vec());
     }

--- a/rust/exchange_rate/src/main.rs
+++ b/rust/exchange_rate/src/main.rs
@@ -250,7 +250,7 @@ async fn get_rate(job: Timestamp) {
     }
 }
 
-fn keep_bucket_start_time_and_closing_price(body: &[u8], context: &Vec<u8>) -> Vec<u8> {
+fn keep_bucket_start_time_and_closing_price(body: &[u8], context: &[u8]) -> Vec<u8> {
     //ic_cdk::api::print(format!("Got decoded result: {}", body));
     let rates_array: Vec<Vec<Value>> = serde_json::from_slice(body).unwrap();
 


### PR DESCRIPTION
**Overview**
The previous example was not making use of the `context` field in the transform function, which was not demonstrating the proper way of using it.

**Solution**
The `transform` function has now been updated to demonstrate correct use of the `context` field by providing the indices  of the data that must be saved (bucket start time and closing price index).