### PR TITLE
fix: use dfx with gzip support for rust-encrypted-notes example

### DIFF
--- a/.github/workflows/rust-encrypted-notes-example.yml
+++ b/.github/workflows/rust-encrypted-notes-example.yml
@@ -1,4 +1,3 @@
-# Known failure: https://dfinity.atlassian.net/browse/EM-3
 name: rust-encrypted-notes
 on:
   push:

--- a/.github/workflows/rust-encrypted-notes-example.yml
+++ b/.github/workflows/rust-encrypted-notes-example.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Provision Darwin
+        env:
+          DFX_VERSION: 0.14.2
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Encrypted Notes Darwin (unit tests)
         run: |
@@ -35,6 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Provision Linux
+        env:
+          DFX_VERSION: 0.14.2
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Encrypted Notes Linux (unit tests)
         run: |


### PR DESCRIPTION
Fix CI for rust-encrypted-notes example dapp. It was broken because the dfx version used could not handle the gzipped II canister.