### PR TITLE
Use Wasm SIMD in the image classification example

### DIFF
--- a/rust/image-classification/Cargo.lock
+++ b/rust/image-classification/Cargo.lock
@@ -256,6 +256,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +358,12 @@ name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a650a461c6a8ff1ef205ed9a2ad56579309853fecefc2423f73dced342f92258"
 
 [[package]]
 name = "either"
@@ -1022,6 +1053,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,8 +1382,8 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tract-core"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "anyhow",
  "bit-set",
@@ -1355,10 +1406,12 @@ dependencies = [
 
 [[package]]
 name = "tract-data"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "anyhow",
+ "downcast-rs",
+ "dyn-hash",
  "half",
  "itertools 0.12.1",
  "lazy_static",
@@ -1374,8 +1427,8 @@ dependencies = [
 
 [[package]]
 name = "tract-hir"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "derive-new",
  "log",
@@ -1384,13 +1437,14 @@ dependencies = [
 
 [[package]]
 name = "tract-linalg"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "cc",
  "derive-new",
  "downcast-rs",
  "dyn-clone",
+ "dyn-hash",
  "half",
  "lazy_static",
  "liquid",
@@ -1398,6 +1452,7 @@ dependencies = [
  "log",
  "num-traits",
  "paste",
+ "rayon",
  "scan_fmt",
  "smallvec",
  "time",
@@ -1408,8 +1463,8 @@ dependencies = [
 
 [[package]]
 name = "tract-nnef"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "byteorder",
  "flate2",
@@ -1422,8 +1477,8 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "bytes",
  "derive-new",
@@ -1439,8 +1494,8 @@ dependencies = [
 
 [[package]]
 name = "tract-onnx-opl"
-version = "0.21.2-pre"
-source = "git+https://github.com/sonos/tract#43b3a6689816c0797157c75e90435afa6426fd1f"
+version = "0.21.6-pre"
+source = "git+https://github.com/sonos/tract?rev=2a2914ac29390cc08963301c9f3d437b52dd321a#2a2914ac29390cc08963301c9f3d437b52dd321a"
 dependencies = [
  "getrandom",
  "log",

--- a/rust/image-classification/README.md
+++ b/rust/image-classification/README.md
@@ -3,18 +3,12 @@
 This is an ICP smart contract that accepts an image from the user and runs image classification inference.
 The smart contract consists of two canisters:
 
-- the backend canister embeds the [the Tract ONNX inference engine](https://github.com/sonos/tract) with [the MobileNet v2-7 model](https://github.com/onnx/models/tree/main/validated/vision/classification/mobilenet). It provides a `classify()` endpoint for the frontend code to call.
+- the backend canister embeds the [the Tract ONNX inference engine](https://github.com/sonos/tract) with [the MobileNet v2-7 model](https://github.com/onnx/models/tree/main/validated/vision/classification/mobilenet).
+  It provides `classify()` and `classify_query()` endpoints for the frontend code to call.
+  The former endpoint is used for replicated execution (running on all nodes) whereas the latter runs only on a single node.
 - the frontend canister contains the Web assets such as HTML, JS, CSS that are served to the browser.
 
-Note that currently Wasm execution is not optimized for this workload.
-A single call executes about 24B instructions (~10s).
-
-This is expected to improve in the future with:
-
-- faster deterministic floating-point operations.
-- Wasm SIMD (Single-Instruction Multiple Data).
-
-The ICP mainnet subnets and `dfx` running a replica version older than [463296](https://dashboard.internetcomputer.org/release/463296c0bc82ad5999b70245e5f125c14ba7d090) may fail with an instruction-limit-exceeded error.
+This example uses Wasm SIMD instructions that are available in `dfx` version `0.20.2-beta.0` or newer.
 
 # Dependencies
 
@@ -45,6 +39,12 @@ Install NodeJS dependencies for the frontend:
 npm install
 ```
 
+Install `wasm-opt`:
+
+```
+cargo install wasm-opt
+```
+
 # Build
 
 ```
@@ -52,5 +52,5 @@ dfx start --background
 dfx deploy
 ```
 
-If the deployment is successfull, the it will show the `frontend` URL.
+If the deployment is successful, the it will show the `frontend` URL.
 Open that URL in browser to interact with the smart contract.

--- a/rust/image-classification/dfx.json
+++ b/rust/image-classification/dfx.json
@@ -7,7 +7,8 @@
       "wasm": "target/wasm32-wasi/release/backend-ic.wasm",
       "build": [
          "cargo build --release --target=wasm32-wasi",
-         "wasi2ic ./target/wasm32-wasi/release/backend.wasm ./target/wasm32-wasi/release/backend-ic.wasm"
+         "wasi2ic ./target/wasm32-wasi/release/backend.wasm ./target/wasm32-wasi/release/backend-ic.wasm",
+         "wasm-opt -Os -o ./target/wasm32-wasi/release/backend-ic.wasm ./target/wasm32-wasi/release/backend-ic.wasm"
        ]
  
     },

--- a/rust/image-classification/dfx.json
+++ b/rust/image-classification/dfx.json
@@ -5,12 +5,7 @@
       "package": "backend",
       "type": "custom",
       "wasm": "target/wasm32-wasi/release/backend-ic.wasm",
-      "build": [
-         "cargo build --release --target=wasm32-wasi",
-         "wasi2ic ./target/wasm32-wasi/release/backend.wasm ./target/wasm32-wasi/release/backend-ic.wasm",
-         "wasm-opt -Os -o ./target/wasm32-wasi/release/backend-ic.wasm ./target/wasm32-wasi/release/backend-ic.wasm"
-       ]
- 
+      "build": [ "bash build.sh" ]
     },
     "frontend": {
       "dependencies": [

--- a/rust/image-classification/src/backend/Cargo.toml
+++ b/rust/image-classification/src/backend/Cargo.toml
@@ -16,6 +16,6 @@ prost = "0.11.0"
 prost-types = "0.11.0"
 image = { version = "0.24", features = ["png"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-tract-onnx = { git = "https://github.com/sonos/tract", version = "=0.21.2-pre" }
+tract-onnx = { git = "https://github.com/sonos/tract", rev = "2a2914ac29390cc08963301c9f3d437b52dd321a" }
 ic-stable-structures = "0.6"
 ic-wasi-polyfill = { git = "https://github.com/wasm-forge/ic-wasi-polyfill", version = "0.3.17" }

--- a/rust/image-classification/src/backend/backend.did
+++ b/rust/image-classification/src/backend/backend.did
@@ -14,4 +14,5 @@ type ClassificationResult = variant {
 
 service : {
     "classify": (image: blob) -> (ClassificationResult);
+    "classify_query": (image: blob) -> (ClassificationResult) query;
 }

--- a/rust/image-classification/src/backend/src/lib.rs
+++ b/rust/image-classification/src/backend/src/lib.rs
@@ -1,6 +1,9 @@
-use std::cell::RefCell;
 use candid::{CandidType, Deserialize};
-use ic_stable_structures::{memory_manager::{MemoryId, MemoryManager}, DefaultMemoryImpl};
+use ic_stable_structures::{
+    memory_manager::{MemoryId, MemoryManager},
+    DefaultMemoryImpl,
+};
+use std::cell::RefCell;
 
 mod onnx;
 
@@ -31,8 +34,19 @@ enum ClassificationResult {
     Err(ClassificationError),
 }
 
-#[ic_cdk::update]
+#[ic_cdk::query]
 fn classify(image: Vec<u8>) -> ClassificationResult {
+    let result = match onnx::classify(image) {
+        Ok(result) => ClassificationResult::Ok(result),
+        Err(err) => ClassificationResult::Err(ClassificationError {
+            message: err.to_string(),
+        }),
+    };
+    result
+}
+
+#[ic_cdk::query]
+fn classify_query(image: Vec<u8>) -> ClassificationResult {
     let result = match onnx::classify(image) {
         Ok(result) => ClassificationResult::Ok(result),
         Err(err) => ClassificationResult::Err(ClassificationError {

--- a/rust/image-classification/src/declarations/backend/backend.did
+++ b/rust/image-classification/src/declarations/backend/backend.did
@@ -14,4 +14,5 @@ type ClassificationResult = variant {
 
 service : {
     "classify": (image: blob) -> (ClassificationResult);
+    "classify_query": (image: blob) -> (ClassificationResult) query;
 }

--- a/rust/image-classification/src/declarations/backend/backend.did.d.ts
+++ b/rust/image-classification/src/declarations/backend/backend.did.d.ts
@@ -8,6 +8,7 @@ export type ClassificationResult = { 'Ok' : Array<Classification> } |
   { 'Err' : ClassificationError };
 export interface _SERVICE {
   'classify' : ActorMethod<[Uint8Array | number[]], ClassificationResult>,
+  'classify_query' : ActorMethod<[Uint8Array | number[]], ClassificationResult>,
 }
 export declare const idlFactory: IDL.InterfaceFactory;
 export declare const init: (args: { IDL: typeof IDL }) => IDL.Type[];

--- a/rust/image-classification/src/declarations/backend/backend.did.js
+++ b/rust/image-classification/src/declarations/backend/backend.did.js
@@ -10,6 +10,11 @@ export const idlFactory = ({ IDL }) => {
   });
   return IDL.Service({
     'classify' : IDL.Func([IDL.Vec(IDL.Nat8)], [ClassificationResult], []),
+    'classify_query' : IDL.Func(
+        [IDL.Vec(IDL.Nat8)],
+        [ClassificationResult],
+        ['query'],
+      ),
   });
 };
 export const init = ({ IDL }) => { return []; };

--- a/rust/image-classification/src/frontend/assets/main.css
+++ b/rust/image-classification/src/frontend/assets/main.css
@@ -47,6 +47,7 @@ textarea {
     flex-flow: row;
     justify-content: left;
     align-items: center;
+    margin-bottom: 20px;
 }
 
 .toggle-switch {
@@ -71,7 +72,6 @@ textarea {
     bottom: 0;
     background-color: #ccc;
     border-radius: 18px;
-    transition: 0.4s;
 }
 
 .slider:before {
@@ -83,7 +83,6 @@ textarea {
     bottom: 1px;
     background-color: white;
     border-radius: 50%;
-    transition: 0.4s;
 }
 
 input:checked+.slider {
@@ -129,15 +128,15 @@ li {
 
 @keyframes astrodance {
     0% {
-        transform: translate(-50%,-50%) rotate(-20deg)
+        transform: translate(-50%, -50%) rotate(-20deg)
     }
 
     50% {
-        transform: translate(-50%,-50%) rotate(10deg)
+        transform: translate(-50%, -50%) rotate(10deg)
     }
 
     to {
-        transform: translate(-50%,-50%) rotate(-20deg)
+        transform: translate(-50%, -50%) rotate(-20deg)
     }
 }
 

--- a/rust/image-classification/src/frontend/src/index.html
+++ b/rust/image-classification/src/frontend/src/index.html
@@ -20,6 +20,15 @@
       <input id="file" class="file" name="file" type="file" accept="image/png, image/jpeg" />
       <div id="container">
         <div id="message"></div>
+        <div class="option invisible" id="replicated_option">
+          <label>
+            <div class="toggle-switch">
+              <input type="checkbox" id="replicated">
+              <span class="slider"></span>
+            </div>
+            &nbsp; replicated execution
+          </label>
+        </div>
         <img id="loader" src="loader.svg" class="loader invisible" />
         <button id="classify" class="clean-button invisible" disabled>Go!</button>
       </div>

--- a/rust/image-classification/src/frontend/src/index.js
+++ b/rust/image-classification/src/frontend/src/index.js
@@ -21,7 +21,7 @@ async function classify(event) {
 
   try {
     const blob = await resize(img);
-    let result;;
+    let result;
     if (document.getElementById("replicated").checked) {
       result = await backend.classify(new Uint8Array(blob));
     } else {

--- a/rust/image-classification/src/frontend/src/index.js
+++ b/rust/image-classification/src/frontend/src/index.js
@@ -11,15 +11,22 @@ async function classify(event) {
   const message = document.getElementById("message");
   const loader = document.getElementById("loader");
   const img = document.getElementById("image");
+  const repl_option = document.getElementById("replicated_option");
 
   button.disabled = true;
   button.className = "clean-button invisible";
+  repl_option.className = "option invisible";
   message.innerText = "Computing...";
   loader.className = "loader";
 
   try {
     const blob = await resize(img);
-    const result = await backend.classify(new Uint8Array(blob));
+    let result;;
+    if (document.getElementById("replicated").checked) {
+      result = await backend.classify(new Uint8Array(blob));
+    } else {
+      result = await backend.classify_query(new Uint8Array(blob));
+    }
     if (result.Ok) {
       render(message, result.Ok);
     } else {
@@ -77,6 +84,7 @@ async function onImageChange(event) {
   const button = document.getElementById("classify");
   const message = document.getElementById("message");
   const img = document.getElementById("image");
+  const repl_option = document.getElementById("replicated_option");
   try {
     const file = event.target.files[0];
     const url = await toDataURL(file);
@@ -89,6 +97,7 @@ async function onImageChange(event) {
   button.disabled = false;
   button.className = "clean-button";
   message.innerText = "";
+  repl_option.className = "option"
   return false;
 }
 


### PR DESCRIPTION
The mainnet and dfx version 0.20.2-beta.0 support Wasm SIMD. Sonos Tract also supports Wasm SIMD on `master`.

This PR updates the Sonos Tract dependency to the version that supports Wasm SIMD.

Now image classification can run in a query. The example is modified to add an option for running as a query or update.
