### PR TITLE
fix: testnet capitalization

### DIFF
--- a/motoko/basic_bitcoin/README.md
+++ b/motoko/basic_bitcoin/README.md
@@ -39,7 +39,7 @@ Deploying to the Internet Computer requires [cycles](https://internetcomputer.or
 ### Deploy the smart contract to the Internet Computer
 
 ```bash
-dfx deploy --network=ic basic_bitcoin --argument '(variant { Testnet })'
+dfx deploy --network=ic basic_bitcoin --argument '(variant { testnet })'
 ```
 
 #### What this does


### PR DESCRIPTION
lower case testnet in the argument to properly deploy

**Overview**
Why do we need this feature? What are we trying to accomplish?

Must lower case `testnet` argument to properly deploy Bitcoin canister

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
