### PR TITLE
chore: Add example of using bitcoin_get_block_headers to basic_bitcoin

### DIFF
--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -219,10 +219,7 @@ reflected in your current balance.
 You can also get a range of Bitcoin block headers by using the `get_block_headers` 
 endpoint on your canister.
 
-In the Candid UI, write the desired start height and optionally end height, and click on "Call":
-
-Alternatively, make the call using the command line. Be sure to replace `10` with your 
-desired start height:
+Make the call using the command line. Be sure to replace `10` with your desired start height:
 
 ```bash
 dfx canister --network=ic call basic_bitcoin get_block_headers "(10: nat32)"

--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -216,7 +216,7 @@ reflected in your current balance.
 
 ## Step 6: Retrieving block headers
 
-You can also get range of Bitcoin block headers by using the `get_block_headers` 
+You can also get a range of Bitcoin block headers by using the `get_block_headers` 
 endpoint on your canister.
 
 In the Candid UI, write the desired start height and optionally end height, and click on "Call":

--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -42,7 +42,7 @@ To clone and build the smart contract in **Rust**:
 ```bash
 git clone https://github.com/dfinity/examples
 cd examples/rust/basic_bitcoin
-cargo build --release --target wasm32-unknown unknown
+cargo build --release --target wasm32-unknown-unknown
 ```
 
 ### Acquire cycles to deploy
@@ -213,6 +213,26 @@ it sent to the network. You can track the status of this transaction using a
 [block explorer](https://en.bitcoin.it/wiki/Block_chain_browser). Once the
 transaction has at least one confirmation, you should be able to see it
 reflected in your current balance.
+
+## Step 6: Retrieving block headers
+
+You can also get range of Bitcoin block headers by using the `get_block_headers` 
+endpoint on your canister.
+
+In the Candid UI, write the desired start height and optionally end height, and click on "Call":
+
+Alternatively, make the call using the command line. Be sure to replace `10` with your 
+desired start height:
+
+```bash
+dfx canister --network=ic call basic_bitcoin get_block_headers "(10: nat32)"
+```
+or replace `0` and `11` with your desired start and end height respectively:
+```bash
+dfx canister --network=ic call basic_bitcoin get_block_headers "(0: nat32, 11: nat32)"
+```
+
+Checking the balance of a Bitcoin address relies on the [bitcoin_get_block_headers](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_block_headers) API.
 
 ## Conclusion
 

--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -232,8 +232,6 @@ or replace `0` and `11` with your desired start and end height respectively:
 dfx canister --network=ic call basic_bitcoin get_block_headers "(0: nat32, 11: nat32)"
 ```
 
-Checking the balance of a Bitcoin address relies on the [bitcoin_get_block_headers](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_block_headers) API.
-
 ## Conclusion
 
 In this tutorial, you were able to:

--- a/rust/basic_bitcoin/src/basic_bitcoin/basic_bitcoin.did
+++ b/rust/basic_bitcoin/src/basic_bitcoin/basic_bitcoin.did
@@ -32,6 +32,14 @@ type get_utxos_response = record {
   next_page : opt blob;
 };
 
+type block_header = blob;
+type block_height = nat32;
+
+type get_block_headers_response = record {
+  tip_height : block_height;
+  block_headers : vec block_header;
+};
+
 service : (network) -> {
   "get_p2pkh_address" : () -> (bitcoin_address);
 
@@ -42,6 +50,8 @@ service : (network) -> {
   "get_balance" : (address : bitcoin_address) -> (satoshi);
 
   "get_utxos" : (bitcoin_address) -> (get_utxos_response);
+
+  "get_block_headers" : (start_height : block_height, end_height : opt block_height) -> (get_block_headers_response);
 
   "get_current_fee_percentiles" : () -> (vec millisatoshi_per_vbyte);
 

--- a/rust/basic_bitcoin/src/basic_bitcoin/src/lib.rs
+++ b/rust/basic_bitcoin/src/basic_bitcoin/src/lib.rs
@@ -56,7 +56,7 @@ pub async fn get_utxos(address: String) -> GetUtxosResponse {
 pub type Height = u32;
 pub type BlockHeader = Vec<u8>;
 
-/// A request for getting the block headers from a given height.
+/// A request for getting the block headers for a given height range.
 #[derive(CandidType, Debug, Deserialize, PartialEq, Eq)]
 pub struct GetBlockHeadersRequest {
     pub start_height: Height,

--- a/rust/basic_bitcoin/src/basic_bitcoin/src/lib.rs
+++ b/rust/basic_bitcoin/src/basic_bitcoin/src/lib.rs
@@ -3,6 +3,7 @@ mod bitcoin_wallet;
 mod ecdsa_api;
 mod schnorr_api;
 
+use candid::{CandidType, Deserialize};
 use ic_cdk::api::management_canister::bitcoin::{
     BitcoinNetwork, GetUtxosResponse, MillisatoshiPerByte,
 };
@@ -50,6 +51,31 @@ pub async fn get_balance(address: String) -> u64 {
 pub async fn get_utxos(address: String) -> GetUtxosResponse {
     let network = NETWORK.with(|n| n.get());
     bitcoin_api::get_utxos(network, address).await
+}
+
+pub type Height = u32;
+pub type BlockHeader = Vec<u8>;
+
+/// A request for getting the block headers from a given height.
+#[derive(CandidType, Debug, Deserialize, PartialEq, Eq)]
+pub struct GetBlockHeadersRequest {
+    pub start_height: Height,
+    pub end_height: Option<Height>,
+    pub network: BitcoinNetwork,
+}
+
+/// The response returned for a request for getting the block headers from a given height.
+#[derive(CandidType, Debug, Deserialize, PartialEq, Eq, Clone)]
+pub struct GetBlockHeadersResponse {
+    pub tip_height: Height,
+    pub block_headers: Vec<BlockHeader>,
+}
+
+/// Returns the block headers in the given height range.
+#[update]
+pub async fn get_block_headers(start_height: u32, end_height: Option<u32>) -> GetBlockHeadersResponse{
+    let network = NETWORK.with(|n| n.get());
+    bitcoin_api::get_block_headers(network, start_height, end_height).await
 }
 
 /// Returns the 100 fee percentiles measured in millisatoshi/byte.


### PR DESCRIPTION
A new endpoint is added to Bitcoin canister, this PR shows its desired usage.