### PR TITLE
Update Node version for darwin to latest v14 to match the one for Linux

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -11,7 +11,7 @@ bash install-brew.sh
 rm install-brew.sh
 
 # Install Node.
-version=14.15.4
+version=14.21.3
 curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$version.pkg"
 sudo installer -pkg node.pkg -store -target /
 rm node.pkg


### PR DESCRIPTION
The Node version installed in provision-darwin.sh is different from the one in provision-linux.sh. In provision-linux.sh the latest v14 is installed, which is v14.21.3.

This is to prevent errors [like the following](https://github.com/dfinity/examples/actions/runs/5490633307/jobs/10006316551?pr=561) when upgrading some node modules:
```
Error: Cannot find module 'node:process'
Require stack:
- /Users/runner/work/examples/examples/motoko/encrypted-notes-dapp/node_modules/rollup/dist/bin/rollup
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Module.<anonymous> (/Users/runner/work/examples/examples/motoko/encrypted-notes-dapp/node_modules/rollup/dist/bin/rollup:16:19)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/runner/work/examples/examples/motoko/encrypted-notes-dapp/node_modules/rollup/dist/bin/rollup'
  ]
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! encrypted-notes-dapp@0.2.0 build: `rollup -c --bundleConfigAsCjs`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the encrypted-notes-dapp@0.2.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/runner/.npm/_logs/2023-07-07T21_24_41_174Z-debug.log
```