### PR TITLE
Improve documentation for encrypted notes examples

### DIFF
--- a/motoko/encrypted-notes-dapp-vetkd/README.md
+++ b/motoko/encrypted-notes-dapp-vetkd/README.md
@@ -15,9 +15,15 @@ Please also see the [README of the original encrypted-notes-dapp](../encrypted-n
 This example uses an [**insecure** implementation](../../rust/vetkd/src/system_api) of [the proposed vetKD system API](https://github.com/dfinity/interface-spec/pull/158) in a pre-compiled form via the [vetkd_system_api.wasm](./vetkd_system_api.wasm). **Do not use this in production or for sensitive data**! This example is solely provided **for demonstration purposes** to collect feedback on the mentioned vetKD system API.
 
 ## Manual local deployment
-1. For **Motoko** deployment set environmental variable:
+1. Choose which implementation to use by setting a respective environment variable. You can choose Motoko or Rust.
+   
+   For **Motoko** deployment use
    ```sh
    export BUILD_ENV=motoko
+   ```
+   For **Rust** deployment use
+   ```sh
+   export BUILD_ENV=rust
    ```
 2. To generate `$BUILD_ENV`-specific files (i.e., Motoko or Rust) run:
    ```sh

--- a/motoko/encrypted-notes-dapp/README.md
+++ b/motoko/encrypted-notes-dapp/README.md
@@ -121,11 +121,7 @@ Follow the steps below to deploy this sample project.
 cd examples/motoko/encrypted-notes-dapp
 ```
 
-or
-
-```
-cd examples/rust/encrypted-notes-dapp
-```
+This project folder contains the files for both Motoko and Rust development.
 
 ### Step 2: Set an environmental variable reflecting which backend canister you'll be using:
 For Motoko deployment run:


### PR DESCRIPTION
The README of the encrypted-notes-dapp-vetkd was misleading for the case where user wants to use the Rust deployment. In particular, users might think that if they want to use the Rust deployment, they simply don't have to call `export BUILD_ENV=motoko`, while in fact they have to call `export BUILD_ENV=rust` instead. This PR adapts the documentation to clarify that.

The PR also fixes wrong instructions for the encrypted-notes-dapp. The README wrongly says to navigate to `examples/rust/encrypted-notes-dapp`, but this folder only contains a README and no code (because the deployment is selected via an environment variable).