### PR TITLE
chore: update markdown content to comply with mdx v3 parsing rules

### DIFF
--- a/hosting/static-website/README.md
+++ b/hosting/static-website/README.md
@@ -125,7 +125,7 @@ dfx deploy
 ## Testing
 The URL for the frontend depends on the canister ID.  Local canister IDs can be obtained using `dfx canister id`, in this case `dfx canister id www`. When deployed, the URL will look like this:
 
-**http://<ui_canister_id>.localhost:8000**
+**http://\{ui_canister_id\}.localhost:8000**
 
 ![Candid UI](README_images/website.png)
 

--- a/motoko/encrypted-notes-dapp/README.md
+++ b/motoko/encrypted-notes-dapp/README.md
@@ -159,8 +159,8 @@ sh ./deploy_locally.sh
 
 - #### Step 5: To stop the docker instance:
    - Hit **Ctrl+C** on your keyboard to abort the running process.
-   - Run `docker ps` and find the <CONTAINER ID'\'> of encrypted_notes.
-   - Run `docker rm -f <CONTAINER ID'\'>`.
+   - Run `docker ps` and find the \<CONTAINER ID\> of encrypted_notes.
+   - Run `docker rm -f <CONTAINER ID>`.
 
 ### Option 2: Manual deployment
 - #### Step 1: For Motoko deployment set environmental variable:

--- a/motoko/hello/README.md
+++ b/motoko/hello/README.md
@@ -22,10 +22,11 @@ This sample is based on the default project created by running `dfx new` as desc
 The sample code is available from the [samples](https://github.com/dfinity/examples) repository in both [Motoko](https://github.com/dfinity/examples/tree/master/motoko/hello) and [Rust](https://github.com/dfinity/examples/tree/master/rust/hello).
 
 Canister `hello`, whether implemented in Motoko or Rust, presents the same Candid interface:
-
-    service : {
-      greet: (text) -> (text);
-    }
+```candid
+service : {
+  greet: (text) -> (text);
+}
+```
 
 The frontend canister, `hello_assets`, displays an HTML page with a text box for the argument and a button for calling the function greet with that argument. The result of the call is displayed in a message box.
 

--- a/motoko/internet_identity_integration/README.md
+++ b/motoko/internet_identity_integration/README.md
@@ -102,7 +102,7 @@ Open the `internet_identity` link in the browser. You should be able to create a
 ### Step 4: Make the Internet Identity URL available in the build process.
 We want the sample application to integrate with Internet Identity differently depending on whether we deploy locally or on mainnet:
 
-- Locally the application should use the Internet Identity URL http://<II_CANISTER_ID>.localhost:4943/.
+- Locally the application should use the Internet Identity URL http://\<II_CANISTER_ID\>.localhost:4943/.
 - On the mainnet it should use https://identity.ic0.app.
 
 > **Note**: If you are using Safari (or any other browser that does not support subdomains on localhost, i.e this URL `http://<II_CANISTER_ID>.localhost:4943/`), you can try to use the following URL instead: `http://localhost:4943/?canisterId=<II_CANISTER_ID>`. This will work for Safari but not Chrome.

--- a/motoko/minimal-counter-dapp/README.md
+++ b/motoko/minimal-counter-dapp/README.md
@@ -188,7 +188,7 @@ $ dfx canister id minimal_dapp
 rrkah-fqaaa-aaaaa-aaaaq-cai
 ```
 
-**http://<candid_canister_id>.localhost:8000/?id=<backend_canister_id>**
+**http://\{candid_canister_id\}.localhost:8000/?id=\<backend_canister_id\>**
 
 ![Candid UI](README_images/candid_ui.png)
 

--- a/rust/encrypted-notes-dapp/README.md
+++ b/rust/encrypted-notes-dapp/README.md
@@ -160,8 +160,8 @@ sh ./deploy_locally.sh
 
 - #### Step 5: To stop the docker instance:
    - Hit **Ctrl+C** on your keyboard to abort the running process.
-   - Run `docker ps` and find the <CONTAINER ID'\'> of encrypted_notes.
-   - Run `docker rm -f <CONTAINER ID'\'>`.
+   - Run `docker ps` and find the \<CONTAINER ID\> of encrypted_notes.
+   - Run `docker rm -f <CONTAINER ID>`.
 
 ### Option 2: Manual deployment
 - #### Step 1: For Rust deployment set environmental variable:

--- a/rust/hello/README.md
+++ b/rust/hello/README.md
@@ -22,10 +22,11 @@ This sample is based on the default project created by running `dfx new` as desc
 The sample code is available from the [samples](https://github.com/dfinity/examples) repository in both [Motoko](https://github.com/dfinity/examples/tree/master/motoko/hello) and [Rust](https://github.com/dfinity/examples/tree/master/rust/hello).
 
 Canister `hello`, whether implemented in Motoko or Rust, presents the same Candid interface:
-
-    service : {
-      greet: (text) -> (text);
-    }
+```candid
+service : {
+  greet: (text) -> (text);
+}
+```
 
 The frontend canister, `hello_assets`, displays an HTML page with a text box for the argument and a button for calling the function greet with that argument. The result of the call is displayed in a message box.
 


### PR DESCRIPTION
To upgrade the portal from Docusaurus v2 to v3, we need to ensure all markdown content can be rendered with the v3 mdx parser.

See https://docusaurus.io/blog/preparing-your-site-for-docusaurus-v3#preparing-content-for-mdx-v3 for more