### PR TITLE
chore: Fix broken build script for basic_bitcoin canister

### DIFF
--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -219,7 +219,9 @@ reflected in your current balance.
 You can also get a range of Bitcoin block headers by using the `get_block_headers` 
 endpoint on your canister.
 
-Make the call using the command line. Be sure to replace `10` with your desired start height:
+In the Candid UI, write the desired start height and optionally end height, and click on "Call":
+
+Alternatively, make the call using the command line. Be sure to replace `10` with your desired start height:
 
 ```bash
 dfx canister --network=ic call basic_bitcoin get_block_headers "(10: nat32)"

--- a/rust/basic_bitcoin/dfx.json
+++ b/rust/basic_bitcoin/dfx.json
@@ -11,14 +11,7 @@
         {
           "name": "candid:service"
         }
-      ],
-      "specified_id": "om77v-qqaaa-aaaap-ahmrq-cai",
-      "remote": {
-        "id": {
-          "ic": "om77v-qqaaa-aaaap-ahmrq-cai",
-          "playground": "om77v-qqaaa-aaaap-ahmrq-cai"
-        }
-      }
+      ]
     }
   },
   "defaults": {

--- a/rust/basic_bitcoin/src/basic_bitcoin/build.sh
+++ b/rust/basic_bitcoin/src/basic_bitcoin/build.sh
@@ -21,7 +21,7 @@ cargo install ic-wasm --version 0.2.0 --root ./
 STATUS=$?
 
 if [[ "$STATUS" -eq "0" ]]; then
-  ./ic-wasm \
+  ./bin/ic-wasm \
       	"$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
       	-o "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
       	metadata candid:service -f "$SCRIPT_DIR/basic_bitcoin.did" -v public

--- a/rust/basic_bitcoin/src/basic_bitcoin/build.sh
+++ b/rust/basic_bitcoin/src/basic_bitcoin/build.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 TARGET="wasm32-unknown-unknown"
+CANISTER="basic_bitcoin"
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 pushd $SCRIPT_DIR
@@ -15,6 +16,11 @@ if [ "$(uname)" == "Darwin" ]; then
 else
   cargo build --target $TARGET --release
 fi
+
+ic-wasm \
+    	"$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
+    	-o "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
+    	metadata candid:service -f "$SCRIPT_DIR/basic_bitcoin.did" -v public
 
 popd
 

--- a/rust/basic_bitcoin/src/basic_bitcoin/build.sh
+++ b/rust/basic_bitcoin/src/basic_bitcoin/build.sh
@@ -18,18 +18,11 @@ else
 fi
 
 cargo install ic-wasm --version 0.2.0 --root ./
-STATUS=$?
 
-if [[ "$STATUS" -eq "0" ]]; then
-  ./bin/ic-wasm \
-      	"$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
-      	-o "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
-      	metadata candid:service -f "$SCRIPT_DIR/basic_bitcoin.did" -v public
-  true
-else
-  echo Could not install ic-wasm
-  false
-fi
+./bin/ic-wasm \
+      "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
+      -o "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
+      metadata candid:service -f "$SCRIPT_DIR/basic_bitcoin.did" -v public
 
 popd
 

--- a/rust/basic_bitcoin/src/basic_bitcoin/build.sh
+++ b/rust/basic_bitcoin/src/basic_bitcoin/build.sh
@@ -17,10 +17,19 @@ else
   cargo build --target $TARGET --release
 fi
 
-ic-wasm \
-    	"$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
-    	-o "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
-    	metadata candid:service -f "$SCRIPT_DIR/basic_bitcoin.did" -v public
+cargo install ic-wasm --version 0.2.0 --root ./
+STATUS=$?
+
+if [[ "$STATUS" -eq "0" ]]; then
+  ./ic-wasm \
+      	"$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
+      	-o "$SCRIPT_DIR/../../target/$TARGET/release/$CANISTER.wasm" \
+      	metadata candid:service -f "$SCRIPT_DIR/basic_bitcoin.did" -v public
+  true
+else
+  echo Could not install ic-wasm
+  false
+fi
 
 popd
 


### PR DESCRIPTION
**Overview**
Build script is outdated, this PR fixes the script to include candid in metadata properly.