### PR TITLE
Update subscriber.did with correct types

### DIFF
--- a/rust/pub-sub/src/subscriber/src/subscriber.did
+++ b/rust/pub-sub/src/subscriber/src/subscriber.did
@@ -1,8 +1,8 @@
-type Counter = variant {    
+type Counter = record {    
     topic : text;
     value:nat64;
 };
-type Subscriber = variant {
+type Subscriber = record {
     topic:text;
   };
 service : {


### PR DESCRIPTION
Counter and Subscriber are structs in Rust and therefore records in Candid. Variants are for Enums.

**Overview**
For correctness sake (esp. in beginner-friendly tutorials)

**Requirements**
Nothing.

**Considered Solutions**
The correct types.

**Recommended Solution**
Changing the candid to the correct types.

**Considerations**
Users will learn candid correctly.
