### PR TITLE
CRP-2532 remove mock API from Schnorr example since dfx now supports Schnorr

### DIFF
--- a/.github/workflows/motoko-threshold-schnorr-example.yaml
+++ b/.github/workflows/motoko-threshold-schnorr-example.yaml
@@ -23,7 +23,6 @@ jobs:
         run: |
           dfx start --background
           pushd motoko/threshold-schnorr
-          make mock
           make test
   motoko-threshold-schnorr-linux:
     runs-on: ubuntu-20.04
@@ -35,5 +34,4 @@ jobs:
         run: |
           dfx start --background
           pushd motoko/threshold-schnorr
-          make mock
           make test

--- a/.github/workflows/motoko-threshold-schnorr-example.yaml
+++ b/.github/workflows/motoko-threshold-schnorr-example.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Motoko Threshold Schnorr Darwin
         run: |
           dfx start --background
+          npm install @noble/curves
           pushd motoko/threshold-schnorr
           make test
   motoko-threshold-schnorr-linux:
@@ -33,5 +34,6 @@ jobs:
       - name: Motoko Threshold Schnorr Linux
         run: |
           dfx start --background
+          npm install @noble/curves
           pushd motoko/threshold-schnorr
           make test

--- a/.github/workflows/motoko-threshold-schnorr-example.yaml
+++ b/.github/workflows/motoko-threshold-schnorr-example.yaml
@@ -21,6 +21,7 @@ jobs:
         run: bash .github/workflows/provision-darwin.sh
       - name: Motoko Threshold Schnorr Darwin
         run: |
+          dfxvm default 0.22.0-beta.0
           dfx start --background
           npm install @noble/curves
           pushd motoko/threshold-schnorr
@@ -33,6 +34,7 @@ jobs:
         run: bash .github/workflows/provision-linux.sh
       - name: Motoko Threshold Schnorr Linux
         run: |
+          dfxvm default 0.22.0-beta.0
           dfx start --background
           npm install @noble/curves
           pushd motoko/threshold-schnorr

--- a/.github/workflows/rust-threshold-schnorr-example.yml
+++ b/.github/workflows/rust-threshold-schnorr-example.yml
@@ -25,6 +25,7 @@ jobs:
         run: bash .github/workflows/provision-pocket-ic-server.sh
       - name: Rust Threshold Schnorr Darwin
         run: |
+          dfxvm default 0.22.0-beta.0
           dfx start --background
           pushd rust/threshold-schnorr
           make deploy
@@ -41,6 +42,7 @@ jobs:
         run: bash .github/workflows/provision-pocket-ic-server.sh
       - name: Rust Threshold Schnorr Linux
         run: |
+          dfxvm default 0.22.0-beta.0
           dfx start --background
           pushd rust/threshold-schnorr
           make deploy

--- a/.github/workflows/rust-threshold-schnorr-example.yml
+++ b/.github/workflows/rust-threshold-schnorr-example.yml
@@ -27,9 +27,10 @@ jobs:
         run: |
           dfx start --background
           pushd rust/threshold-schnorr
-          make mock
-          sleep 10
-          make test
+          make deploy
+# This should be re-enabled when Pocket IC supports threshold Schnorr
+# sleep 10
+# make test
   rust-threshold-schnorr-linux:
     runs-on: ubuntu-20.04
     steps:
@@ -42,6 +43,7 @@ jobs:
         run: |
           dfx start --background
           pushd rust/threshold-schnorr
-          make mock
-          sleep 10
-          make test
+          make deploy
+# This should be re-enabled when Pocket IC supports threshold Schnorr
+# sleep 10
+# make test

--- a/motoko/threshold-schnorr/Makefile
+++ b/motoko/threshold-schnorr/Makefile
@@ -6,18 +6,9 @@ all: deploy
 deploy:
 	dfx deploy
 
-.PHONY: mock
-.SILENT: mock
-mock: deploy
-	SCHNORR_MOCK_CANISTER_ID=$(shell dfx canister id schnorr_canister); \
-	SCHNORR_EXAMPLE_CANISTER_ID=$(shell dfx canister id schnorr_example_motoko); \
-	echo "Changing to using mock canister instead of management canister for signing"; \
-	CMD="dfx canister call "$${SCHNORR_EXAMPLE_CANISTER_ID}" for_test_only_change_management_canister_id '("\"$${SCHNORR_MOCK_CANISTER_ID}\"")'"; \
-	eval "$${CMD}"
-
 .PHONY: test
 .SILENT: test
-test: mock
+test: deploy
 	bash test.sh hello
 
 .PHONY: clean

--- a/motoko/threshold-schnorr/README.md
+++ b/motoko/threshold-schnorr/README.md
@@ -29,13 +29,16 @@ More specifically:
 This tutorial gives a complete overview of the development, starting with downloading [`dfx`](https://internetcomputer.org/docs/current/developer-docs/setup/index.md), up to the deployment and trying out the code on the mainnet.
 
 This walkthrough focuses on the version of the sample canister code written in
-Motoko programming language.. There is also a
+Motoko programming language. There is also a
 [Rust](https://github.com/dfinity/examples/tree/master/rust/threshold-schnorr)
 version available in the same repo and follows the same commands for deploying.
 
 
 ## Prerequisites
--   [x] Download and [install the IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/index.md) if you do not already have it.
+-   [x] Download and [install the IC
+    SDK](https://internetcomputer.org/docs/current/developer-docs/setup/index.md)
+    if you do not already have it. For local testing, `dfx >= 0.22.0-beta.0` is
+    required.
 -   [x] Clone the example dapp project: `git clone https://github.com/dfinity/examples`
 
 ## Getting started
@@ -49,13 +52,12 @@ This tutorial will use the Motoko version of the canister:
 ```bash
 cd examples/motoko/threshold-schnorr
 dfx start --background
-npm install
-make deploy
+make test
 ```
 
 #### What this does
 - `dfx start --background` starts a local instance of the IC via the IC SDK
-- `make deploy` deploys the canister code on the local version of the IC
+- `make test` deploys the canister code on the local version of the IC
 
 If successful, you should see something like this:
 
@@ -67,8 +69,8 @@ URLs:
 ```
 
 If you open the URL in a web browser, you will see a web UI that shows the
-public methods the canister exposes. Since the canister exposes `public_key`,
-`sign`, and `verify` methods, those are rendered in the web UI.
+public methods the canister exposes. Since the canister exposes `public_key` and
+`sign`, those are rendered in the web UI.
 
 ### Deploying the canister on the mainnet
 
@@ -107,7 +109,6 @@ key ID in `src/schnorr_example_motoko/src/main.mo` must be consistent.
 To [deploy via the mainnet](https://internetcomputer.org/docs/current/developer-docs/setup/deploy-mainnet.md), run the following commands:
 
 ```bash
-npm install
 dfx deploy --network ic
 ```
 If successful, you should see something like this:
@@ -206,7 +207,11 @@ Computing threshold Schnorr signatures is the core functionality of this feature
 
 ## Signature verification
 
-For completeness of the example, we show that the created signatures can be verified with the public key corresponding to the same canister and derivation path.
+For completeness of the example, we show that the created signatures can be
+verified with the public key corresponding to the same canister and derivation
+path in javascript. Note that in contrast to the Rust implementation of this
+example, the signature verification is not part of the canister API and happens
+externally.
 
 Ed25519 can be verified as follows:
 ```javascript

--- a/motoko/threshold-schnorr/README.md
+++ b/motoko/threshold-schnorr/README.md
@@ -47,19 +47,30 @@ Sample code for `threshold-schnorr-example` is provided in the [examples reposit
 
 ### Deploy and test the canister locally 
 
-This tutorial will use the Motoko version of the canister:
+This tutorial will use the Motoko version of the canister.
 
+To deploy:
 ```bash
 cd examples/motoko/threshold-schnorr
 dfx start --background
+make deploy
+```
+
+To test (includes deploying):
+```bash
+cd examples/motoko/threshold-schnorr
+dfx start --background
+npm install @noble/curves
 make test
 ```
 
 #### What this does
 - `dfx start --background` starts a local instance of the IC via the IC SDK
-- `make test` deploys the canister code on the local version of the IC
+- `make deploy` deploys the canister code on the local version of the IC
+- `npm install @noble/curves` installs a test javascript dependency
+- `make test` deploys and tests the canister code on the local version of the IC
 
-If successful, you should see something like this:
+If deployment was successful, you should see something like this:
 
 ```bash
 Deployed canisters.

--- a/motoko/threshold-schnorr/README.md
+++ b/motoko/threshold-schnorr/README.md
@@ -128,8 +128,14 @@ If successful, you should see something like this:
 Deployed canisters.
 URLs:
   Backend canister via Candid interface:
-    schnorr_example_motoko: https://a3gq9-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=736w4-cyaaa-aaaal-qb3wq-cai
+    schnorr_example_motoko: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=enb64-iaaaa-aaaap-ahnkq-cai
 ```
+
+The implementation of this canister in Rust is (`schnorr_example_rust`) is
+deployed on mainnet. It has the URL
+https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=enb64-iaaaa-aaaap-ahnkq-cai
+and serves up the Candid web UI for this particular canister deployed on
+mainnet.
 
 ## Obtaining public keys
 

--- a/motoko/threshold-schnorr/README.md
+++ b/motoko/threshold-schnorr/README.md
@@ -13,13 +13,6 @@ We present a minimal example canister smart contract for showcasing the
 Schnorr](https://org5p-7iaaa-aaaak-qckna-cai.icp0.io/docs#ic-sign_with_schnorr)
 API.
 
-WARNING: the current version of this canister calls not the management canister
-but a custom canister, which produces Schnorr signatures in an INSECURE way.
-This is done for testing purposes ONLY and MUST NOT be done in production. In
-production, ONLY the management canister API MUST be used. The reason is that
-the management canister API is not yet fully implemented and instead of the
-management canister we use a mock canister that provides Schnorr signatures.
-
 The example canister is a signing oracle that creates Schnorr signatures with
 keys derived based on the canister ID and the chosen algorithm, either BIP340 or
 Ed25519.
@@ -57,14 +50,12 @@ This tutorial will use the Motoko version of the canister:
 cd examples/motoko/threshold-schnorr
 dfx start --background
 npm install
-make mock
+make deploy
 ```
 
 #### What this does
 - `dfx start --background` starts a local instance of the IC via the IC SDK
-- `make mock` deploys the canister code on the local version of the IC and
-  updates the canister ID that produces Schnorr signatures (see the WARNING at
-  the beginning of this document)
+- `make deploy` deploys the canister code on the local version of the IC
 
 If successful, you should see something like this:
 

--- a/motoko/threshold-schnorr/dfx.json
+++ b/motoko/threshold-schnorr/dfx.json
@@ -5,11 +5,6 @@
       "package": "schnorr_example_motoko",
       "main": "src/schnorr_example_motoko/main.mo",
       "type": "motoko"
-    },
-    "schnorr_canister": {
-      "type": "custom",
-      "candid": "https://github.com/domwoe/schnorr_canister/releases/download/v0.4.0//schnorr_canister.did",
-      "wasm": "https://github.com/domwoe/schnorr_canister/releases/download/v0.4.0/schnorr_canister.wasm.gz"
     }
   }
 }

--- a/motoko/threshold-schnorr/src/schnorr_example_motoko/main.mo
+++ b/motoko/threshold-schnorr/src/schnorr_example_motoko/main.mo
@@ -29,14 +29,6 @@ actor {
 
   var ic : IC = actor ("aaaaa-aa");
 
-  public func for_test_only_change_management_canister_id(mock_id : Text) : async {
-    #Ok : ();
-    #Err : Text;
-  } {
-    ic := actor (mock_id);
-    #Ok(());
-  };
-
   public shared ({ caller }) func public_key(algorithm_arg : SchnorrAlgorithm) : async {
     #Ok : { public_key_hex : Text };
     #Err : Text;

--- a/motoko/threshold-schnorr/test.sh
+++ b/motoko/threshold-schnorr/test.sh
@@ -10,27 +10,29 @@ function test_impl() {
     message="$1"
     echo message="$message"
 
-    ed25519_sign_cmd="dfx canister call schnorr_example_motoko sign '(\"${message}\" ,(variant { ed25519 }))'"
-    ed25519_sig_raw_output="$(eval ${ed25519_sign_cmd} | grep signature_hex)"
-    ed25519_sig_hex="$(get_text_in_double_quotes "${ed25519_sig_raw_output}")"
-    echo ed25519_signature_hex="$ed25519_sig_hex"
+#     This should be uncommented when dfx deploys an Ed25519 key
 
-    ed25519_public_key_raw_output="$(dfx canister call schnorr_example_motoko public_key '(variant { ed25519 })' | grep public_key_hex)"
-    ed25519_public_key_hex="$(get_text_in_double_quotes "${ed25519_public_key_raw_output}")"
-    echo ed25519_public_key_hex="$ed25519_public_key_hex"
+#     ed25519_sign_cmd="dfx canister call schnorr_example_motoko sign '(\"${message}\" ,(variant { ed25519 }))'"
+#     ed25519_sig_raw_output="$(eval ${ed25519_sign_cmd} | grep signature_hex)"
+#     ed25519_sig_hex="$(get_text_in_double_quotes "${ed25519_sig_raw_output}")"
+#     echo ed25519_signature_hex="$ed25519_sig_hex"
 
-    node <<END
-    import('@noble/curves/ed25519').then((ed25519) => { verify(ed25519.ed25519); })
-    .catch((err) => { console.log(err) });
+#     ed25519_public_key_raw_output="$(dfx canister call schnorr_example_motoko public_key '(variant { ed25519 })' | grep public_key_hex)"
+#     ed25519_public_key_hex="$(get_text_in_double_quotes "${ed25519_public_key_raw_output}")"
+#     echo ed25519_public_key_hex="$ed25519_public_key_hex"
 
-    function verify(ed25519) {
-        const sig = '${ed25519_sig_hex}';
-        const pubkey = '${ed25519_public_key_hex}';
-        const msg = Uint8Array.from(Buffer.from("${message}", 'utf8'));
+#     node <<END
+#     import('@noble/curves/ed25519').then((ed25519) => { verify(ed25519.ed25519); })
+#     .catch((err) => { console.log(err) });
 
-        console.log(ed25519.verify(sig, msg, pubkey));
-    }
-END
+#     function verify(ed25519) {
+#         const sig = '${ed25519_sig_hex}';
+#         const pubkey = '${ed25519_public_key_hex}';
+#         const msg = Uint8Array.from(Buffer.from("${message}", 'utf8'));
+
+#         console.log(ed25519.verify(sig, msg, pubkey));
+#     }
+# END
 
     bip340_sign_cmd="dfx canister call schnorr_example_motoko sign '(\"${message}\" ,(variant { bip340secp256k1 }))'"
     bip340_sig_raw_output="$(eval ${bip340_sign_cmd} | grep signature_hex)"
@@ -57,10 +59,10 @@ END
 
 test_output=$(test_impl "$1")
 echo $test_output
-if echo $test_output | grep "false"; then
-    echo "failed to validate signatures"
-    exit 1
-else
+if echo $test_output | grep "true"; then
     echo "successfully validated signatures"
     exit 0
+else
+    echo "failed to validate signatures"
+    exit 1
 fi

--- a/rust/threshold-schnorr/Cargo.lock
+++ b/rust/threshold-schnorr/Cargo.lock
@@ -39,6 +39,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,16 +829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,16 +854,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -969,29 +960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.5",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,8 +1016,10 @@ dependencies = [
 [[package]]
 name = "pocket-ic"
 version = "3.1.0"
-source = "git+https://github.com/dfinity/ic?rev=09f58cf9488a0afb2363e8a39b327176be6d7495#09f58cf9488a0afb2363e8a39b327176be6d7495"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9765eeff77b8750cf6258eaeea237b96607cd770aa3d4003f021924192b7e4e"
 dependencies = [
+ "async-trait",
  "base64 0.13.1",
  "candid",
  "hex",
@@ -1059,8 +1029,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2",
- "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1117,15 +1085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1194,7 +1153,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1377,12 +1335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,15 +1469,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1713,23 +1656,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -1899,15 +1828,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/rust/threshold-schnorr/Cargo.lock
+++ b/rust/threshold-schnorr/Cargo.lock
@@ -39,17 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-trait"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,12 +111,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -423,35 +406,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "errno"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -484,21 +442,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -737,22 +680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,10 +818,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.14"
+name = "lock_api"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -924,6 +855,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,23 +882,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1033,54 +957,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "paste"
@@ -1137,18 +1046,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "pocket-ic"
 version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9765eeff77b8750cf6258eaeea237b96607cd770aa3d4003f021924192b7e4e"
+source = "git+https://github.com/dfinity/ic?rev=09f58cf9488a0afb2363e8a39b327176be6d7495#09f58cf9488a0afb2363e8a39b327176be6d7495"
 dependencies = [
- "async-trait",
  "base64 0.13.1",
  "candid",
  "hex",
@@ -1158,6 +1059,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -1217,6 +1120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,13 +1174,12 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1278,13 +1189,12 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -1296,9 +1206,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
  "tokio-util",
@@ -1350,19 +1258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
-dependencies = [
- "bitflags 2.5.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1476,11 +1371,16 @@ dependencies = [
  "ic-cdk",
  "k256",
  "pocket-ic",
- "reqwest",
  "serde",
  "serde_bytes",
  "sha2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1502,7 +1402,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1527,9 +1427,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -1545,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1567,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1617,6 +1517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1718,39 +1627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
-dependencies = [
- "cfg-if",
- "fastrand",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,28 +1704,32 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-macros"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
- "native-tls",
- "tokio",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2021,6 +1901,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,12 +1958,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/rust/threshold-schnorr/Makefile
+++ b/rust/threshold-schnorr/Makefile
@@ -6,18 +6,9 @@ all: build
 deploy:
 	dfx deploy
 
-.PHONY: mock
-.SILENT: mock
-mock: deploy
-	SCHNORR_MOCK_CANISTER_ID=$(shell dfx canister id schnorr_canister); \
-	SCHNORR_EXAMPLE_CANISTER_ID=$(shell dfx canister id schnorr_example_rust); \
-	echo "Changing to using mock canister instead of management canister for signing"; \
-	CMD="dfx canister call "$${SCHNORR_EXAMPLE_CANISTER_ID}" for_test_only_change_management_canister_id '("\"$${SCHNORR_MOCK_CANISTER_ID}\"")'"; \
-	eval "$${CMD}"
-
 .PHONY: test
 .SILENT: test
-test: mock
+test:
 	cargo test
 
 .PHONY: clean

--- a/rust/threshold-schnorr/README.md
+++ b/rust/threshold-schnorr/README.md
@@ -35,7 +35,10 @@ version available in the same repo and follows the same commands for deploying.
 
 
 ## Prerequisites
--   [x] Download and [install the IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/index.md) if you do not already have it.
+-   [x] Download and [install the IC
+    SDK](https://internetcomputer.org/docs/current/developer-docs/setup/index.md)
+    if you do not already have it. For local testing, `dfx >= 0.22.0-beta.0` is
+    required.
 -   [x] Clone the example dapp project: `git clone https://github.com/dfinity/examples`
 
 ## Getting started
@@ -49,7 +52,6 @@ This tutorial will use the Rust version of the canister:
 ```bash
 cd examples/rust/threshold-schnorr
 dfx start --background
-npm install
 make deploy
 ```
 
@@ -108,7 +110,6 @@ Both uses of key ID in `src/schnorr_example_rust/src/lib.rs` must be consistent.
 To [deploy via the mainnet](https://internetcomputer.org/docs/current/developer-docs/setup/deploy-mainnet.md), run the following commands:
 
 ```bash
-npm install
 dfx deploy --network ic
 ```
 If successful, you should see something like this:

--- a/rust/threshold-schnorr/README.md
+++ b/rust/threshold-schnorr/README.md
@@ -45,7 +45,7 @@ version available in the same repo and follows the same commands for deploying.
 
 Sample code for `threshold-schnorr-example` is provided in the [examples repository](https://github.com/dfinity/examples), under either [`/motoko`](https://github.com/dfinity/examples/tree/master/motoko/threshold-schnorr) or [`/rust`](https://github.com/dfinity/examples/tree/master/rust/threshold-schnorr) sub-directories.
 
-### Deploy and test the canister locally 
+### Deploy the canister locally
 
 This tutorial will use the Rust version of the canister:
 

--- a/rust/threshold-schnorr/README.md
+++ b/rust/threshold-schnorr/README.md
@@ -13,13 +13,6 @@ We present a minimal example canister smart contract for showcasing the
 Schnorr](https://org5p-7iaaa-aaaak-qckna-cai.icp0.io/docs#ic-sign_with_schnorr)
 API.
 
-WARNING: the current version of this canister calls not the management canister
-but a custom canister, which produces Schnorr signatures in an INSECURE way.
-This is done for testing purposes ONLY and MUST NOT be done in production. In
-production, ONLY the management canister API MUST be used. The reason is that
-the management canister API is not yet fully implemented and instead of the
-management canister we use a mock canister that provides Schnorr signatures.
-
 The example canister is a signing oracle that creates Schnorr signatures with
 keys derived based on the canister ID and the chosen algorithm, either BIP340 or
 Ed25519.
@@ -57,14 +50,12 @@ This tutorial will use the Rust version of the canister:
 cd examples/rust/threshold-schnorr
 dfx start --background
 npm install
-make mock
+make deploy
 ```
 
 #### What this does
 - `dfx start --background` starts a local instance of the IC via the IC SDK
-- `make mock` deploys the canister code on the local version of the IC and
-  updates the canister ID that produces Schnorr signatures (see the WARNING at
-  the beginning of this document)
+- `make deploy` deploys the canister code on the local version of the IC
 
 If successful, you should see something like this:
 
@@ -165,7 +156,7 @@ async fn public_key(algorithm: SchnorrAlgorithm) -> Result<PublicKeyReply, Strin
     };
 
     let (res,): (ManagementCanisterSchnorrPublicKeyReply,) =
-        ic_cdk::call(mgmt_canister_id(), "schnorr_public_key", (request,))
+        ic_cdk::call(Principal::management_canister(), "schnorr_public_key", (request,))
             .await
             .map_err(|e| format!("schnorr_public_key failed {}", e.1))?;
 
@@ -210,7 +201,7 @@ async fn sign(message: String, algorithm: SchnorrAlgorithm) -> Result<SignatureR
 
     let (internal_reply,): (ManagementCanisterSignatureReply,) =
         ic_cdk::api::call::call_with_payment(
-            mgmt_canister_id(),
+            Principal::management_canister(),
             "sign_with_schnorr",
             (internal_request,),
             25_000_000_000,

--- a/rust/threshold-schnorr/README.md
+++ b/rust/threshold-schnorr/README.md
@@ -118,10 +118,10 @@ If successful, you should see something like this:
 Deployed canisters.
 URLs:
   Backend canister via Candid interface:
-    schnorr_example_rust: https://a3gq9-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=736w4-cyaaa-aaaal-qb3wq-cai
+    schnorr_example_rust: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=enb64-iaaaa-aaaap-ahnkq-cai
 ```
 
-# In the example above, `schnorr_example_rust` has the URL https://a3gq9-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=736w4-cyaaa-aaaal-qb3wq-cai and serves up the Candid web UI for this particular canister deployed on mainnet.
+In the example above, `schnorr_example_rust` has the URL https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=enb64-iaaaa-aaaap-ahnkq-cai and serves up the Candid web UI for this particular canister deployed on mainnet.
 
 ## Obtaining public keys
 

--- a/rust/threshold-schnorr/dfx.json
+++ b/rust/threshold-schnorr/dfx.json
@@ -4,11 +4,6 @@
       "candid": "src/schnorr_example_rust/schnorr_example.did",
       "package": "schnorr_example_rust",
       "type": "rust"
-    },
-    "schnorr_canister": {
-      "type": "custom",
-      "candid": "https://github.com/domwoe/schnorr_canister/releases/download/v0.4.0//schnorr_canister.did",
-      "wasm": "https://github.com/domwoe/schnorr_canister/releases/download/v0.4.0/schnorr_canister.wasm.gz"
     }
   }
 }

--- a/rust/threshold-schnorr/src/schnorr_example_rust/Cargo.toml
+++ b/rust/threshold-schnorr/src/schnorr_example_rust/Cargo.toml
@@ -20,4 +20,4 @@ serde_bytes = "0.11"
 
 [dev-dependencies]
 flate2 = "1.0"
-pocket-ic = { git = "https://github.com/dfinity/ic", rev = "09f58cf9488a0afb2363e8a39b327176be6d7495" }
+pocket-ic = "3.1"

--- a/rust/threshold-schnorr/src/schnorr_example_rust/Cargo.toml
+++ b/rust/threshold-schnorr/src/schnorr_example_rust/Cargo.toml
@@ -20,5 +20,4 @@ serde_bytes = "0.11"
 
 [dev-dependencies]
 flate2 = "1.0"
-pocket-ic = "3.1"
-reqwest = "0.12"
+pocket-ic = { git = "https://github.com/dfinity/ic", rev = "09f58cf9488a0afb2363e8a39b327176be6d7495" }

--- a/rust/threshold-schnorr/src/schnorr_example_rust/schnorr_example.did
+++ b/rust/threshold-schnorr/src/schnorr_example_rust/schnorr_example.did
@@ -1,7 +1,6 @@
 type SchnorrAlgorithm = variant {bip340secp256k1; ed25519};
 
 service : {
-  for_test_only_change_management_canister_id : (text) -> (variant { Ok: null; Err: text });
   public_key : (SchnorrAlgorithm) -> (variant { Ok: record { public_key_hex: text; }; Err: text });
   sign : (text, SchnorrAlgorithm) -> (variant { Ok: record { signature_hex: text; }; Err: text });
   verify : (text, text, text, SchnorrAlgorithm) -> (variant { Ok: record { is_signature_valid: bool; }; Err: text });

--- a/rust/threshold-schnorr/src/schnorr_example_rust/tests/tests.rs
+++ b/rust/threshold-schnorr/src/schnorr_example_rust/tests/tests.rs
@@ -23,18 +23,6 @@ fn signing_and_verification_should_work_correctly() {
 fn test_impl(pic: &PocketIc, algorithm: SchnorrAlgorithm) {
     let my_principal = Principal::anonymous();
 
-    // Create an empty canister as the anonymous principal and add cycles.
-    let schnorr_mock_canister_id = pic.create_canister();
-    pic.add_cycles(schnorr_mock_canister_id, 2_000_000_000_000);
-
-    let schnorr_mock_wasm_bytes = load_schnorr_mock_canister_wasm();
-    pic.install_canister(
-        schnorr_mock_canister_id,
-        schnorr_mock_wasm_bytes,
-        vec![],
-        None,
-    );
-
     // Create an empty example canister as the anonymous principal and add cycles.
     let example_canister_id = pic.create_canister();
     pic.add_cycles(example_canister_id, 2_000_000_000_000);
@@ -43,19 +31,6 @@ fn test_impl(pic: &PocketIc, algorithm: SchnorrAlgorithm) {
     pic.install_canister(example_canister_id, example_wasm_bytes, vec![], None);
 
     // Make sure the canister is properly initialized
-    fast_forward(&pic, 5);
-
-    let _dummy_reply: () = update(
-        &pic,
-        my_principal,
-        example_canister_id,
-        "for_test_only_change_management_canister_id",
-        encode_one(schnorr_mock_canister_id.to_text()).unwrap(),
-    )
-    .expect("failed to update management canister id");
-
-    // Make sure the example canister uses mock schnorr canister instead of
-    // the management canister
     fast_forward(&pic, 5);
 
     let message_hex = hex::encode("Test message");
@@ -199,15 +174,6 @@ fn load_schnorr_example_canister_wasm() -> Vec<u8> {
     let zipped_bytes = e.finish().unwrap();
 
     zipped_bytes
-}
-
-fn load_schnorr_mock_canister_wasm() -> Vec<u8> {
-    let wasm_url = "https://github.com/domwoe/schnorr_canister/releases/download/v0.4.0/schnorr_canister.wasm.gz";
-    reqwest::blocking::get(wasm_url)
-        .unwrap()
-        .bytes()
-        .unwrap()
-        .to_vec()
 }
 
 pub fn update<T: CandidType + for<'de> Deserialize<'de>>(


### PR DESCRIPTION

The rust tests were disabled because PocketIC doesn't yet support Schnorr but will in the future. Having this example without a mock seems more important than having tests enabled for a few weeks, therefore, the tests are disabled until PocketIC supports Schnorr.