### PR TITLE
Remove broken links & images

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository provides access to sample code, applications, and microservices that run on the Internet Computer platform.
 
 From this repository, you can download, clone, fork, or share sample projects.
-<!-- You will also be able to contribute your own project or suggest updates to published projects using the standard Git work flow. --> 
+
+You will also be able to contribute your own project or suggest updates to published projects using the standard Git work flow.
 
 Sample projects provide a way for you to experiment and collaborate with other developers.
 The projects and sample code are not, however, intended to be used as commercial applications and do not provide any explicit or implied support or warranty of any kind.

--- a/motoko/actor_reference/README.md
+++ b/motoko/actor_reference/README.md
@@ -62,7 +62,7 @@ The output will resemble the following:
 
 ## Resources
 
-- [Actors and sync data](https://internetcomputer.org/docs/current/motoko/main/actors-async.md).
+- [Actors and sync data](https://internetcomputer.org/docs/current/motoko/main/actors-async).
 - [Basic Motoko concepts and terms](https://internetcomputer.org/docs/current/motoko/main/basic-concepts.md).
 
 # Security Considerations and Security Best Practices

--- a/motoko/actor_reference/README.md
+++ b/motoko/actor_reference/README.md
@@ -29,7 +29,7 @@ This is a Motoko example that does not currently have a Rust variant.
 ## Prerequisites
 This example requires an installation of:
 
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 
 Begin by opening a terminal window.
 
@@ -62,8 +62,8 @@ The output will resemble the following:
 
 ## Resources
 
-- [Actors and sync data](../motoko/main/actors-async.md).
-- [Basic Motoko concepts and terms](../motoko/main/basic-concepts.md).
+- [Actors and sync data](https://internetcomputer.org/docs/current/motoko/main/actors-async.md).
+- [Basic Motoko concepts and terms](https://internetcomputer.org/docs/current/motoko/main/basic-concepts.md).
 
 # Security Considerations and Security Best Practices
 

--- a/motoko/actor_reference/README.md
+++ b/motoko/actor_reference/README.md
@@ -63,7 +63,7 @@ The output will resemble the following:
 ## Resources
 
 - [Actors and sync data](https://internetcomputer.org/docs/current/motoko/main/actors-async).
-- [Basic Motoko concepts and terms](https://internetcomputer.org/docs/current/motoko/main/basic-concepts.md).
+- [Basic Motoko concepts and terms](https://internetcomputer.org/docs/current/motoko/main/basic-concepts).
 
 # Security Considerations and Security Best Practices
 

--- a/motoko/basic_bitcoin/README.md
+++ b/motoko/basic_bitcoin/README.md
@@ -70,8 +70,6 @@ In the output above, to see the Candid Web UI for your bitcoin canister, you wou
 * `public_key`
 * `sign`
 
-![Candid web UI for bitcoin canister](../../_attachments/candid-web-ui-bitcoin-canister.webp)
-
 ## Step 2: Generating a Bitcoin address
 
 Bitcoin has different types of addresses (e.g. P2PKH, P2SH). Most of these
@@ -79,15 +77,11 @@ addresses can be generated from an ECDSA public key. The example code
 showcases how your canister can generate a [P2PKH address](https://en.bitcoin.it/wiki/Transaction#Pay-to-PubkeyHash) using the [ecdsa_public_key](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key) API.
 
 On the Candid UI of your canister, click the "Call" button under `get_p2pkh_address` to
-generate a P2PKH Bitcoin address:
-
-![Generating a P2PKH Bitcoin Address](../../_attachments/generate-ecdsa-key.png)
+generate a P2PKH Bitcoin address.
 
 Or, if you prefer the command line:
 
     dfx canister --network=ic call basic_bitcoin get_p2pkh_address
-
-
 
 * The Bitcoin address you see will be different from the one above, because the
   ECDSA public key your canister retrieves is unique.
@@ -104,12 +98,6 @@ to receive some bitcoin.
 
 Enter your address and click on "Send testnet Bitcoins". In the example below we will use bitcoin address `n31eU1K11m1r58aJMgTyxGonu7wSMoUYe7`, but you would use your own address. The canister will be receiving 0.011 test BTC on the Bitcoin Testnet.
 
-![Bitcoin Testnet Faucet](../../_attachments/bitcoin-testnet-faucet.png)
-
-You should see something similar to this:
-
-![Bitcoin Testnet Faucet](../../_attachments/bitcoin-testnet-faucet-received.png)
-
 
 Once the transaction has at least one confirmation, which can take a few minutes,
 you'll be able to see it in your canister's balance.
@@ -118,9 +106,7 @@ you'll be able to see it in your canister's balance.
 
 You can check a Bitcoin address's balance by using the `get_balance` endpoint on your canister.
 
-In the Candid UI, paste in your canister's address, and click on "Call":
-
-![Checking Bitcoin Balance](../../_attachments/bitcoin-received-funds.png)
+In the Candid UI, paste in your canister's address, and click on "Call".
 
 Alternatively, make the call using the command line. Be sure to replace `mheyfRsAQ1XrjtzjfU1cCH2B6G1KmNarNL` with your own generated P2PKH address:
 
@@ -134,8 +120,6 @@ You can send Bitcoin using the `send` endpoint on your canister.
 
 In the Candid UI, add a destination address and an amount to send. In the example
 below, we're sending 4'321 Satoshi (0.00004321 BTC) back to the testnet faucet.
-
-![Sending Bitcoin](../../_attachments/bitcoin-send-transaction.png)
 
 Via command line, the same call would look like this:
 

--- a/motoko/basic_dao/README.md
+++ b/motoko/basic_dao/README.md
@@ -23,7 +23,7 @@ For example, the following aspects are particularly relevant for this app:
 ### Prerequisites
 This example requires an installation of:
 
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 - [x] To run the test scripts, you need to download [ic-repl](https://github.com/chenyan2002/ic-repl/releases).
 
 Begin by opening a terminal window.

--- a/motoko/classes/README.md
+++ b/motoko/classes/README.md
@@ -27,7 +27,7 @@ This is a Motoko example that does not currently have a Rust variant.
 ## Prerequisites
 This example requires an installation of:
 
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 
 Begin by opening a terminal window.
 

--- a/motoko/defi/README.md
+++ b/motoko/defi/README.md
@@ -86,7 +86,7 @@ Compared to depositing funds, withdrawing funds is simpler. Since the exchange h
     `rustup target add wasm32-unknown-unknown`
 
 
-## Step 1: Download the project's GitHub repo and install the dependencies:
+### Step 1: Download the project's GitHub repo and install the dependencies:
 
 ```
 git clone --recurse-submodules --shallow-submodules https://github.com/dfinity/examples.git
@@ -105,43 +105,27 @@ http://127.0.0.1:4943?canisterId=by6od-j4aaa-aaaaa-qaadq-cai
 
 or you can regenerate the URL "http://127.0.0.1:4943?canisterId=$(dfx canister id frontend)". Open this URL in a web browser.
 
-## Step 2: To interact with the exchange, you can create a local Internet Identity by clicking the login button.
+### Step 2: To interact with the exchange, you can create a local Internet Identity by clicking the login button.
 
 This sample project uses a local test version of Internet Identity. Do not use your mainnet Internet Identity, and this testnet Internet Identity will not work on the mainnet. 
 
-![DEX II Login](../../_attachments/dex-ii.png)
+### Step 3: When prompted, select **Create Internet Identity**.
 
-## Step 3: When prompted, select **Create Internet Identity**.
+### Step 4: Then select **Create Passkey**.
 
-![II Step 1](../../_attachments/II1.png)
+### Step 5: Complete the CAPTCHA.
 
-## Step 4: Then select **Create Passkey**.
+### Step 6: Save the II number and click **I saved it, continue**.
 
-![II Step 2](../../_attachments/II2.png)
+### Step 7: You will be redirected to the exchange's frontend webpage.
 
-## Step 5: Complete the CAPTCHA.
+### Step 8: You can give yourself some tokens and ICP by running an initialization script with your II principal that you can copy from the frontend.
 
-![II Step 3](../../_attachments/II3.png)
-
-## Step 6: Save the II number and click **I saved it, continue**.
-
-![II Step 4](../../_attachments/II4.png)
-
-## Step 7: You will be redirected to the exchange's frontend webpage.
-
-![II Step 5](../../_attachments/II5.png)
-
-## Step 8: You can give yourself some tokens and ICP by running an initialization script with your II principal that you can copy from the frontend.
-
-![II Principal](../../_attachments/II-principal.png)
-
-## Step 9: Then run the following command:
+### Step 9: Then run the following command:
 
 `make init-local II_PRINCIPAL=<YOUR II PRINCIPAL>`
 
-## Step 10: Refresh the web browser to verify that your tokens were deposited. 
-
-![II Deposit](../../_attachments/II-deposit.png)
+### Step 10: Refresh the web browser to verify that your tokens were deposited. 
 
 To trade tokens with yourself, you can open a second incognito browser window.
 

--- a/motoko/echo/README.md
+++ b/motoko/echo/README.md
@@ -13,7 +13,7 @@ This is a Motoko example that does not currently have a Rust variant.
 ## Prerequisites
 This example requires an installation of:
 
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 
 Begin by opening a terminal window.
 

--- a/motoko/encrypted-notes-dapp/README.md
+++ b/motoko/encrypted-notes-dapp/README.md
@@ -111,7 +111,7 @@ Once authenticated with II:
 Follow the steps below to deploy this sample project.
 
 ## Prerequisites
-- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index).
 - [x] Download and install [Docker](https://docs.docker.com/get-docker/) if using the Docker option. 
 - [x] Download the GitHub repo containing this project's files: https://github.com/dfinity/examples/tree/master/motoko/encrypted-notes-dapp. (If using Rust, use the /master/rust/encrypted-notes-dapp folder.)
 

--- a/motoko/encrypted-notes-dapp/README.md
+++ b/motoko/encrypted-notes-dapp/README.md
@@ -111,7 +111,7 @@ Once authenticated with II:
 Follow the steps below to deploy this sample project.
 
 ## Prerequisites
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
 - [x] Download and install [Docker](https://docs.docker.com/get-docker/) if using the Docker option. 
 - [x] Download the GitHub repo containing this project's files: https://github.com/dfinity/examples/tree/master/motoko/encrypted-notes-dapp. (If using Rust, use the /master/rust/encrypted-notes-dapp folder.)
 

--- a/motoko/hello/README.md
+++ b/motoko/hello/README.md
@@ -23,8 +23,6 @@ Canister `hello`, whether implemented in Motoko or Rust, presents the same Candi
 
 The frontend canister, `hello_assets`, displays an HTML page with a text box for the argument and a button for calling the function greet with that argument. The result of the call is displayed in a message box.
 
-![hello frontend](_attachments/hello.png)
-
 The frontend canister is a generic canister provided by `dfx` but the assets it serves to browsers are determined by the dfx project settings and project files.
 
 The frontend canister and its assets are identical for both projects.

--- a/motoko/http_counter/README.md
+++ b/motoko/http_counter/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The example demonstrates a counter dapp and an HTTP interface. It is essentially an iteration on the [counter canister](../Counter/README.md) which adds native HTTP interfaces.
+The example demonstrates a counter dapp and an HTTP interface. It is essentially an iteration on the counter canister which adds native HTTP interfaces.
 
 This sample dapp provides an interface that exposes the following methods:
 

--- a/motoko/internet_identity_integration/README.md
+++ b/motoko/internet_identity_integration/README.md
@@ -373,8 +373,6 @@ URLs:
 
 Open the `greet_frontend` URL in a web browser. 
 
-![II Sample](../../_attachments/ii-sample.png)
-
 You should be able to observe the following behavior:
 
 - If you press the "Click me!" button without logging in first, you should be greeted by the anonymous principal (2vxsx-fae).

--- a/motoko/invoice-canister/docs/bounty-task-checklist.md
+++ b/motoko/invoice-canister/docs/bounty-task-checklist.md
@@ -10,7 +10,7 @@ All the referenced line numbers should be correct to within one or two lines (so
 
 In addition to these bounty tasks, two other non-trivial changes include using the literal of a generated ULID for an invoice's id (instead of the invoice creation counter value). ULID was chosen for its timestamp encoding and human copy and paste friendly dash-lacking format; there's an example of decoding the timestamp from an invoice's ulid in the frontend of the `motoko-seller-client` example. Also note a monotonic invoice creation counter is still used and available if needed for an invoice record. The other change was upgrading from the volatile hashmap to the stable compatible trie to remove the need for using the pre and postupgrade system hooks. 
 
-In addition to this, there's also a [Testing Glossary](./docs/TestingGlossay.md) showing an example output of all the unit and E2E tests, as well as an example of the [startup script's output](./docs/clean-startup-console-output.md) showing a shell running the `clean-startup-mjs` script with the `deployForTesting` flag.
+In addition to this, there's also a [Testing Glossary](TestingGlossay.md) showing an example output of all the unit and E2E tests, as well as an example of the [startup script's output](clean-startup-console-output.md) showing a shell running the `clean-startup-mjs` script with the `deployForTesting` flag.
 
 ---
 

--- a/motoko/life/README.md
+++ b/motoko/life/README.md
@@ -48,10 +48,6 @@ echo "http://127.0.0.1:4943/?canisterId=$(dfx canister id life_assets)"
 
 ### Step 3: Open the frontend in your browser by clicking on the link returned in the output of the previous command.
 
-You should see a frontend like this: 
-
-![Game of Life](../../_attachments/game-of-life.png)
-
 Click the button **Step**. The grid will advance to the next generation of the Game of Life.
 
 Click the button **Run**. The grid will (slowly) animate sequential generations.
@@ -123,8 +119,6 @@ dfx deploy
 Then, return to the same browser tab and refresh (or re-load the link). Note the current grid state is unchanged (thus preserved), apart from changing display character in grid.
 Click button **Run**, then click button **Pause** when bored. Open **Details** and click **View State**. Admire the #v1 state on display.
 
-![Game of life v1](../../_attachments/game-of-life2.png)
-
 After first upgrading from v0 the state will be random, as on deploying v0. This is because the v0 code did not declare its state variable stable, forcing the upgraded actor to re-initialize state as no previous value for state is available in the retired actor.
 
 However, if you re-deploy the v1 project a second time, perhaps after making a minor edit, you'll see the last state of the grid, before deployment, preserved across the deployment, in a state-preserving upgrade. The random initializer for state is skipped and state just assumes the value it had before the upgrade.
@@ -142,8 +136,6 @@ dfx deploy
 Return to the same browser tab. Refresh the tab. Note the current grid state is unchanged (thus preserved), apart from changing the display character in the textual display of the grid.
 
 Click button **Run**, then click button **Pause** when bored. Open **Details** and click **View State**. Admire the #v2 state on display.
-
-![Game of life v2](../../_attachments/game-of-life3.png)
 
 ## Security considerations and security best practices
 

--- a/motoko/phone-book/README.md
+++ b/motoko/phone-book/README.md
@@ -43,13 +43,10 @@ dfx deploy
 
 ### Step 4: Take note of the URL at which the phone book is accessible.
 
+```
 echo "http://127.0.0.1:4943/?canisterId=$(dfx canister id www)"
+```
 
 ### Step 5: Open the aforementioned URL in your web browser.
 
-You will see an interface that you can interact with to store phone book entries:
-
-![Phonebook](./_attachments/phonebook.png)
-
-
-
+You will see an interface that you can interact with to store phone book entries.

--- a/motoko/random_maze/README.md
+++ b/motoko/random_maze/README.md
@@ -55,12 +55,7 @@ dfx deploy
 echo "http://127.0.0.1:4943/?canisterId=$(dfx canister id random_maze_assets)"
 ```
 
-![Maze interface](../../_attachments/maze1.png)
-
-Enter a size for the maze, then select **Generate!**. The maze will be displayed below.
-
-![Random maze](../../_attachments/maze2.png)
-
+Enter a size for the maze, then select **Generate!**. The maze will be displayed.
 
 ## Security considerations and security best practices
 

--- a/motoko/superheroes/README.md
+++ b/motoko/superheroes/README.md
@@ -42,9 +42,7 @@ echo "http://127.0.0.1:4943/?canisterId=$(dfx canister id www)"
 ```
 
 ### Step 5: Open the aforementioned URL in your web browser.
-You will see the following interface that you can interact with:
-
-![Superheros interface](../../_attachments/superheros.png)
+You will see the following interface that you can interact with.
 
 ## Security considerations and security best practices
 

--- a/motoko/threshold-ecdsa/README.md
+++ b/motoko/threshold-ecdsa/README.md
@@ -49,9 +49,7 @@ URLs:
     ecdsa_example_motoko: http://127.0.0.1:4943/?canisterId=t6rzw-2iaaa-aaaaa-aaama-cai&id=st75y-vaaaa-aaaaa-aaalq-cai
 ```
 
-If you open the URL in a web browser, you will see a web UI that shows the public methods the canister exposes. Since the canister exposes `public_key` and `sign` methods, those are rendered in the web UI:
-
- ![Candid UI](../../_attachments/tecdsa-candid-ui.png)
+If you open the URL in a web browser, you will see a web UI that shows the public methods the canister exposes. Since the canister exposes `public_key` and `sign` methods, those are rendered in the web UI.
 
 
 ## Step 2: Deploying the canister on IC mainnet
@@ -124,9 +122,7 @@ In example above, `ecdsa_example_motoko` has the URL https://a3gq9-oaaaa-aaaab-q
 
 ### Using the Candid web UI
 
-If you deployed your canister locally or to mainnet, you should have a URL to the Candid web UI where you can access the public methods. We can call the `public-key` method:
-
-![Public key method](../../_attachments/tecdsa-candid-public-key.png)
+If you deployed your canister locally or to mainnet, you should have a URL to the Candid web UI where you can access the public methods. We can call the `public-key` method.
 
 In the example below, the method returns `03c22bef676644dba524d4a24132ea8463221a55540a27fc86d690fda8e688e31a` as the public key.
 

--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -71,8 +71,6 @@ In the output above, to see the Candid Web UI for your bitcoin canister, you wou
 * `public_key`
 * `sign`
 
-![Candid web UI for bitcoin canister](../../_attachments/candid-web-ui-bitcoin-canister.webp)
-
 ## Step 2: Generating a Bitcoin address
 
 Bitcoin has different types of addresses (e.g. P2PKH, P2SH). Most of these
@@ -80,15 +78,11 @@ addresses can be generated from an ECDSA public key. The example code
 showcases how your canister can generate a [P2PKH address](https://en.bitcoin.it/wiki/Transaction#Pay-to-PubkeyHash) using the [ecdsa_public_key](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key) API.
 
 On the Candid UI of your canister, click the "Call" button under `get_p2pkh_address` to
-generate a P2PKH Bitcoin address:
-
-![Generating a P2PKH Bitcoin Address](../../_attachments/generate-ecdsa-key.png)
+generate a P2PKH Bitcoin address.
 
 Or, if you prefer the command line:
 
     dfx canister --network=ic call basic_bitcoin get_p2pkh_address
-
-
 
 * The Bitcoin address you see will be different from the one above, because the
   ECDSA public key your canister retrieves is unique.
@@ -105,13 +99,6 @@ to receive some bitcoin.
 
 Enter your address and click on "Send testnet Bitcoins". In the example below we will use bitcoin address `n31eU1K11m1r58aJMgTyxGonu7wSMoUYe7`, but you would use your own address. The canister will be receiving 0.011 test BTC on the Bitcoin Testnet.
 
-![Bitcoin Testnet Faucet](../../_attachments/bitcoin-testnet-faucet.png)
-
-You should see something similar to this:
-
-![Bitcoin Testnet Faucet](../../_attachments/bitcoin-testnet-faucet-received.png)
-
-
 Once the transaction has at least one confirmation, which can take a few minutes,
 you'll be able to see it in your canister's balance.
 
@@ -120,8 +107,6 @@ you'll be able to see it in your canister's balance.
 You can check a Bitcoin address's balance by using the `get_balance` endpoint on your canister.
 
 In the Candid UI, paste in your canister's address, and click on "Call":
-
-![Checking Bitcoin Balance](../../_attachments/bitcoin-received-funds.png)
 
 Alternatively, make the call using the command line. Be sure to replace `mheyfRsAQ1XrjtzjfU1cCH2B6G1KmNarNL` with your own generated P2PKH address:
 
@@ -135,8 +120,6 @@ You can send Bitcoin using the `send` endpoint on your canister.
 
 In the Candid UI, add a destination address and an amount to send. In the example
 below, we're sending 4'321 Satoshi (0.00004321 BTC) back to the testnet faucet.
-
-![Sending Bitcoin](../../_attachments/bitcoin-send-transaction.png)
 
 Via command line, the same call would look like this:
 

--- a/rust/basic_dao/README.md
+++ b/rust/basic_dao/README.md
@@ -25,7 +25,7 @@ This example requires an installation of:
 
 - [x] The Rust toolchain (e.g. cargo).
 - [x] [didc.](https://github.com/dfinity/candid/tree/master/tools/didc)
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 
 
 Begin by opening a terminal window.

--- a/rust/counter/README.md
+++ b/rust/counter/README.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 This example requires an installation of:
 
-- [x] Install the [IC SDK](../developer-docs/setup/install/index.mdx).
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 - [x] Download the following project files from GitHub: https://github.com/dfinity/examples/
 
 Begin by opening a terminal window.

--- a/rust/encrypted-notes-dapp/README.md
+++ b/rust/encrypted-notes-dapp/README.md
@@ -51,8 +51,6 @@ To support multiple devices per user, IC Vault employs a device manager; a canis
 
 For further details and user stories, please refer to the [README file](https://github.com/dfinity/examples/blob/master/motoko/encrypted-notes-dapp/README.md).
 
-![High-level architecture overview diagram of the Encrypted Notes dapp](../../_attachments/encrypted-notes-arch.png)
-
 ## Note management
 
 -   Users are linked to II in the frontend, getting the user a principal that can be used for calling API queries and updates.

--- a/rust/hello/README.md
+++ b/rust/hello/README.md
@@ -23,8 +23,6 @@ Canister `hello`, whether implemented in Motoko or Rust, presents the same Candi
 
 The frontend canister, `hello_assets`, displays an HTML page with a text box for the argument and a button for calling the function greet with that argument. The result of the call is displayed in a message box.
 
-![hello frontend](_attachments/hello.png)
-
 The frontend canister is a generic canister provided by `dfx` but the assets it serves to browsers are determined by the dfx project settings and project files.
 
 The frontend canister and its assets are identical for both projects.

--- a/rust/threshold-ecdsa/README.md
+++ b/rust/threshold-ecdsa/README.md
@@ -48,10 +48,7 @@ URLs:
     ecdsa_example_motoko: http://127.0.0.1:4943/?canisterId=t6rzw-2iaaa-aaaaa-aaama-cai&id=st75y-vaaaa-aaaaa-aaalq-cai
 ```
 
-If you open the URL in a web browser, you will see a web UI that shows the public methods the canister exposes. Since the canister exposes `public_key` and `sign` methods, those are rendered in the web UI:
-
- ![Candid UI](../../_attachments/tecdsa-candid-ui.png)
-
+If you open the URL in a web browser, you will see a web UI that shows the public methods the canister exposes. Since the canister exposes `public_key` and `sign` methods, those are rendered in the web UI.
 
 ## Step 2: Deploying the canister on IC mainnet
 
@@ -123,9 +120,7 @@ In example above, `ecdsa_example_motoko` has the URL https://a3gq9-oaaaa-aaaab-q
 
 ### Using the Candid web UI
 
-If you deployed your canister locally or to mainnet, you should have a URL to the Candid web UI where you can access the public methods. We can call the `public-key` method:
-
-![Public key method](../../_attachments/tecdsa-candid-public-key.png)
+If you deployed your canister locally or to mainnet, you should have a URL to the Candid web UI where you can access the public methods. We can call the `public-key` method.
 
 In the example below, the method returns `03c22bef676644dba524d4a24132ea8463221a55540a27fc86d690fda8e688e31a` as the public key.
 

--- a/svelte/README.md
+++ b/svelte/README.md
@@ -1,7 +1,3 @@
-<p align="left" >
-  <img width="240"  src="./sveltekit-starter/src/frontend/static/logo.png">
-</p>
-
 # Svelte Dapp templates
 
 This subdirectory provides access to Svelte dapp samples that run on the Internet Computer platform.

--- a/svelte/svelte-motoko-starter/README.md
+++ b/svelte/svelte-motoko-starter/README.md
@@ -106,8 +106,6 @@ git submodule update --init --recursive
 
 When the repository is cloned, switch to its directory and install it:
 
-(If you're running this on an M1 Mac, make sure you follow [these steps]())
-
 ```
 cd internet-identity
 npm install

--- a/svelte/svelte-starter/README.md
+++ b/svelte/svelte-starter/README.md
@@ -1,7 +1,3 @@
-<p align="left" >
-  <img width="240"  src="assets/logo.png">
-</p>
-
 # Svelte Dapp template
 
 This repository is meant to give [Svelte](https://svelte.dev/) developers an easy on-ramp to get started with developing decentralized applications (Dapps in short) for the Internet Computer blockchain. Dapps, also known as smart contracts are specialized software that run on a blockchain.

--- a/svelte/sveltekit-starter/README.md
+++ b/svelte/sveltekit-starter/README.md
@@ -1,7 +1,3 @@
-<p align="left" >
-  <img width="240"  src="./src/frontend/static/logo.png">
-</p>
-
 # SvelteKit Dapp template
 
 This repository is meant to give [SvelteKit](https://kit.svelte.dev/) developers an easy on-ramp to get started with developing decentralized applications (Dapps in short) for the Internet Computer blockchain.


### PR DESCRIPTION
Removes broken links and images from README files so that they render as submodules on the dev docs correctly.