### PR TITLE
Fix issue that deleting notes in Rust enc-notes-dapp-vetkd causes error

### DIFF
--- a/motoko/encrypted-notes-dapp-vetkd/src/encrypted_notes_motoko/main.mo
+++ b/motoko/encrypted-notes-dapp-vetkd/src/encrypted_notes_motoko/main.mo
@@ -73,7 +73,7 @@ shared({ caller = initializer }) actor class() {
     // Check that a note identifier is sane. This is needed since Motoko integers 
     // are infinite-precision. 
     // Note: avoid extraneous usage of async functions, hence [user_count]
-    private func is_id_sane(id: Int): Bool {
+    private func is_id_sane(id: Nat): Bool {
         0 <= id and id < MAX_NOTES_PER_USER * user_count()
     };
 
@@ -200,7 +200,7 @@ shared({ caller = initializer }) actor class() {
     // Traps: 
     //      [caller] is the anonymous identity
     //      [id] is unreasonable; see [is_id_sane]
-    public shared({ caller }) func delete_note(id: Int): async () {
+    public shared({ caller }) func delete_note(id: Nat): async () {
         assert not Principal.isAnonymous(caller);
         assert is_id_sane(id);
 

--- a/motoko/encrypted-notes-dapp-vetkd/src/encrypted_notes_rust/src/encrypted_notes_rust.did
+++ b/motoko/encrypted-notes-dapp-vetkd/src/encrypted_notes_rust/src/encrypted_notes_rust.did
@@ -1,7 +1,7 @@
 type anon_class_15_1 = 
  service {
    add_note: (text) -> ();
-   delete_note: (int) -> ();
+   delete_note: (nat) -> ();
    get_notes: () -> (vec EncryptedNote);
    update_note: (EncryptedNote) -> ();
    whoami: () -> (text);


### PR DESCRIPTION
Deletion of notes in the Rust-based encrypted-notes-dapp-vetkd causes a candid type conversion error (because candid `int` is not compatible with `u128`). This PR fixes this  issue by using the correct candid type, namely `nat` in the respective .did file.

Also updates the respective `main.mo` to use  the correct type (`Nat`), even though this didn't cause an actual error when using the demo.