### PR TITLE
chore: update canister logging examples with trapped query calls

### DIFF
--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -41,6 +41,18 @@ test: install
 	dfx canister logs CanisterLogs \
 		| grep 'trap via update' && echo 'PASS'
 
+	# Test trap via replicated query call.
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call --update CanisterLogs trap_query 'trap via replicated query'
+	dfx canister logs CanisterLogs \
+		| grep 'trap via replicated query' && echo 'PASS'
+
+	# Test trap via non-replicated query call should NOT record the message.
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call --query CanisterLogs trap_query 'trap via non-replicated query'
+	! dfx canister logs CanisterLogs \
+		| grep 'trap via non-replicated query' && echo 'PASS'
+
 	# Test call to fail with memory out of bounds.
 	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
 	- dfx canister call CanisterLogs memory_oob

--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -50,7 +50,7 @@ test: install
 	# Test timer trap.
 	# The timer is setup to trap every 5 seconds, so this test has to be called 
 	# at least 5 seconds after the start to record the trap log message.
-	sleep 2  # This delay considers previous tests execution time.
+	sleep 5
 	dfx canister logs CanisterLogs \
 		| grep 'timer trap' && echo 'PASS'
 

--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -36,19 +36,21 @@ test: install
 		| grep 'print via non-replicated query' && echo 'PASS'
 
 	# Test trapped call is recorded in logs. 
-	# Ignore failed call output (so the test continues) and check the logs to contain the message.
-	-dfx canister call CanisterLogs trap 'trap via update'
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call CanisterLogs trap 'trap via update'
 	dfx canister logs CanisterLogs \
 		| grep 'trap via update' && echo 'PASS'
 
 	# Test call to fail with memory out of bounds.
-	# Ignore failed call output (so the test continues) and check the logs to contain the message.
-	-dfx canister call CanisterLogs memory_oob
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call CanisterLogs memory_oob
 	dfx canister logs CanisterLogs \
 		| grep 'StableMemory range out of bounds' && echo 'PASS'
 
-	# Test timer trap, assume it's been 5 seconds since the start.
-	sleep 2
+	# Test timer trap.
+	# The timer is setup to trap every 5 seconds, so this test has to be called 
+	# at least 5 seconds after the start to record the trap log message.
+	sleep 2  # This delay considers previous tests execution time.
 	dfx canister logs CanisterLogs \
 		| grep 'timer trap' && echo 'PASS'
 

--- a/motoko/canister_logs/src/Main.mo
+++ b/motoko/canister_logs/src/Main.mo
@@ -33,6 +33,11 @@ actor CanisterLogs {
     Debug.trap(text);
   };
 
+  public query func trap_query(text : Text) : async () {
+    Debug.print("right before trap_query");
+    Debug.trap(text);
+  };
+
   public func memory_oob() : async () {
     Debug.print("right before memory out of bounds");
     let offset : Nat64 = 10;

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -62,6 +62,7 @@ test: install
 	# Test timer trap.
 	# The timer is setup to trap every 5 seconds, so this test has to be called 
 	# at least 5 seconds after the start to record the trap log message.
+	sleep 5
 	dfx canister logs canister_logs \
 		| grep 'timer trap' && echo 'PASS'
 

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -36,30 +36,32 @@ test: install
 		| grep 'print via non-replicated query' && echo 'PASS'
 
 	# Test trapped call is recorded in logs. 
-	# Ignore failed call output (so the test continues) and check the logs to contain the message.
-	-dfx canister call canister_logs trap 'trap via update'
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call canister_logs trap 'trap via update'
 	dfx canister logs canister_logs \
 		| grep 'trap via update' && echo 'PASS'
 
 	# Test the call with panic is recorded in logs. 
-	# Ignore failed call output (so the test continues) and check the logs to contain the message.
-	-dfx canister call canister_logs panic 'panic via update'
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call canister_logs panic 'panic via update'
 	dfx canister logs canister_logs \
 		| grep 'panic via update' && echo 'PASS'
 
 	# Test call to fail with memory out of bounds.
-	# Ignore failed call output (so the test continues) and check the logs to contain the message.
-	-dfx canister call canister_logs memory_oob
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call canister_logs memory_oob
 	dfx canister logs canister_logs \
 		| grep 'stable memory out of bounds' && echo 'PASS'
 
 	# Test call to fail with failed unwrap.
-	# Ignore failed call output (so the test continues) and check the logs to contain the message.
-	-dfx canister call canister_logs failed_unwrap
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call canister_logs failed_unwrap
 	dfx canister logs canister_logs \
 		| grep 'Result::unwrap()' && echo 'PASS'
 
-	# Test timer trap, assume it's been 5 seconds since the start.
+	# Test timer trap.
+	# The timer is setup to trap every 5 seconds, so this test has to be called 
+	# at least 5 seconds after the start to record the trap log message.
 	dfx canister logs canister_logs \
 		| grep 'timer trap' && echo 'PASS'
 

--- a/rust/canister_logs/Makefile
+++ b/rust/canister_logs/Makefile
@@ -41,6 +41,18 @@ test: install
 	dfx canister logs canister_logs \
 		| grep 'trap via update' && echo 'PASS'
 
+	# Test trap via replicated query call.
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call --update canister_logs trap_query 'trap via replicated query'
+	dfx canister logs canister_logs \
+		| grep 'trap via replicated query' && echo 'PASS'
+
+	# Test trap via non-replicated query call should NOT record the message.
+	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
+	- dfx canister call --query canister_logs trap_query 'trap via non-replicated query'
+	! dfx canister logs canister_logs \
+		| grep 'trap via non-replicated query' && echo 'PASS'
+
 	# Test the call with panic is recorded in logs. 
 	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
 	- dfx canister call canister_logs panic 'panic via update'

--- a/rust/canister_logs/canister_logs.did
+++ b/rust/canister_logs/canister_logs.did
@@ -2,6 +2,7 @@ service : {
     "print" : (text) -> ();
     "print_query" : (text) -> () query;
     "trap" : (text) -> ();
+    "trap_query" : (text) -> () query;
     "panic" : (text) -> ();
     "memory_oob" : () -> ();
     "failed_unwrap" : () -> ();

--- a/rust/canister_logs/src/lib.rs
+++ b/rust/canister_logs/src/lib.rs
@@ -36,6 +36,12 @@ fn trap(message: String) {
     ic_cdk::trap(&message);
 }
 
+#[query]
+fn trap_query(message: String) {
+    ic_cdk::print("right before trap_query");
+    ic_cdk::trap(&message);
+}
+
 #[update]
 fn panic(message: String) {
     ic_cdk::print("right before panic");


### PR DESCRIPTION
This PR updates canister logging examples with trapped query calls in replicated and non-replicated modes.

It also improves tests' comments.