### PR TITLE
Update rust-basic-bitcoin-example.yml

### DIFF
--- a/.github/workflows/rust-basic-bitcoin-example.yml
+++ b/.github/workflows/rust-basic-bitcoin-example.yml
@@ -35,7 +35,7 @@ jobs:
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Basic Bitcoin Linux
         run: |
-          dfx start --background
+          dfx start --background --clean
           pushd rust/basic_bitcoin
           make deploy
           popd


### PR DESCRIPTION
Use `--clean` when starting dfx for the rust basic bitcoin workflow to avoid any old state lingering around affect things.