### PR TITLE
chore: update canister_logs examples with replicated query cases

### DIFF
--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -21,19 +21,24 @@ upgrade: build
 .SILENT: test
 test: install
 	# Test print via update call.
-	dfx canister call CanisterLogs print 'print via update call'
+	dfx canister call CanisterLogs print 'print via update'
 	dfx canister logs CanisterLogs \
-		| grep 'print via update call' && echo 'PASS'
+		| grep 'print via update' && echo 'PASS'
 
 	# Test print via replicated query call.
-	dfx canister call CanisterLogs print_query 'print via replicated query'
+	dfx canister call --update CanisterLogs print_query 'print via replicated query'
 	dfx canister logs CanisterLogs \
 		| grep 'print via replicated query' && echo 'PASS'
 
+	# Test print via non-replicated query call should NOT record the message.
+	dfx canister call --query CanisterLogs print_query 'print via non-replicated query'
+	! dfx canister logs CanisterLogs \
+		| grep 'print via non-replicated query' && echo 'PASS'
+
 	# Test trap, ignore failed call output.
-	-dfx canister call CanisterLogs trap 'trap_message'
+	-dfx canister call CanisterLogs trap 'trap via update'
 	dfx canister logs CanisterLogs \
-		| grep 'trap_message' && echo 'PASS'
+		| grep 'trap via update' && echo 'PASS'
 
 	# Test memory_oob, ignore failed call output.
 	-dfx canister call CanisterLogs memory_oob

--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -20,10 +20,15 @@ upgrade: build
 .PHONY: test
 .SILENT: test
 test: install
-	# Test print.
-	dfx canister call CanisterLogs print 'print_message'
+	# Test print via update call.
+	dfx canister call CanisterLogs print 'print via update call'
 	dfx canister logs CanisterLogs \
-		| grep 'print_message' && echo 'PASS'
+		| grep 'print via update call' && echo 'PASS'
+
+	# Test print via replicated query call.
+	dfx canister call CanisterLogs print_query 'print via replicated query'
+	dfx canister logs CanisterLogs \
+		| grep 'print via replicated query' && echo 'PASS'
 
 	# Test trap, ignore failed call output.
 	-dfx canister call CanisterLogs trap 'trap_message'

--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -20,9 +20,25 @@ upgrade: build
 .PHONY: test
 .SILENT: test
 test: install
-	dfx canister call CanisterLogs print 'hi'
+	# Test print.
+	dfx canister call CanisterLogs print 'print_message'
 	dfx canister logs CanisterLogs \
-		| grep 'hi' && echo 'PASS'
+		| grep 'print_message' && echo 'PASS'
+
+	# Test trap, ignore failed call output.
+	-dfx canister call CanisterLogs trap 'trap_message'
+	dfx canister logs CanisterLogs \
+		| grep 'trap_message' && echo 'PASS'
+
+	# Test memory_oob, ignore failed call output.
+	-dfx canister call CanisterLogs memory_oob
+	dfx canister logs CanisterLogs \
+		| grep 'StableMemory range out of bounds' && echo 'PASS'
+
+	# Test timer trap, assume it's been 5 seconds since the start.
+	sleep 2
+	dfx canister logs CanisterLogs \
+		| grep 'timer trap' && echo 'PASS'
 
 .PHONY: clean
 .SILENT: clean

--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -35,12 +35,14 @@ test: install
 	! dfx canister logs CanisterLogs \
 		| grep 'print via non-replicated query' && echo 'PASS'
 
-	# Test trap, ignore failed call output.
+	# Test trapped call is recorded in logs. 
+	# Ignore failed call output (so the test continues) and check the logs to contain the message.
 	-dfx canister call CanisterLogs trap 'trap via update'
 	dfx canister logs CanisterLogs \
 		| grep 'trap via update' && echo 'PASS'
 
-	# Test memory_oob, ignore failed call output.
+	# Test call to fail with memory out of bounds.
+	# Ignore failed call output (so the test continues) and check the logs to contain the message.
 	-dfx canister call CanisterLogs memory_oob
 	dfx canister logs CanisterLogs \
 		| grep 'StableMemory range out of bounds' && echo 'PASS'

--- a/motoko/canister_logs/src/Main.mo
+++ b/motoko/canister_logs/src/Main.mo
@@ -24,6 +24,10 @@ actor CanisterLogs {
     Debug.print(text);
   };
 
+  public query func print_query(text : Text) : async () {
+    Debug.print(text);
+  };
+
   public func trap(text : Text) : async () {
     Debug.print("right before trap");
     Debug.trap(text);

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -21,26 +21,31 @@ upgrade: build
 .SILENT: test
 test: install
 	# Test print via update call.
-	dfx canister call canister_logs print 'print via update call'
+	dfx canister call canister_logs print 'print via update'
 	dfx canister logs canister_logs \
-		| grep 'print via update call' && echo 'PASS'
+		| grep 'print via update' && echo 'PASS'
 
 	# Test print via replicated query call.
 	dfx canister call canister_logs print_query 'print via replicated query'
 	dfx canister logs canister_logs \
 		| grep 'print via replicated query' && echo 'PASS'
 
+	# Test print via non-replicated query call should NOT record the message.
+	dfx canister call --query canister_logs print_query 'print via non-replicated query'
+	! dfx canister logs canister_logs \
+		| grep 'print via non-replicated query' && echo 'PASS'
+
 	# Test trap, ignore failed call output.
-	-dfx canister call canister_logs trap 'trap_message'
+	-dfx canister call canister_logs trap 'trap via update'
 	dfx canister logs canister_logs \
-		| grep 'trap_message' && echo 'PASS'
+		| grep 'trap via update' && echo 'PASS'
 
 	# Test panic, ignore failed call output.
-	-dfx canister call canister_logs panic 'panic_message'
+	-dfx canister call canister_logs panic 'panic via update'
 	dfx canister logs canister_logs \
-		| grep 'panic_message' && echo 'PASS'
+		| grep 'panic via update' && echo 'PASS'
 
-	# Test memory_oob, ignore failed call output.
+	# # Test memory_oob, ignore failed call output.
 	-dfx canister call canister_logs memory_oob
 	dfx canister logs canister_logs \
 		| grep 'stable memory out of bounds' && echo 'PASS'

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -20,10 +20,15 @@ upgrade: build
 .PHONY: test
 .SILENT: test
 test: install
-	# Test print.
-	dfx canister call canister_logs print 'print_message'
+	# Test print via update call.
+	dfx canister call canister_logs print 'print via update call'
 	dfx canister logs canister_logs \
-		| grep 'print_message' && echo 'PASS'
+		| grep 'print via update call' && echo 'PASS'
+
+	# Test print via replicated query call.
+	dfx canister call canister_logs print_query 'print via replicated query'
+	dfx canister logs canister_logs \
+		| grep 'print via replicated query' && echo 'PASS'
 
 	# Test trap, ignore failed call output.
 	-dfx canister call canister_logs trap 'trap_message'

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -26,7 +26,7 @@ test: install
 		| grep 'print via update' && echo 'PASS'
 
 	# Test print via replicated query call.
-	dfx canister call canister_logs print_query 'print via replicated query'
+	dfx canister call --update canister_logs print_query 'print via replicated query'
 	dfx canister logs canister_logs \
 		| grep 'print via replicated query' && echo 'PASS'
 

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -35,22 +35,26 @@ test: install
 	! dfx canister logs canister_logs \
 		| grep 'print via non-replicated query' && echo 'PASS'
 
-	# Test trap, ignore failed call output.
+	# Test trapped call is recorded in logs. 
+	# Ignore failed call output (so the test continues) and check the logs to contain the message.
 	-dfx canister call canister_logs trap 'trap via update'
 	dfx canister logs canister_logs \
 		| grep 'trap via update' && echo 'PASS'
 
-	# Test panic, ignore failed call output.
+	# Test the call with panic is recorded in logs. 
+	# Ignore failed call output (so the test continues) and check the logs to contain the message.
 	-dfx canister call canister_logs panic 'panic via update'
 	dfx canister logs canister_logs \
 		| grep 'panic via update' && echo 'PASS'
 
-	# # Test memory_oob, ignore failed call output.
+	# Test call to fail with memory out of bounds.
+	# Ignore failed call output (so the test continues) and check the logs to contain the message.
 	-dfx canister call canister_logs memory_oob
 	dfx canister logs canister_logs \
 		| grep 'stable memory out of bounds' && echo 'PASS'
 
-	# Test failed_unwrap, ignore failed call output.
+	# Test call to fail with failed unwrap.
+	# Ignore failed call output (so the test continues) and check the logs to contain the message.
 	-dfx canister call canister_logs failed_unwrap
 	dfx canister logs canister_logs \
 		| grep 'Result::unwrap()' && echo 'PASS'

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -20,9 +20,34 @@ upgrade: build
 .PHONY: test
 .SILENT: test
 test: install
-	dfx canister call canister_logs print 'hi'
+	# Test print.
+	dfx canister call canister_logs print 'print_message'
 	dfx canister logs canister_logs \
-		| grep 'hi' && echo 'PASS'
+		| grep 'print_message' && echo 'PASS'
+
+	# Test trap, ignore failed call output.
+	-dfx canister call canister_logs trap 'trap_message'
+	dfx canister logs canister_logs \
+		| grep 'trap_message' && echo 'PASS'
+
+	# Test panic, ignore failed call output.
+	-dfx canister call canister_logs panic 'panic_message'
+	dfx canister logs canister_logs \
+		| grep 'panic_message' && echo 'PASS'
+
+	# Test memory_oob, ignore failed call output.
+	-dfx canister call canister_logs memory_oob
+	dfx canister logs canister_logs \
+		| grep 'stable memory out of bounds' && echo 'PASS'
+
+	# Test failed_unwrap, ignore failed call output.
+	-dfx canister call canister_logs failed_unwrap
+	dfx canister logs canister_logs \
+		| grep 'Result::unwrap()' && echo 'PASS'
+
+	# Test timer trap, assume it's been 5 seconds since the start.
+	dfx canister logs canister_logs \
+		| grep 'timer trap' && echo 'PASS'
 
 .PHONY: clean
 .SILENT: clean

--- a/rust/canister_logs/canister_logs.did
+++ b/rust/canister_logs/canister_logs.did
@@ -1,5 +1,6 @@
 service : {
     "print" : (text) -> ();
+    "print_query" : (text) -> () query;
     "trap" : (text) -> ();
     "panic" : (text) -> ();
     "memory_oob" : () -> ();

--- a/rust/canister_logs/src/lib.rs
+++ b/rust/canister_logs/src/lib.rs
@@ -1,4 +1,4 @@
-use ic_cdk::{init, post_upgrade, update};
+use ic_cdk::{init, post_upgrade, query, update};
 use std::time::Duration;
 
 const TIMER_INTERVAL_SEC: u64 = 5;
@@ -22,6 +22,11 @@ fn post_upgrade() {
 
 #[update]
 fn print(text: String) {
+    ic_cdk::print(text);
+}
+
+#[query]
+fn print_query(text: String) {
     ic_cdk::print(text);
 }
 


### PR DESCRIPTION
This PR adds more cases to the canister logging examples in Rust and Motoko.

Specifically it adds a case of recording logs in a query method called in replicated mode.
It also adds separate tests for each canister logging example case.