### PR TITLE
chore: fix CODEOWNERS and workflow for canister-logs example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 /motoko/basic_bitcoin/ @dfinity/execution
 /motoko/basic_dao/ @dfinity/languages
 /motoko/calc/ @dfinity/languages
+/motoko/canister_logs/ @dfinity/execution
 /motoko/cert-var/ @dfinity/trust
 /motoko/classes/ @dfinity/languages
 /motoko/composite_query/ @dfinity/languages
@@ -54,6 +55,7 @@
 
 /rust/basic_bitcoin/ @dfinity/execution
 /rust/basic_dao/ @dfinity/testing-verification
+/rust/canister_logs/ @dfinity/execution
 /rust/canister-info/ @dfinity/testing-verification
 /rust/composite_query/ @dfinity/execution
 /rust/counter/ @dfinity/growth

--- a/.github/workflows/motoko-canister-logs-example.yml
+++ b/.github/workflows/motoko-canister-logs-example.yml
@@ -1,0 +1,40 @@
+name: motoko-canister-logs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - motoko/canister_logs/**
+      - .github/workflows/provision-darwin.sh
+      - .github/workflows/provision-linux.sh
+      - .github/workflows/motoko-canister-logs-example.yaml
+      - .ic-commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  motoko-canister-logs-example-darwin:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v1
+      - name: Provision Darwin
+        run: bash .github/workflows/provision-darwin.sh
+      - name: Motoko Canister Logs Darwin
+        run: |
+          dfx start --background
+          pushd motoko/canister_logs
+          make test
+          popd
+  motoko-canister-logs-example-linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
+      - name: Motoko Canister Logs Linux
+        run: |
+          dfx start --background
+          pushd motoko/canister_logs
+          make test
+          popd

--- a/.github/workflows/rust-canister-logs-example.yml
+++ b/.github/workflows/rust-canister-logs-example.yml
@@ -1,0 +1,40 @@
+name: rust-canister-logs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - rust/canister_logs/**
+      - .github/workflows/provision-darwin.sh
+      - .github/workflows/provision-linux.sh
+      - .github/workflows/rust-canister-logs-example.yaml
+      - .ic-commit
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  rust-canister-logs-example-darwin:
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v1
+      - name: Provision Darwin
+        run: bash .github/workflows/provision-darwin.sh
+      - name: Rust Canister Logs Darwin
+        run: |
+          dfx start --background
+          pushd rust/canister_logs
+          make test
+          popd
+  rust-canister-logs-example-linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
+      - name: Rust Canister Logs Linux
+        run: |
+          dfx start --background
+          pushd rust/canister_logs
+          make test
+          popd

--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -1,0 +1,30 @@
+.PHONY: all
+all: build
+
+.PHONY: build
+.SILENT: build
+build:
+	dfx canister create CanisterLogs
+	dfx build
+
+.PHONY: install
+.SILENT: install
+install: build
+	dfx canister install CanisterLogs
+
+.PHONY: upgrade
+.SILENT: upgrade
+upgrade: build
+	dfx canister install CanisterLogs --mode=upgrade
+
+.PHONY: test
+.SILENT: test
+test: install
+	dfx canister call CanisterLogs print 'hi'
+	dfx canister logs CanisterLogs \
+		| grep 'hi' && echo 'PASS'
+
+.PHONY: clean
+.SILENT: clean
+clean:
+	rm -fr .dfx

--- a/motoko/canister_logs/README.md
+++ b/motoko/canister_logs/README.md
@@ -9,6 +9,7 @@ keywords: [beginner, motoko, canister logs, logging]
 ## Prerequisites
 This example requires an installation of:
 
+- [x] DFX version 0.19.0 or newer
 - [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 - [x] Download the following project files from GitHub: `git clone https://github.com/dfinity/examples/`
 

--- a/motoko/counter/README.md
+++ b/motoko/counter/README.md
@@ -21,7 +21,6 @@ The application provides an interface that exposes the following methods:
 ### Prerequisites
 This example requires an installation of:
 
-- [x] DFX version 0.19.0 or newer
 - [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
 - [x] Clone the example dapp project: `git clone https://github.com/dfinity/examples`
 

--- a/motoko/counter/README.md
+++ b/motoko/counter/README.md
@@ -21,6 +21,7 @@ The application provides an interface that exposes the following methods:
 ### Prerequisites
 This example requires an installation of:
 
+- [x] DFX version 0.19.0 or newer
 - [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
 - [x] Clone the example dapp project: `git clone https://github.com/dfinity/examples`
 

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -1,0 +1,30 @@
+.PHONY: all
+all: build
+
+.PHONY: build
+.SILENT: build
+build:
+	dfx canister create canister_logs
+	dfx build
+
+.PHONY: install
+.SILENT: install
+install: build
+	dfx canister install canister_logs
+
+.PHONY: upgrade
+.SILENT: upgrade
+upgrade: build
+	dfx canister install canister_logs --mode=upgrade
+
+.PHONY: test
+.SILENT: test
+test: install
+	dfx canister call canister_logs print 'hi'
+	dfx canister logs canister_logs \
+		| grep 'hi' && echo 'PASS'
+
+.PHONY: clean
+.SILENT: clean
+clean:
+	rm -fr .dfx

--- a/rust/canister_logs/README.md
+++ b/rust/canister_logs/README.md
@@ -9,6 +9,7 @@ keywords: [beginner, rust, canister logs, logging]
 ## Prerequisites
 This example requires an installation of:
 
+- [x] DFX version 0.19.0 or newer
 - [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/).
 - [x] Download the following project files from GitHub: `git clone https://github.com/dfinity/examples/`
 
@@ -64,7 +65,7 @@ $ dfx canister logs canister_logs
 ...
 [18. 2024-05-22T12:36:20.881326098Z]: right before timer trap
 [19. 2024-05-22T12:36:20.881326098Z]: [TRAP]: timer trap
-[20. 2024-05-22T12:36:26.305162772Z]: hi
+<b>[20. 2024-05-22T12:36:26.305162772Z]: hi</b>
 [21. 2024-05-22T12:36:27.185879186Z]: right before timer trap
 [22. 2024-05-22T12:36:27.185879186Z]: [TRAP]: timer trap
 ```

--- a/rust/canister_logs/README.md
+++ b/rust/canister_logs/README.md
@@ -65,7 +65,7 @@ $ dfx canister logs canister_logs
 ...
 [18. 2024-05-22T12:36:20.881326098Z]: right before timer trap
 [19. 2024-05-22T12:36:20.881326098Z]: [TRAP]: timer trap
-<b>[20. 2024-05-22T12:36:26.305162772Z]: hi</b>
+[20. 2024-05-22T12:36:26.305162772Z]: hi
 [21. 2024-05-22T12:36:27.185879186Z]: right before timer trap
 [22. 2024-05-22T12:36:27.185879186Z]: [TRAP]: timer trap
 ```


### PR DESCRIPTION
This PR fixes ownership, readme nits and workflow for canister_logs examples.