### PR TITLE
Make Crypto team own the Motoko threshold-ecdsa dapp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,7 +46,7 @@
 /motoko/send_http_post/ @dfinity/networking
 /motoko/simple-to-do/ @dfinity/growth
 /motoko/superheroes/ @dfinity/growth
-/motoko/threshold-ecdsa/ @dfinity/div-Crypto
+/motoko/threshold-ecdsa/ @dfinity/dept-crypto-library
 /motoko/token_transfer/ @dfinity/growth
 /motoko/token_transfer_from/ @dfinity/growth
 /motoko/vetkd/ @dfinity/dept-crypto-library


### PR DESCRIPTION
Adapts the CODEOWERS file so that the Crypto team, rather than the Crypto division, owns the Motoko threshold-ecdsa example dapp. The idea was to do this already in https://github.com/dfinity/examples/pull/880, but that was missed.