### PR TITLE
chore: use dfinity/setup-dfx github action

### DIFF
--- a/.github/workflows/hosting-photo-storage-example.yml
+++ b/.github/workflows/hosting-photo-storage-example.yml
@@ -16,7 +16,7 @@ jobs:
   hosting-photo-storage-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Photo Storage Darwin
@@ -32,7 +32,7 @@ jobs:
   hosting-photo-storage-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Hosting Photo Storage Linux

--- a/.github/workflows/hosting-photo-storage-example.yml
+++ b/.github/workflows/hosting-photo-storage-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Photo Storage Darwin
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Hosting Photo Storage Linux

--- a/.github/workflows/hosting-static-website-example.yaml
+++ b/.github/workflows/hosting-static-website-example.yaml
@@ -16,7 +16,7 @@ jobs:
   hosting-unity-static-website-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Static Website Darwin
@@ -28,7 +28,7 @@ jobs:
   hosting-static-website-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Hosting Static Website Linux

--- a/.github/workflows/hosting-static-website-example.yaml
+++ b/.github/workflows/hosting-static-website-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Static Website Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Hosting Static Website Linux

--- a/.github/workflows/hosting-unity-webgl-example.yaml
+++ b/.github/workflows/hosting-unity-webgl-example.yaml
@@ -16,7 +16,7 @@ jobs:
   hosting-unity-webgl-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Unity Webgl Darwin
@@ -28,7 +28,7 @@ jobs:
   hosting-unity-webgl-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Hosting Unity Webgl Linux

--- a/.github/workflows/hosting-unity-webgl-example.yaml
+++ b/.github/workflows/hosting-unity-webgl-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Hosting Unity Webgl Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Hosting Unity Webgl Linux

--- a/.github/workflows/motoko-actor_reference-example.yaml
+++ b/.github/workflows/motoko-actor_reference-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-actor-reference-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Actor Reference Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-actor-reference-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Actor Reference Linux

--- a/.github/workflows/motoko-actor_reference-example.yaml
+++ b/.github/workflows/motoko-actor_reference-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Actor Reference Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Actor Reference Linux

--- a/.github/workflows/motoko-basic-bitcoin.yaml
+++ b/.github/workflows/motoko-basic-bitcoin.yaml
@@ -16,7 +16,7 @@ jobs:
   rust-basic-bitcoin-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -30,7 +30,7 @@ jobs:
   rust-basic-bitcoin-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/motoko-basic-bitcoin.yaml
+++ b/.github/workflows/motoko-basic-bitcoin.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Basic Bitcoin Darwin
@@ -33,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Basic Bitcoin Linux

--- a/.github/workflows/motoko-basic-dao-example.yml
+++ b/.github/workflows/motoko-basic-dao-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko DAO Darwin
@@ -34,6 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko DAO Linux

--- a/.github/workflows/motoko-basic-dao-example.yml
+++ b/.github/workflows/motoko-basic-dao-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-dao-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko DAO Darwin
@@ -33,7 +33,7 @@ jobs:
   motoko-hello-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko DAO Linux

--- a/.github/workflows/motoko-calc-example.yaml
+++ b/.github/workflows/motoko-calc-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Calc Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Calc Linux

--- a/.github/workflows/motoko-calc-example.yaml
+++ b/.github/workflows/motoko-calc-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Calc Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Calc Linux

--- a/.github/workflows/motoko-cert_var-example.yaml
+++ b/.github/workflows/motoko-cert_var-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-cert-var-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Certified Variable Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-cert-var-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Certified Variable Linux

--- a/.github/workflows/motoko-cert_var-example.yaml
+++ b/.github/workflows/motoko-cert_var-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Certified Variable Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Certified Variable Linux

--- a/.github/workflows/motoko-classes-example.yaml
+++ b/.github/workflows/motoko-classes-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Classes Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Classes Linux

--- a/.github/workflows/motoko-classes-example.yaml
+++ b/.github/workflows/motoko-classes-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-classes-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Classes Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-classes-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Classes Linux

--- a/.github/workflows/motoko-composite-query-example.yaml
+++ b/.github/workflows/motoko-composite-query-example.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Composite Query Darwin
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Composite Query Linux

--- a/.github/workflows/motoko-composite-query-example.yaml
+++ b/.github/workflows/motoko-composite-query-example.yaml
@@ -17,7 +17,7 @@ jobs:
   motoko-composite-query-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Composite Query Darwin
@@ -29,7 +29,7 @@ jobs:
   motoko-composite-query-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Composite Query Linux

--- a/.github/workflows/motoko-counter-example.yaml
+++ b/.github/workflows/motoko-counter-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Counter Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Counter Linux

--- a/.github/workflows/motoko-counter-example.yaml
+++ b/.github/workflows/motoko-counter-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Counter Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Counter Linux

--- a/.github/workflows/motoko-defi-example.yml
+++ b/.github/workflows/motoko-defi-example.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Defi Darwin
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Defi Linux

--- a/.github/workflows/motoko-defi-example.yml
+++ b/.github/workflows/motoko-defi-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-defi-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -32,7 +32,7 @@ jobs:
   motoko-defi-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/motoko-dip721-example.yml
+++ b/.github/workflows/motoko-dip721-example.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko DIP-721 Darwin
@@ -32,6 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko DIP-721 Linux

--- a/.github/workflows/motoko-dip721-example.yml
+++ b/.github/workflows/motoko-dip721-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-dip721-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -29,7 +29,7 @@ jobs:
   motoko-dip721-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/motoko-echo-example.yaml
+++ b/.github/workflows/motoko-echo-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Echo Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Echo Linux

--- a/.github/workflows/motoko-echo-example.yaml
+++ b/.github/workflows/motoko-echo-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Echo Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Echo Linux

--- a/.github/workflows/motoko-encrypted-notes-example.yml
+++ b/.github/workflows/motoko-encrypted-notes-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-encrypted-notes-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Encrypted Notes Darwin (unit tests)
@@ -32,7 +32,7 @@ jobs:
   motoko-encrypted-notes-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Encrypted Notes Linux (unit tests)

--- a/.github/workflows/motoko-encrypted-notes-example.yml
+++ b/.github/workflows/motoko-encrypted-notes-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Encrypted Notes Darwin (unit tests)
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Encrypted Notes Linux (unit tests)

--- a/.github/workflows/motoko-encrypted-notes-vetkd-example.yml
+++ b/.github/workflows/motoko-encrypted-notes-vetkd-example.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.14.2
       - name: Provision Darwin
-        env:
-          DFX_VERSION: 0.14.2
         run: bash motoko/encrypted-notes-dapp-vetkd/provision-darwin.sh
       - name: Motoko Encrypted Notes Darwin (unit tests)
         run: |
@@ -35,9 +36,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.14.2
       - name: Provision Linux
-        env:
-          DFX_VERSION: 0.14.2
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Encrypted Notes Linux (unit tests)
         run: |

--- a/.github/workflows/motoko-encrypted-notes-vetkd-example.yml
+++ b/.github/workflows/motoko-encrypted-notes-vetkd-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-encrypted-notes-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         env:
           DFX_VERSION: 0.14.2
@@ -34,7 +34,7 @@ jobs:
   motoko-encrypted-notes-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         env:
           DFX_VERSION: 0.14.2

--- a/.github/workflows/motoko-factorial-example.yaml
+++ b/.github/workflows/motoko-factorial-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Factorial Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Factorial Linux

--- a/.github/workflows/motoko-factorial-example.yaml
+++ b/.github/workflows/motoko-factorial-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Factorial Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Factorial Linux

--- a/.github/workflows/motoko-hello-example.yml
+++ b/.github/workflows/motoko-hello-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Hello Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Hello Linux

--- a/.github/workflows/motoko-hello-example.yml
+++ b/.github/workflows/motoko-hello-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-hello-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Hello Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-hello-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Hello Linux

--- a/.github/workflows/motoko-hello-world-example.yaml
+++ b/.github/workflows/motoko-hello-world-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Hello World Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Hello World Linux

--- a/.github/workflows/motoko-hello-world-example.yaml
+++ b/.github/workflows/motoko-hello-world-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Hello World Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Hello World Linux

--- a/.github/workflows/motoko-hello_cycles-example.yaml
+++ b/.github/workflows/motoko-hello_cycles-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-hello_cycles-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Hello Cycles Darwin
@@ -29,7 +29,7 @@ jobs:
   motoko-hello_cycles-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Hello Cycles Linux

--- a/.github/workflows/motoko-hello_cycles-example.yaml
+++ b/.github/workflows/motoko-hello_cycles-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Hello Cycles Darwin
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Hello Cycles Linux

--- a/.github/workflows/motoko-http_counter-example.yaml
+++ b/.github/workflows/motoko-http_counter-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Http Counter Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Http Counter Linux

--- a/.github/workflows/motoko-http_counter-example.yaml
+++ b/.github/workflows/motoko-http_counter-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-http_counter-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Http Counter Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-http_counter-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Http Counter Linux

--- a/.github/workflows/motoko-icrc2-swap-example.yml
+++ b/.github/workflows/motoko-icrc2-swap-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-icrc2-swap-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko ICRC2-Swap Linux

--- a/.github/workflows/motoko-icrc2-swap-example.yml
+++ b/.github/workflows/motoko-icrc2-swap-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko ICRC2-Swap Linux

--- a/.github/workflows/motoko-internet-identity-integration-example.yaml
+++ b/.github/workflows/motoko-internet-identity-integration-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Internet Identity Integration Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Internet Identity Integration Linux

--- a/.github/workflows/motoko-internet-identity-integration-example.yaml
+++ b/.github/workflows/motoko-internet-identity-integration-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-internet-identity-integration-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Internet Identity Integration Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-internet-identity-integration-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Internet Identity Integration Linux

--- a/.github/workflows/motoko-invoice-e2e.yaml
+++ b/.github/workflows/motoko-invoice-e2e.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         env:
           NODE_VERSION: 19.8.1
@@ -58,6 +59,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Install vessel

--- a/.github/workflows/motoko-invoice-e2e.yaml
+++ b/.github/workflows/motoko-invoice-e2e.yaml
@@ -17,7 +17,7 @@ jobs:
   motoko-invoice-canister-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         env:
           NODE_VERSION: 19.8.1
@@ -57,7 +57,7 @@ jobs:
   motoko-invoice-canister-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Install vessel

--- a/.github/workflows/motoko-invoice-unit.yaml
+++ b/.github/workflows/motoko-invoice-unit.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Install vessel
@@ -38,6 +39,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Install vessel

--- a/.github/workflows/motoko-invoice-unit.yaml
+++ b/.github/workflows/motoko-invoice-unit.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-invoice-canister-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Install vessel
@@ -37,7 +37,7 @@ jobs:
   motoko-invoice-canister-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Install vessel

--- a/.github/workflows/motoko-ios-notifications-example.yml
+++ b/.github/workflows/motoko-ios-notifications-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko iOS Notifications Darwin
@@ -28,6 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko iOS Notifications Linux

--- a/.github/workflows/motoko-ios-notifications-example.yml
+++ b/.github/workflows/motoko-ios-notifications-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-ios-notifications-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko iOS Notifications Darwin
@@ -27,7 +27,7 @@ jobs:
   motoko-ios-notifications-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko iOS Notifications Linux

--- a/.github/workflows/motoko-ledger-transfer-example.yml
+++ b/.github/workflows/motoko-ledger-transfer-example.yml
@@ -17,7 +17,7 @@ jobs:
   motoko-ledger-transfer-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Ledger Transfer Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-ledger-transfer-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Ledger Transfer Linux

--- a/.github/workflows/motoko-ledger-transfer-example.yml
+++ b/.github/workflows/motoko-ledger-transfer-example.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Ledger Transfer Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Ledger Transfer Linux

--- a/.github/workflows/motoko-life-example.yaml
+++ b/.github/workflows/motoko-life-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-life-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Life Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-life-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Life Linux

--- a/.github/workflows/motoko-life-example.yaml
+++ b/.github/workflows/motoko-life-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Life Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Life Linux

--- a/.github/workflows/motoko-minimal-counter-dapp-example.yaml
+++ b/.github/workflows/motoko-minimal-counter-dapp-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-minimal-counter-dapp-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Minimal Counter Dapp Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-minimal-counter-dapp-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Minimal Counter Dapp Linux

--- a/.github/workflows/motoko-minimal-counter-dapp-example.yaml
+++ b/.github/workflows/motoko-minimal-counter-dapp-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Minimal Counter Dapp Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Minimal Counter Dapp Linux

--- a/.github/workflows/motoko-persistent-storage-example.yaml
+++ b/.github/workflows/motoko-persistent-storage-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Persistent Storage Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Persistent Storage Linux

--- a/.github/workflows/motoko-persistent-storage-example.yaml
+++ b/.github/workflows/motoko-persistent-storage-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-persistent-storage-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Persistent Storage Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-persistent-storage-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Persistent Storage Linux

--- a/.github/workflows/motoko-phone-book-example.yaml
+++ b/.github/workflows/motoko-phone-book-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Phone Book Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Phone Book Linux

--- a/.github/workflows/motoko-phone-book-example.yaml
+++ b/.github/workflows/motoko-phone-book-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Phone Book Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Phone Book Linux

--- a/.github/workflows/motoko-pub-sub-example.yaml
+++ b/.github/workflows/motoko-pub-sub-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Pub-Sub Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Pub-Sub Linux

--- a/.github/workflows/motoko-pub-sub-example.yaml
+++ b/.github/workflows/motoko-pub-sub-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Pub-Sub Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Pub-Sub Linux

--- a/.github/workflows/motoko-quicksort-example.yaml
+++ b/.github/workflows/motoko-quicksort-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Quicksort Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Quicksort Linux

--- a/.github/workflows/motoko-quicksort-example.yaml
+++ b/.github/workflows/motoko-quicksort-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Quicksort Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Quicksort Linux

--- a/.github/workflows/motoko-random_maze-example.yaml
+++ b/.github/workflows/motoko-random_maze-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Random Maze Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Random Maze Linux

--- a/.github/workflows/motoko-random_maze-example.yaml
+++ b/.github/workflows/motoko-random_maze-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-random_maze-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Random Maze Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-random_maze-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Random Maze Linux

--- a/.github/workflows/motoko-send-http-get-example.yml
+++ b/.github/workflows/motoko-send-http-get-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-send-http-get-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Send HTTP GET Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-send-http-get-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Send HTTP GET Linux

--- a/.github/workflows/motoko-send-http-get-example.yml
+++ b/.github/workflows/motoko-send-http-get-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Send HTTP GET Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Send HTTP GET Linux

--- a/.github/workflows/motoko-send-http-post-example.yml
+++ b/.github/workflows/motoko-send-http-post-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Send HTTP POST Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Send HTTP POST Linux

--- a/.github/workflows/motoko-send-http-post-example.yml
+++ b/.github/workflows/motoko-send-http-post-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-send-http-post-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Send HTTP POST Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-send-http-post-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Send HTTP POST Linux

--- a/.github/workflows/motoko-simple-to-do-example.yaml
+++ b/.github/workflows/motoko-simple-to-do-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Simple To-Do Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Simple To-Do Linux

--- a/.github/workflows/motoko-simple-to-do-example.yaml
+++ b/.github/workflows/motoko-simple-to-do-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Simple To-Do Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Simple To-Do Linux

--- a/.github/workflows/motoko-superheroes-example.yaml
+++ b/.github/workflows/motoko-superheroes-example.yaml
@@ -34,6 +34,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Superheroes Darwin
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Superheroes Linux

--- a/.github/workflows/motoko-superheroes-example.yaml
+++ b/.github/workflows/motoko-superheroes-example.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Superheroes Darwin
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || needs.changes.outputs.sources == 'true'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Superheroes Linux

--- a/.github/workflows/motoko-threshold-ecdsa-example.yaml
+++ b/.github/workflows/motoko-threshold-ecdsa-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-threshold-ecdsa-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Threshold ECDSA Darwin
@@ -30,7 +30,7 @@ jobs:
   motoko-threshold-ecdsa-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Threshold ECDSA Linux

--- a/.github/workflows/motoko-threshold-ecdsa-example.yaml
+++ b/.github/workflows/motoko-threshold-ecdsa-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Threshold ECDSA Darwin
@@ -31,6 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Threshold ECDSA Linux

--- a/.github/workflows/motoko-vetkd-example.yml
+++ b/.github/workflows/motoko-vetkd-example.yml
@@ -16,7 +16,7 @@ jobs:
   motoko-vetkd-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         env:
           NODE_VERSION: 19.8.1
@@ -30,7 +30,7 @@ jobs:
   motoko-vetkd-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko vetKD Linux

--- a/.github/workflows/motoko-vetkd-example.yml
+++ b/.github/workflows/motoko-vetkd-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         env:
           NODE_VERSION: 19.8.1
@@ -31,6 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko vetKD Linux

--- a/.github/workflows/motoko-whoami-example.yaml
+++ b/.github/workflows/motoko-whoami-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Who Am I Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Who Am I Linux

--- a/.github/workflows/motoko-whoami-example.yaml
+++ b/.github/workflows/motoko-whoami-example.yaml
@@ -16,7 +16,7 @@ jobs:
   motoko-whoami-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Who Am I Darwin
@@ -28,7 +28,7 @@ jobs:
   motoko-whoami-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Who Am I Linux

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -16,10 +16,7 @@ curl --location --output node.pkg "https://nodejs.org/dist/v$version/node-v$vers
 sudo installer -pkg node.pkg -store -target /
 rm node.pkg
 
-# Install DFINITY SDK.
-curl --location --output install-dfx.sh "https://internetcomputer.org/install.sh"
-DFX_VERSION=${DFX_VERSION:=0.16.1} bash install-dfx.sh < <(yes Y)
-rm install-dfx.sh
+# Initialize DFINITY SDK.
 dfx cache install
 
 # Install ic-repl

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -11,10 +11,7 @@ sudo bash install-node.sh
 sudo apt-get install --yes nodejs
 rm install-node.sh
 
-# Install DFINITY SDK.
-wget --output-document install-dfx.sh "https://internetcomputer.org/install.sh"
-DFX_VERSION=${DFX_VERSION:=0.16.1} bash install-dfx.sh < <(yes Y)
-rm install-dfx.sh
+# Initialize DFINITY SDK.
 dfx cache install
 
 # Install ic-repl

--- a/.github/workflows/rust-basic-bitcoin-example.yml
+++ b/.github/workflows/rust-basic-bitcoin-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
@@ -31,6 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Basic Bitcoin Linux

--- a/.github/workflows/rust-basic-bitcoin-example.yml
+++ b/.github/workflows/rust-basic-bitcoin-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-basic-bitcoin-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
@@ -30,7 +30,7 @@ jobs:
   rust-basic-bitcoin-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Basic Bitcoin Linux

--- a/.github/workflows/rust-basic-dao-example.yml
+++ b/.github/workflows/rust-basic-dao-example.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust DAO Darwin
@@ -35,6 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust DAO Linux

--- a/.github/workflows/rust-basic-dao-example.yml
+++ b/.github/workflows/rust-basic-dao-example.yml
@@ -17,7 +17,7 @@ jobs:
   rust-dao-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust DAO Darwin
@@ -34,7 +34,7 @@ jobs:
   rust-hello-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust DAO Linux

--- a/.github/workflows/rust-canister-info-example.yml
+++ b/.github/workflows/rust-canister-info-example.yml
@@ -18,8 +18,11 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.14.2
       - name: Provision Darwin
-        run: DFX_VERSION="0.14.2" bash .github/workflows/provision-darwin.sh
+        run: bash .github/workflows/provision-darwin.sh
       - name: Rust Canister info Darwin
         run: |
           dfx start --background
@@ -30,8 +33,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.14.2
       - name: Provision Linux
-        run: DFX_VERSION="0.14.2" bash .github/workflows/provision-linux.sh
+        run: bash .github/workflows/provision-linux.sh
       - name: Rust Canister info Linux
         run: |
           dfx start --background

--- a/.github/workflows/rust-canister-info-example.yml
+++ b/.github/workflows/rust-canister-info-example.yml
@@ -17,7 +17,7 @@ jobs:
   rust-canister-info-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: DFX_VERSION="0.14.2" bash .github/workflows/provision-darwin.sh
       - name: Rust Canister info Darwin
@@ -29,7 +29,7 @@ jobs:
   rust-canister-info-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: DFX_VERSION="0.14.2" bash .github/workflows/provision-linux.sh
       - name: Rust Canister info Linux

--- a/.github/workflows/rust-composite_query-example.yml
+++ b/.github/workflows/rust-composite_query-example.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust composite_query Darwin
@@ -36,6 +37,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust composite_query Linux

--- a/.github/workflows/rust-composite_query-example.yml
+++ b/.github/workflows/rust-composite_query-example.yml
@@ -17,7 +17,7 @@ jobs:
   rust-composite_query-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust composite_query Darwin
@@ -35,7 +35,7 @@ jobs:
   rust-composite_query-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust composite_query Linux

--- a/.github/workflows/rust-counter-example.yml
+++ b/.github/workflows/rust-counter-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Counter Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Counter Linux

--- a/.github/workflows/rust-counter-example.yml
+++ b/.github/workflows/rust-counter-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-counter-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Counter Darwin
@@ -28,7 +28,7 @@ jobs:
   rust-counter-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Counter Linux

--- a/.github/workflows/rust-defi-example.yml
+++ b/.github/workflows/rust-defi-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-defi-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -32,7 +32,7 @@ jobs:
   rust-defi-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/rust-defi-example.yml
+++ b/.github/workflows/rust-defi-example.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Defi Darwin

--- a/.github/workflows/rust-dip721-example.yml
+++ b/.github/workflows/rust-dip721-example.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust DIP-721 Darwin

--- a/.github/workflows/rust-dip721-example.yml
+++ b/.github/workflows/rust-dip721-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-dip721-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -29,7 +29,7 @@ jobs:
   rust-dip721-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/rust-encrypted-notes-example.yml
+++ b/.github/workflows/rust-encrypted-notes-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Encrypted Notes Darwin (unit tests)
@@ -33,6 +34,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Encrypted Notes Linux (unit tests)

--- a/.github/workflows/rust-encrypted-notes-example.yml
+++ b/.github/workflows/rust-encrypted-notes-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-encrypted-notes-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Encrypted Notes Darwin (unit tests)
@@ -32,7 +32,7 @@ jobs:
   rust-encrypted-notes-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Encrypted Notes Linux (unit tests)

--- a/.github/workflows/rust-encrypted-notes-vetkd-example.yml
+++ b/.github/workflows/rust-encrypted-notes-vetkd-example.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.14.2
       - name: Provision Darwin
-        env:
-          DFX_VERSION: 0.14.2
         run: bash motoko/encrypted-notes-dapp-vetkd/provision-darwin.sh
       - name: Rust Encrypted Notes Darwin (unit tests)
         run: |
@@ -35,9 +36,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
+        with:
+          dfx-version: 0.14.2
       - name: Provision Linux
-        env:
-          DFX_VERSION: 0.14.2
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Encrypted Notes Linux (unit tests)
         run: |

--- a/.github/workflows/rust-encrypted-notes-vetkd-example.yml
+++ b/.github/workflows/rust-encrypted-notes-vetkd-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-encrypted-notes-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         env:
           DFX_VERSION: 0.14.2
@@ -34,7 +34,7 @@ jobs:
   rust-encrypted-notes-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         env:
           DFX_VERSION: 0.14.2

--- a/.github/workflows/rust-hello-example.yml
+++ b/.github/workflows/rust-hello-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Hello Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Hello Linux

--- a/.github/workflows/rust-hello-example.yml
+++ b/.github/workflows/rust-hello-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-hello-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Hello Darwin
@@ -28,7 +28,7 @@ jobs:
   rust-hello-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Hello Linux

--- a/.github/workflows/rust-nft-wallet-example.yml
+++ b/.github/workflows/rust-nft-wallet-example.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Install icx-asset
@@ -36,6 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Install icx-asset

--- a/.github/workflows/rust-nft-wallet-example.yml
+++ b/.github/workflows/rust-nft-wallet-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-nft-wallet-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -33,7 +33,7 @@ jobs:
   rust-nft-wallet-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/rust-performance_counters-example.yaml
+++ b/.github/workflows/rust-performance_counters-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Performance Counters Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Performance Counters Linux

--- a/.github/workflows/rust-performance_counters-example.yaml
+++ b/.github/workflows/rust-performance_counters-example.yaml
@@ -16,7 +16,7 @@ jobs:
   rust-performance_counters-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Performance Counters Darwin
@@ -28,7 +28,7 @@ jobs:
   rust-performance_counters-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Performance Counters Linux

--- a/.github/workflows/rust-periodic_tasks-example.yaml
+++ b/.github/workflows/rust-periodic_tasks-example.yaml
@@ -16,7 +16,7 @@ jobs:
   rust-periodic_tasks-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Periodic Tasks Darwin
@@ -28,7 +28,7 @@ jobs:
   rust-periodic_tasks-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Periodic Tasks Linux

--- a/.github/workflows/rust-periodic_tasks-example.yaml
+++ b/.github/workflows/rust-periodic_tasks-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Periodic Tasks Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Periodic Tasks Linux

--- a/.github/workflows/rust-pub-sub-example.yml
+++ b/.github/workflows/rust-pub-sub-example.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Pub-Sub Darwin
@@ -35,6 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Pub-Sub Linux

--- a/.github/workflows/rust-pub-sub-example.yml
+++ b/.github/workflows/rust-pub-sub-example.yml
@@ -17,7 +17,7 @@ jobs:
   rust-pub-sub-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -32,7 +32,7 @@ jobs:
   rust-pub-sub-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/rust-qrcode-example.yaml
+++ b/.github/workflows/rust-qrcode-example.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust QRCode Darwin
@@ -29,6 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust QRCode Linux

--- a/.github/workflows/rust-qrcode-example.yaml
+++ b/.github/workflows/rust-qrcode-example.yaml
@@ -16,7 +16,7 @@ jobs:
   rust-qrcode-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust QRCode Darwin
@@ -28,7 +28,7 @@ jobs:
   rust-qrcode-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust QRCode Linux

--- a/.github/workflows/rust-send-http-get-example.yml
+++ b/.github/workflows/rust-send-http-get-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-send-http-get-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Send HTTP GET Darwin
@@ -29,7 +29,7 @@ jobs:
   rust-send-http-get-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Send HTTP GET Linux

--- a/.github/workflows/rust-send-http-get-example.yml
+++ b/.github/workflows/rust-send-http-get-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Send HTTP GET Darwin
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Send HTTP GET Linux

--- a/.github/workflows/rust-send-http-post-example.yml
+++ b/.github/workflows/rust-send-http-post-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-send-http-post-example-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Send HTTP POST Darwin
@@ -29,7 +29,7 @@ jobs:
   rust-send-http-post-example-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Send HTTP POST Linux

--- a/.github/workflows/rust-send-http-post-example.yml
+++ b/.github/workflows/rust-send-http-post-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Send HTTP POST Darwin
@@ -30,6 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Send HTTP POST Linux

--- a/.github/workflows/rust-threshold-ecdsa-example.yml
+++ b/.github/workflows/rust-threshold-ecdsa-example.yml
@@ -17,7 +17,7 @@ jobs:
   rust-threshold-ecdsa-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Threshold ECDSA Darwin
@@ -31,7 +31,7 @@ jobs:
   rust-threshold-ecdsa-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Threshold ECDSA Linux

--- a/.github/workflows/rust-threshold-ecdsa-example.yml
+++ b/.github/workflows/rust-threshold-ecdsa-example.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Threshold ECDSA Darwin
@@ -32,6 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Threshold ECDSA Linux

--- a/.github/workflows/rust-tokens-transfer-example.yml
+++ b/.github/workflows/rust-tokens-transfer-example.yml
@@ -17,7 +17,7 @@ jobs:
   rust-tokens_transfer-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Darwin
@@ -30,7 +30,7 @@ jobs:
   rust-tokens_transfer-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Provision Linux

--- a/.github/workflows/rust-tokens-transfer-example.yml
+++ b/.github/workflows/rust-tokens-transfer-example.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Tokens Transfer Darwin
@@ -33,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Tokens Transfer Linux

--- a/.github/workflows/rust-vetkd-example.yml
+++ b/.github/workflows/rust-vetkd-example.yml
@@ -16,7 +16,7 @@ jobs:
   rust-vetkd-darwin:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Darwin
         env:
           NODE_VERSION: 19.8.1
@@ -30,7 +30,7 @@ jobs:
   rust-vetkd-linux:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust vetKD Linux

--- a/.github/workflows/rust-vetkd-example.yml
+++ b/.github/workflows/rust-vetkd-example.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Darwin
         env:
           NODE_VERSION: 19.8.1
@@ -31,6 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+      - uses: dfinity/setup-dfx@main
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Rust vetKD Linux


### PR DESCRIPTION
**Overview**
This is to be compatible with dfxvm once it's released.

I also updated all of the workflows to use actions/checkout@v4.  This PR is split into two commits: the first updates to actions/checkout@v4, the second updates to use dfinity/setup-dfx.

**Requirements**
These tests should install dfx now, and after dfxvm is released.

**Considered Solutions**
Another option would have been to copy the path setup from https://github.com/dfinity/setup-dfx/blob/main/action.yml into the provision scripts.
```
# Linux
echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
# Macos
echo "$HOME/Library/Application Support/org.dfinity.dfx/bin" >> $GITHUB_PATH
```

**Recommended Solution**
There's a github action now, so it seems nice to use it.  Also the workflows used to use a couple different methods of overriding the dfx version.  Now there's just one:
```
      - uses: dfinity/setup-dfx@main
        with:
          dfx-version: 0.14.2
```

**Considerations**
This should reduce maintenance costs going forward, since https://github.com/dfinity/setup-dfx should be able to perform its part.
