### PR TITLE
test: configurable node version (darwin only)

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -11,10 +11,12 @@ bash install-brew.sh
 rm install-brew.sh
 
 # Install Node.
-version=14.15.4
+version=${NODE_VERSION:=14.15.4}
+echo "Using node version: $version"
 curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$version.pkg"
 sudo installer -pkg node.pkg -store -target /
 rm node.pkg
+node --version
 
 # Install DFINITY SDK.
 curl --location --output install-dfx.sh "https://internetcomputer.org/install.sh"

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -10,6 +10,7 @@ wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"
 sudo bash install-node.sh
 sudo apt-get install --yes nodejs
 rm install-node.sh
+node --version
 
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"


### PR DESCRIPTION
**Overview**
Reference: https://github.com/dfinity/examples/pull/604

The above PR needs to configure the node version (on darwin only) for one test, but unrelated workflows on that PR are failing.

This PR only adds version configurability (on darwin only), in part to see if CI workflows are broken without other changes.
