### PR TITLE
Use default provisioned DFX version in encrypted-notes-vetkd dapps

### DIFF
--- a/.github/workflows/motoko-encrypted-notes-vetkd-example.yml
+++ b/.github/workflows/motoko-encrypted-notes-vetkd-example.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Provision Linux
-        env:
-          DFX_VERSION: 0.14.2
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Encrypted Notes Linux (unit tests)
         run: |

--- a/.github/workflows/rust-encrypted-notes-vetkd-example.yml
+++ b/.github/workflows/rust-encrypted-notes-vetkd-example.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Provision Darwin
         env:
-          DFX_VERSION: 0.14.2
           NODE_VERSION: 14.21.3
         run: bash .github/workflows/provision-darwin.sh
       - name: Rust Encrypted Notes Darwin (unit tests)
@@ -37,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Provision Linux
-        env:
-          DFX_VERSION: 0.14.2
         run: bash .github/workflows/provision-linux.sh
       - name: Rust Encrypted Notes Linux (unit tests)
         run: |


### PR DESCRIPTION
Removes the custom DFX versions used for provisioning the Linux CI checks for the encrypted-notes-vetkd dapp for both Rust and Motoko. This is done because the custom DFX version, 0.14.2, is outdated. With this, the default DFX version defined in `provision-linux.sh` is used, which version is regularly updated to ensure the examples work with the latest version.