### PR TITLE
Use dfx with gzip support for defi examples

### DIFF
--- a/.github/workflows/motoko-defi-example.yml
+++ b/.github/workflows/motoko-defi-example.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           submodules: recursive
       - name: Provision Linux
+        env:
+          DFX_VERSION: 0.15.3
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Defi Linux
         run: |

--- a/.github/workflows/motoko-defi-example.yml
+++ b/.github/workflows/motoko-defi-example.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           submodules: recursive
       - name: Provision Darwin
+        env:
+          DFX_VERSION: 0.15.3
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Defi Darwin
         run: |

--- a/.github/workflows/motoko-defi-example.yml
+++ b/.github/workflows/motoko-defi-example.yml
@@ -1,4 +1,3 @@
-# known failure: https://dfinity.atlassian.net/browse/EM-1
 name: motoko-defi
 on:
   push:

--- a/.github/workflows/rust-defi-example.yml
+++ b/.github/workflows/rust-defi-example.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           submodules: recursive
       - name: Provision Darwin
+        env:
+          DFX_VERSION: 0.15.3
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Defi Darwin
         run: |

--- a/.github/workflows/rust-defi-example.yml
+++ b/.github/workflows/rust-defi-example.yml
@@ -1,4 +1,3 @@
-# Known failure: https://dfinity.atlassian.net/browse/EM-2
 name: rust-defi
 on:
   push:

--- a/.github/workflows/rust-defi-example.yml
+++ b/.github/workflows/rust-defi-example.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           submodules: recursive
       - name: Provision Linux
+        env:
+          DFX_VERSION: 0.15.3
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Defi Linux
         run: |


### PR DESCRIPTION
CI was broken for motoko and rust defi examples because the `dfx` version used could not handle the gzipped II canister.

