### PR TITLE
chore(FI-1221): Bump the version of the ICP Ledger canister

### DIFF
--- a/motoko/ledger-transfer/demo.sh
+++ b/motoko/ledger-transfer/demo.sh
@@ -8,17 +8,15 @@ trap 'dfx stop' EXIT
 export IC_VERSION=98eb213581b239c3829eee7076bea74acad9937b
 test -f ledger.wasm.gz || curl -o ledger.wasm.gz https://download.dfinity.systems/ic/${IC_VERSION}/canisters/ledger-canister_notify-method.wasm.gz
 test -f ledger.wasm || gunzip ledger.wasm.gz
-test -f ledger.private.did || curl -o ledger.private.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/ledger.did
-test -f ledger.public.did || curl -o ledger.public.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/ledger_canister/ledger.did
+test -f ledger.did || curl -o ledger.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/icp_ledger/ledger.did
 
 dfx start --background --clean
 dfx identity new alice --disable-encryption || true
-cat <<<"$(jq '.canisters.ledger.candid="ledger.private.did"' dfx.json)" >dfx.json
+cat <<<"$(jq '.canisters.ledger.candid="ledger.did"' dfx.json)" >dfx.json
 export MINT_ACC=$(dfx --identity anonymous ledger account-id)
 export LEDGER_ACC=$(dfx ledger account-id)
 export ARCHIVE_CONTROLLER=$(dfx identity get-principal)
 dfx deploy ledger --argument '(record {minting_account = "'${MINT_ACC}'"; initial_values = vec { record { "'${LEDGER_ACC}'"; record { e8s=100_000_000_000 } }; }; send_whitelist = vec {}})'
-cat <<<"$(jq '.canisters.ledger.candid="ledger.public.did"' dfx.json)" >dfx.json
 dfx canister call ledger account_balance '(record { account = '$(python3 -c 'print("vec{" + ";".join([str(b) for b in bytes.fromhex("'$LEDGER_ACC'")]) + "}")')' })'
 
 dfx deploy ledger_transfer

--- a/motoko/ledger-transfer/demo.sh
+++ b/motoko/ledger-transfer/demo.sh
@@ -3,7 +3,9 @@ dfx stop
 set -e
 trap 'dfx stop' EXIT
 
-export IC_VERSION=2cb0afe1f49b8bbd4e60db234ca1f4a6f68ea115
+# Version corresponding to the latest upgrade proposal for the ICP Ledger canister
+# https://dashboard.internetcomputer.org/canister/ryjl3-tyaaa-aaaaa-aaaba-cai
+export IC_VERSION=98eb213581b239c3829eee7076bea74acad9937b
 test -f ledger.wasm.gz || curl -o ledger.wasm.gz https://download.dfinity.systems/ic/${IC_VERSION}/canisters/ledger-canister_notify-method.wasm.gz
 test -f ledger.wasm || gunzip ledger.wasm.gz
 test -f ledger.private.did || curl -o ledger.private.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/ledger.did

--- a/rust/tokens_transfer/demo.sh
+++ b/rust/tokens_transfer/demo.sh
@@ -4,7 +4,9 @@ set -e
 trap 'dfx stop' EXIT
 
 echo "===========SETUP========="
-export IC_VERSION=2cb0afe1f49b8bbd4e60db234ca1f4a6f68ea115
+# Version corresponding to the latest upgrade proposal for the ICP Ledger canister
+# https://dashboard.internetcomputer.org/canister/ryjl3-tyaaa-aaaaa-aaaba-cai
+export IC_VERSION=98eb213581b239c3829eee7076bea74acad9937b
 test -f ledger.wasm.gz || curl -o ledger.wasm.gz https://download.dfinity.systems/ic/${IC_VERSION}/canisters/ledger-canister_notify-method.wasm.gz
 test -f ledger.wasm || gunzip ledger.wasm.gz
 test -f ledger.private.did || curl -o ledger.private.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/ledger.did

--- a/rust/tokens_transfer/demo.sh
+++ b/rust/tokens_transfer/demo.sh
@@ -9,16 +9,14 @@ echo "===========SETUP========="
 export IC_VERSION=98eb213581b239c3829eee7076bea74acad9937b
 test -f ledger.wasm.gz || curl -o ledger.wasm.gz https://download.dfinity.systems/ic/${IC_VERSION}/canisters/ledger-canister_notify-method.wasm.gz
 test -f ledger.wasm || gunzip ledger.wasm.gz
-test -f ledger.private.did || curl -o ledger.private.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/ledger.did
-test -f ledger.public.did || curl -o ledger.public.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/ledger_canister/ledger.did
+test -f ledger.did || curl -o ledger.did https://raw.githubusercontent.com/dfinity/ic/${IC_VERSION}/rs/rosetta-api/icp_ledger/ledger.did
 dfx start --background --clean
 dfx identity new alice --disable-encryption || true
-cat <<<"$(jq '.canisters.ledger.candid="ledger.private.did"' dfx.json)" >dfx.json
+cat <<<"$(jq '.canisters.ledger.candid="ledger.did"' dfx.json)" >dfx.json
 export MINT_ACC=$(dfx --identity anonymous ledger account-id)
 export LEDGER_ACC=$(dfx ledger account-id)
 export ARCHIVE_CONTROLLER=$(dfx identity get-principal)
 dfx deploy ledger --argument '(record {minting_account = "'${MINT_ACC}'"; initial_values = vec { record { "'${LEDGER_ACC}'"; record { e8s=100_000_000_000 } }; }; send_whitelist = vec {}})'
-cat <<<"$(jq '.canisters.ledger.candid="ledger.public.did"' dfx.json)" >dfx.json
 dfx canister call ledger account_balance '(record { account = '$(python3 -c 'print("vec{" + ";".join([str(b) for b in bytes.fromhex("'$LEDGER_ACC'")]) + "}")')' })'
 echo "===========SETUP DONE========="
 


### PR DESCRIPTION
chore(FI-1221): Bump the version of the ICP Ledger canister

**Overview**
The `rust-tokens_transfer` and `motoko-ledger-transfer` tests are currently failing (e.g., in [this job](https://github.com/dfinity/examples/actions/runs/8177922736/job/22360689453?pr=725) of [this PR](https://github.com/dfinity/examples/pull/725)) since they try to download a version of the ICP ledger that is over 1,5 years old, and the file no longer exists at [https://download.dfinity.systems/ic/2cb0afe1f49b8bbd4e60db234ca1f4a6f68ea115/canisters/ledger-canister_notify-method.wasm.gz](https://download.dfinity.systems/ic/2cb0afe1f49b8bbd4e60db234ca1f4a6f68ea115/canisters/ledger-canister_notify-method.wasm.gz) .

**Requirements**
If the following tests pass, then this problem can be considered solved:

- `rust-tokens_transfer / rust-tokens_transfer-linux`
- `rust-tokens_transfer / rust-tokens_transfer-darwin`
- `motoko-ledger-transfer / motoko-ledger-transfer-linux`
- `motoko-ledger-transfer / motoko-ledger-transfer-darwin`

**Considered Solutions**
Ideally, this version should be updated whenever the ICP Ledger on mainnet is updated.

**Recommended Solution**
Updating the hard-coded version is the recommended solution for now.

**Considerations**
The recommended solution should improve the developer experience, but it will not reduce the maintenance work.
