### PR TITLE
Fix and review outdated documentation URLs from smartcontracts.org

### DIFF
--- a/hosting/static-website/README.md
+++ b/hosting/static-website/README.md
@@ -22,7 +22,7 @@ The example project requires the following installed:
 - git
 - dfx 
 
-git can be installed from various package managers. DFX can be installed following the instructions [here](https://smartcontracts.org/docs/quickstart/local-quickstart.html#download-and-install).
+git can be installed from various package managers. DFX can be installed following the instructions [here](https://internetcomputer.org/docs/current/developer-docs/setup/deploy-locally).
 
 ### Install
 Install the example dapp project:

--- a/hosting/unity-webgl-template/README.md
+++ b/hosting/unity-webgl-template/README.md
@@ -14,7 +14,7 @@ The example project requires the following installed:
 - git
 - dfx 
 
-git can be installed from various package managers. DFX can be installed following the instructions [here](https://smartcontracts.org/docs/quickstart/local-quickstart.html#download-and-install).
+git can be installed from various package managers. DFX can be installed following the instructions [here](https://internetcomputer.org/docs/current/developer-docs/setup/deploy-locally).
 
 ### Install
 Install the example dapp project:

--- a/motoko/defi/src/defi_dapp/main.mo
+++ b/motoko/defi/src/defi_dapp/main.mo
@@ -449,7 +449,7 @@ shared(init_msg) actor class Dex() = this {
 
     // !!!! UPGRADES ONLY USED FOR DEVELOPMENT !!!!
     // Defi apps are not upgradable and should have an empty controller list
-    // https://smartcontracts.org/docs/developers-guide/concepts/trust-in-canisters.html
+    // https://internetcomputer.org/docs/current/concepts/trust-in-canisters
     // !!!! UPGRADES ONLY USED FOR DEVELOPMENT !!!!
     
     // Required since maps cannot be stable and need to be moved to stable memory

--- a/motoko/defi/src/frontend/src/App.svelte
+++ b/motoko/defi/src/frontend/src/App.svelte
@@ -21,7 +21,7 @@
     <Orders />
   </div>
   <div class="footer">
-    <a class="ic-badge-link" href="https://www.smartcontracts.org">
+    <a class="ic-badge-link" href="https://internetcomputer.org">
       <picture>
         <img src="images/ic-badge.png" alt="Powered by the Internet Computer" />
       </picture>

--- a/motoko/defi/src/frontend/src/components/Links.svelte
+++ b/motoko/defi/src/frontend/src/components/Links.svelte
@@ -1,4 +1,4 @@
 <p>
-  Visit the <a href="https://smartcontracts.org">Internet Computer SDK</a> to learn
+  Visit the <a href="https://internetcomputer.org">Internet Computer SDK</a> to learn
   how to build canister smart contracts.
 </p>

--- a/motoko/dip721-nft-container/README.md
+++ b/motoko/dip721-nft-container/README.md
@@ -21,7 +21,7 @@ When upgrading canister code, however, it is necessary to explicitly handle cani
 
  ### 2. Certified data.
 Generally, when a function only reads data, instead of modifying the state of the canister, it is
-beneficial to use a [query call instead of an update call](https://smartcontracts.org/docs/current/concepts/canisters-code.md#query-and-update-methods).
+beneficial to use a [query call instead of an update call](https://internetcomputer.org/docs/current/concepts/canisters-code.md#query-and-update-methods).
 But, since query calls do not go through consensus, [certified responses](https://internetcomputer.org/docs/current/developer-docs/security/general-security-best-practices)
 should be used wherever possible. The HTTP interface of the Rust implementation shows how certified data can be handled.
 
@@ -76,7 +76,7 @@ The NFT example canister keeps access control in these three levels very simple:
 - If a user is not authorized to call a certain function an error is returned.
 
 Burning an NFT is a special case. To burn an NFT means to either delete the NFT (not intended in DIP-721) or to set ownership to `null` (or a similar value).
-On the Internet Computer, this non-existing principal is called the [management canister](https://smartcontracts.org/docs/current/references/ic-interface-spec.md#the-ic-management-canister).
+On the Internet Computer, this non-existing principal is called the [management canister](https://internetcomputer.org/docs/current/references/ic-interface-spec.md#the-ic-management-canister).
 > "The IC management canister is just a facade; it does not actually exist as a canister (with isolated state, Wasm code, etc.)," and its address is `aaaaa-aa`.
 Using this management canister address, we can construct its principal and set the management canister as the owner of a burned NFT.
 

--- a/motoko/encrypted-notes-dapp/Dockerfile
+++ b/motoko/encrypted-notes-dapp/Dockerfile
@@ -13,7 +13,7 @@ RUN \
 # Uppercase [DFX_VERSION] is an environment variable for expected by the DFX installation script
 ARG dfx_version=0.9.3
 ENV DFX_VERSION=${dfx_version}
-RUN sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
+RUN sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
 ENV NODE_OPTIONS=--openssl-legacy-provider
 EXPOSE 8080 8000 3000 35729
 WORKDIR /canister

--- a/motoko/encrypted-notes-dapp/README.md
+++ b/motoko/encrypted-notes-dapp/README.md
@@ -1,6 +1,6 @@
 # Encrypted notes
 
-Encrypted notes is an example dapp for authoring and storing confidential information on the Internet Computer (IC) in the form of short pieces of text. Users can create and access their notes via any number of automatically synchronized devices authenticated via [Internet Identity (II)](https://smartcontracts.org/docs/ic-identity-guide/what-is-ic-identity.html). Notes are stored confidentially thanks to the end-to-end encryption performed by the dapp’s frontend.
+Encrypted notes is an example dapp for authoring and storing confidential information on the Internet Computer (IC) in the form of short pieces of text. Users can create and access their notes via any number of automatically synchronized devices authenticated via [Internet Identity (II)](https://wiki.internetcomputer.org/wiki/What_is_Internet_Identity). Notes are stored confidentially thanks to the end-to-end encryption performed by the dapp’s frontend.
 
 This project serves as a simple (but not too simple) example of a dapp, which uses Motoko and Rust as backend and Svelte as frontend.
 
@@ -317,7 +317,7 @@ export BUILD_ENV=rust
 ### Local deployment
 #### Option 1: Docker deployment
 
-**Note:** this option does not yet work on Apple M1; the combination of [DFX](https://smartcontracts.org/docs/developers-guide/cli-reference/dfx-parent.html) and Docker do not currently support the required architecture.
+**Note:** this option does not yet work on Apple M1; the combination of [DFX](https://internetcomputer.org/docs/current/references/cli-reference/dfx-parent) and Docker do not currently support the required architecture.
 
 1. Install and start Docker by following the [instructions](https://docs.docker.com/get-docker/).
 2. For **Motoko** build/deployment set environmental variable:
@@ -365,7 +365,7 @@ export BUILD_ENV=rust
    dfx start --clean
    ```
    ⚠️ If you see an error `Failed to set socket of tcp builder to 0.0.0.0:8000`, make sure that the port `8000` is not occupied, e.g., by the previously run Docker command (you might want to stop the Docker deamon whatsoever for this step).
-7. Install a local [Internet Identity (II)](https://smartcontracts.org/docs/ic-identity-guide/what-is-ic-identity.html) canister:
+7. Install a local [Internet Identity (II)](https://wiki.internetcomputer.org/wiki/What_is_Internet_Identity) canister:
    _Note_: If you have multiple dfx identities set up, ensure you are using the identity you intend to use with the `--identity` flag.
    1. To install and deploy a canister run:
       ```sh
@@ -404,7 +404,7 @@ export BUILD_ENV=rust
 &nbsp;
 
 ### Mainnet deployment
-**Note:** Prior to starting the mainnet deployment process, ensure you have your identities and wallets set up for controlling the canisters correctly. This guide assumes that this work has been done in advance. [More info here](https://smartcontracts.org/docs/developers-guide/cli-reference/dfx-identity.html).
+**Note:** Prior to starting the mainnet deployment process, ensure you have your identities and wallets set up for controlling the canisters correctly. This guide assumes that this work has been done in advance. [More info here](https://internetcomputer.org/docs/current/references/cli-reference/dfx-identity).
 
 1. Create the canisters:
    ```sh
@@ -419,7 +419,7 @@ export BUILD_ENV=rust
       ```
 
 3.  Deploy to mainnet:
-      _Note_: In the commands below, `--mode` could also be `reinstall` to reset the [stable memory](https://smartcontracts.org/docs/language-guide/upgrades.html).
+      _Note_: In the commands below, `--mode` could also be `reinstall` to reset the [stable memory](https://internetcomputer.org/docs/current/motoko/main/upgrades/).
 
       ```sh
       dfx canister --network ic install "encrypted_notes_${BUILD_ENV}" --mode=upgrade
@@ -451,7 +451,7 @@ Fig. 2. Basic single-device scenario for a user.
 2. Click the "Login" button. You will be redirected to the _Internet Identity_ canister (see Fig. 2(b)).
 
    1. If you already have an `anchor`, you may continue with it. Click "Authenticate", then verify your identity and finally click "Proceed", see Fig. 2(c).
-   2. If you do not have an anchor yet, you should [create one](https://smartcontracts.org/docs/ic-identity-guide/auth-how-to.html). Once an `anchor` is created, please follow 2.1.
+   2. If you do not have an anchor yet, you should [create one](https://internetcomputer.org/how-it-works/web-authentication-identity/). Once an `anchor` is created, please follow 2.1.
 
 3. Once logged in for the first time, your notes list should be empty. At this moment, your _Local Storage_ should be populated with additional variables (see Fig. 2(d)): **ic-identity**, **ic-delegation**. These variables are used for storing/retrieving notes from the backend canister. In addition, another two variables are generated in the _IndexedDB_: **PrivateKey**, **PublicKey**. These two variable are used for encrypting/decrypting the shared secret key.
 4. Create/edit/delete notes and observe changes in the resulting notes list (see Fig. 2(e)).

--- a/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
+++ b/motoko/encrypted-notes-dapp/src/encrypted_notes_motoko/main.mo
@@ -57,13 +57,13 @@ shared({ caller = initializer }) actor class() {
 
     // Define private fields
     // Stable actor fields are automatically retained across canister upgrades. 
-    // See https://smartcontracts.org/docs/language-guide/upgrades.html
+    // See https://internetcomputer.org/docs/current/motoko/main/upgrades/
 
     // Design choice: Use globally unique note identifiers for all users.
     //
     // The keyword `stable` makes this (scalar) variable keep its value across canister upgrades.
     //
-    // See https://smartcontracts.org/docs/developers-guide/working-with-canisters.html#upgrade-canister
+    // See https://internetcomputer.org/docs/current/developer-docs/setup/manage-canisters#upgrade-a-canister
     private stable var nextNoteId: Nat = 1;
     
     // Internal representation: store each user's notes in a separate List. 
@@ -156,7 +156,7 @@ shared({ caller = initializer }) actor class() {
     // Shared functions, i.e., those specified with [shared], are 
     // accessible to remote callers. 
     // The extra parameter [caller] is the caller's principal
-    // See https://smartcontracts.org/docs/language-guide/actors-async.html
+    // See https://internetcomputer.org/docs/current/motoko/main/actors-async
 
     // Add new note for this [caller]. Note: this function may be called only by 
     // those users that have at least one device registered via [register_device].
@@ -200,7 +200,7 @@ shared({ caller = initializer }) actor class() {
     // functions gets through consensus. Otherwise, this function could e.g. omit some notes 
     // if it got executed by a malicious node. (To make the dapp more efficient, one could 
     // use an approach in which both queries and updates are combined.)
-    // See https://smartcontracts.org/docs/developers-guide/concepts/canisters-code.html#query-update
+    // See https://internetcomputer.org/docs/current/concepts/canisters-code#query-and-update-methods
     //
     // Returns: 
     //      Future of array of EncryptedNote
@@ -498,7 +498,7 @@ shared({ caller = initializer }) actor class() {
     };
 
     // Below, we implement the upgrade hooks for our canister.
-    // See https://smartcontracts.org/docs/language-guide/upgrades.html
+    // See https://internetcomputer.org/docs/current/motoko/main/upgrades/
 
     // The work required before a canister upgrade begins.
     // See [nextNoteId], [stable_notesByUser], [stable_users]

--- a/motoko/encrypted-notes-dapp/src/encrypted_notes_rust/src/lib.rs
+++ b/motoko/encrypted-notes-dapp/src/encrypted_notes_rust/src/lib.rs
@@ -128,7 +128,7 @@ fn init() {}
 /// if it got executed by a malicious node. (To make the dapp more efficient, one could 
 /// use an approach in which both queries and updates are combined.)
 ///
-/// See https://smartcontracts.org/docs/developers-guide/concepts/canisters-code.html#query-update
+/// See https://internetcomputer.org/docs/current/concepts/canisters-code#query-and-update-methods
 
 /// Reflects the [caller]'s identity by returning (a future of) its principal. 
 /// Useful for debugging.

--- a/motoko/invoice-canister/candid/nns-cycles-minting.did
+++ b/motoko/invoice-canister/candid/nns-cycles-minting.did
@@ -79,7 +79,7 @@ type IcpXdrConversionRateResponse = record {
   data : IcpXdrConversionRate;
 
   // CBOR-serialized hash tree as specified in
-  // https://smartcontracts.org/docs/interface-spec/index.html#certification-encoding.
+  // https://internetcomputer.org/docs/current/references/ic-interface-spec#certification-encoding.
   // The hash tree is used for certification and hash the following structure:
   // ```
   // *
@@ -91,7 +91,7 @@ type IcpXdrConversionRateResponse = record {
   hash_tree : blob;
 
   // System certificate as specified in
-  // https://smartcontracts.org/docs/interface-spec/index.html#certification-encoding
+  // https://internetcomputer.org/docs/current/references/ic-interface-spec#certification-encoding
   certificate : blob;
 };
 

--- a/react-native-starter/src/App.tsx
+++ b/react-native-starter/src/App.tsx
@@ -129,7 +129,7 @@ const App = () => {
               title="Learn more"
               onPress={e => {
                 e.preventDefault();
-                Linking.openURL("https://smartcontracts.org/");
+                Linking.openURL("https://internetcomputer.org/");
               }}
             />
           </View>

--- a/rust/dip721-nft-container/README.md
+++ b/rust/dip721-nft-container/README.md
@@ -21,7 +21,7 @@ When upgrading canister code, however, it is necessary to explicitly handle cani
 
  ### 2. Certified data.
 Generally, when a function only reads data, instead of modifying the state of the canister, it is
-beneficial to use a [query call instead of an update call](https://smartcontracts.org/docs/current/concepts/canisters-code.md#query-and-update-methods).
+beneficial to use a [query call instead of an update call](https://internetcomputer.org/docs/current/concepts/canisters-code.md#query-and-update-methods).
 But, since query calls do not go through consensus, [certified responses](https://internetcomputer.org/docs/current/developer-docs/security/general-security-best-practices)
 should be used wherever possible. The HTTP interface of the Rust implementation shows how certified data can be handled.
 
@@ -76,7 +76,7 @@ The NFT example canister keeps access control in these three levels very simple:
 - If a user is not authorized to call a certain function an error is returned.
 
 Burning an NFT is a special case. To burn an NFT means to either delete the NFT (not intended in DIP-721) or to set ownership to `null` (or a similar value).
-On the Internet Computer, this non-existing principal is called the [management canister](https://smartcontracts.org/docs/current/references/ic-interface-spec.md#the-ic-management-canister).
+On the Internet Computer, this non-existing principal is called the [management canister](https://internetcomputer.org/docs/current/references/ic-interface-spec.md#the-ic-management-canister).
 > "The IC management canister is just a facade; it does not actually exist as a canister (with isolated state, Wasm code, etc.)," and its address is `aaaaa-aa`.
 Using this management canister address, we can construct its principal and set the management canister as the owner of a burned NFT.
 

--- a/rust/encrypted-notes-dapp/README.md
+++ b/rust/encrypted-notes-dapp/README.md
@@ -1,6 +1,6 @@
 # Encrypted notes
 
-Encrypted notes is an example dapp for authoring and storing confidential information on the Internet Computer (IC) in the form of short pieces of text. Users can create and access their notes via any number of automatically synchronized devices authenticated via [Internet Identity (II)](https://smartcontracts.org/docs/ic-identity-guide/what-is-ic-identity.html). Notes are stored confidentially thanks to the end-to-end encryption performed by the dapp’s frontend.
+Encrypted notes is an example dapp for authoring and storing confidential information on the Internet Computer (IC) in the form of short pieces of text. Users can create and access their notes via any number of automatically synchronized devices authenticated via [Internet Identity (II)](https://wiki.internetcomputer.org/wiki/What_is_Internet_Identity). Notes are stored confidentially thanks to the end-to-end encryption performed by the dapp’s frontend.
 
 This project serves as a simple (but not too simple) example of a dapp, which uses Motoko and Rust as backend and Svelte as frontend.
 
@@ -311,7 +311,7 @@ Fig. 2. Basic single-device scenario for a user.
 2. Click the "Login" button. You will be redirected to the _Internet Identity_ canister (see Fig. 2(b)).
 
    1. If you already have an `anchor`, you may continue with it. Click "Authenticate", then verify your identity and finally click "Proceed", see Fig. 2(c).
-   2. If you do not have an anchor yet, you should [create one](https://smartcontracts.org/docs/ic-identity-guide/auth-how-to.html). Once an `anchor` is created, please follow 2.1.
+   2. If you do not have an anchor yet, you should [create one](https://internetcomputer.org/how-it-works/web-authentication-identity/). Once an `anchor` is created, please follow 2.1.
 
 3. Once logged in for the first time, your notes list should be empty. At this moment, your _Local Storage_ should be populated with additional variables (see Fig. 2(d)): **ic-identity**, **ic-delegation**. These variables are used for storing/retrieving notes from the backend canister. In addition, another two variables are generated in the _IndexedDB_: **PrivateKey**, **PublicKey**. These two variable are used for encrypting/decrypting the shared secret key.
 4. Create/edit/delete notes and observe changes in the resulting notes list (see Fig. 2(e)).

--- a/rust/tokens_transfer/src/lib.rs
+++ b/rust/tokens_transfer/src/lib.rs
@@ -11,7 +11,7 @@ pub struct Conf {
     ledger_canister_id: Principal,
     // The subaccount of the account identifier that will be used to withdraw tokens and send them
     // to another account identifier. If set to None then the default subaccount will be used.
-    // See the [Ledger doc](https://smartcontracts.org/docs/integration/ledger-quick-start.html#_accounts).
+    // See the [Ledger doc](https://internetcomputer.org/docs/current/developer-docs/integrations/ledger/#accounts).
     subaccount: Option<Subaccount>,
     transaction_fee: Tokens
 }

--- a/svelte/svelte-motoko-starter/README.md
+++ b/svelte/svelte-motoko-starter/README.md
@@ -33,11 +33,11 @@ You will build and deploy the following _canisters_:
 
 ### What is Motoko?
 
-Motoko is a new language designed for the Internet Computer. Easy to learn for JavaScript and Solidity developers. Created by the Motoko team at the DFINITY Foundation, led by WebAssembly co-creator Andreas Rossberg. To learn more about the language, check out the [SDK](https://smartcontracts.org/docs/language-guide/motoko.html).
+Motoko is a new language designed for the Internet Computer. Easy to learn for JavaScript and Solidity developers. Created by the Motoko team at the DFINITY Foundation, led by WebAssembly co-creator Andreas Rossberg. To learn more about the language, check out the [SDK](https://internetcomputer.org/docs/current/motoko/main/motoko).
 
 ### What is Internet Identity?
 
-This starter template also includes integration with Internet Identity. Internet Identity is a new authentication framework similar to Github or Google login, but providing complete anonimity to the users. To learn more about Internet Identity check out the [documentation](https://smartcontracts.org/docs/ic-identity-guide/what-is-ic-identity.html).
+This starter template also includes integration with Internet Identity. Internet Identity is a new authentication framework similar to Github or Google login, but providing complete anonimity to the users. To learn more about Internet Identity check out the [documentation](https://wiki.internetcomputer.org/wiki/What_is_Internet_Identity).
 
 ## Security Considerations and Security Best Practices
 
@@ -65,7 +65,7 @@ npx degit dfinity/examples/svelte/svelte-motoko-starter svelte-motoko-starter
 Install `dfx` by running
 
 ```
-sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
+sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
 ```
 
 ### Rust
@@ -162,7 +162,7 @@ To deploy the backend canister to the local replica you have several options:
 
 `dfx deploy backend --mode reinstall` will reinstall the backend canister clearing all existing state.
 
-For more options and other commands see the [dfx CLI reference](https://smartcontracts.org/docs/developers-guide/cli-reference.html).
+For more options and other commands see the [dfx CLI reference](https://internetcomputer.org/docs/current/references/cli-reference).
 
 ### Svelte frontend
 
@@ -178,7 +178,7 @@ from the project root directory, it is not necessary to deploy it to the fronten
 
 To host the frontend and backend on the IC, you'll need to have some cycles available. Cycles pay for the execution of your app, and they are also needed to create canisters.
 
-You can get $20 worth of cycles for free from the Cycles Faucet, if you have a GitHub account. To claim them, follow [this guide](https://smartcontracts.org/docs/quickstart/cycles-faucet.html).
+You can get $20 worth of cycles for free from the Cycles Faucet, if you have a GitHub account. To claim them, follow [this guide](https://internetcomputer.org/docs/current/developer-docs/setup/cycles/cycles-faucet).
 
 You should have a canister running the cycles wallet on the IC at this point. The cycles wallet makes it easy to pay for canister creation.
 

--- a/svelte/svelte-motoko-starter/src/frontend/src/components/Links.svelte
+++ b/svelte/svelte-motoko-starter/src/frontend/src/components/Links.svelte
@@ -1,4 +1,4 @@
 <p>
-  Visit the <a href="https://smartcontracts.org">Internet Computer SDK</a> to learn
+  Visit the <a href="https://internetcomputer.org">Internet Computer SDK</a> to learn
   how to build canister smart contracts.
 </p>

--- a/svelte/svelte-starter/README.md
+++ b/svelte/svelte-starter/README.md
@@ -48,7 +48,7 @@ npx degit dfinity/examples/svelte-starter svelte-starter
 Install `dfx` by running
 
 ```
-sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
+sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
 ```
 
 ## Start the local replica
@@ -107,7 +107,7 @@ from the project root directory, it is not necessary to deploy it to the fronten
 
 To host the Svelte app on the IC, you'll need to have some cycles available. Cycles pay for the execution of your app, and they are also needed to create canisters.
 
-You can get $20 worth of cycles for free from the Cycles Faucet, if you have a GitHub account. To claim them, follow [this guide](https://smartcontracts.org/docs/quickstart/cycles-faucet.html).
+You can get $20 worth of cycles for free from the Cycles Faucet, if you have a GitHub account. To claim them, follow [this guide](https://internetcomputer.org/docs/current/developer-docs/setup/cycles/cycles-faucet).
 
 You should have a canister running the cycles wallet on the IC at this point. The cycles wallet makes it easy to pay for canister creation.
 

--- a/svelte/svelte-starter/src/frontend/src/components/Links.svelte
+++ b/svelte/svelte-starter/src/frontend/src/components/Links.svelte
@@ -1,4 +1,4 @@
 <p>
-  Visit the <a href="https://smartcontracts.org">Internet Computer SDK</a> to learn
+  Visit the <a href="https://internetcomputer.org">Internet Computer SDK</a> to learn
   how to build canister smart contracts.
 </p>

--- a/svelte/sveltekit-starter/README.md
+++ b/svelte/sveltekit-starter/README.md
@@ -43,7 +43,7 @@ npm ci
 Install `dfx` by running
 
 ```
-sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
+sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)"
 ```
 
 ### Start and stop the local replica


### PR DESCRIPTION
**Overview**
(second attempt after [pull/511](https://github.com/dfinity/examples/pull/511)) 
Fix broken URLs pointing to smartcontracts.org.
New documentation pages from https://internetcomputer.org/docs/current/ are now linked instead.
For each broken URL or unreachable page, an archive copy was checked to see which current document fits that link the best.

**Requirements**
Links to old documentation pages should be replaced with the most appropriate current document.

**Considered Solutions**
N/A

**Recommended Solution**
N/A

**Considerations**
N/A