### PR TITLE
chore: Bump dfx

### DIFF
--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -18,7 +18,7 @@ rm node.pkg
 
 # Install DFINITY SDK.
 curl --location --output install-dfx.sh "https://internetcomputer.org/install.sh"
-DFX_VERSION=${DFX_VERSION:=0.12.0} bash install-dfx.sh < <(yes Y)
+DFX_VERSION=${DFX_VERSION:=0.15.3} bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 dfx cache install
 

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -13,7 +13,7 @@ rm install-node.sh
 
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-DFX_VERSION=${DFX_VERSION:=0.12.0} bash install-dfx.sh < <(yes Y)
+DFX_VERSION=${DFX_VERSION:=0.15.3} bash install-dfx.sh < <(yes Y)
 rm install-dfx.sh
 dfx cache install
 


### PR DESCRIPTION
`dfx` is severly outdated in this repo and seems to break on gzipped wasm modules.
