### PR TITLE
Add get_balance endpoint to the basic_ethereum example

### DIFF
--- a/rust/basic_ethereum/Cargo.toml
+++ b/rust/basic_ethereum/Cargo.toml
@@ -21,5 +21,6 @@ ic-crypto-extended-bip32 = { git = "https://github.com/dfinity/ic", tag = "relea
 ic-crypto-sha3 = { git = "https://github.com/dfinity/ic", tag = "release-2024-06-26_23-01-base", package = "ic-crypto-sha3" }
 ic-ethereum-types = { git = "https://github.com/dfinity/ic", tag = "release-2024-06-26_23-01-base", package = "ic-ethereum-types" }
 serde = "1.0"
+serde_json = "1.0"
 serde_bytes = "0.11.15"
 num-traits = "0.2.19"

--- a/rust/basic_ethereum/basic_ethereum.did
+++ b/rust/basic_ethereum/basic_ethereum.did
@@ -42,6 +42,9 @@ service : (opt InitArg) -> {
     // If the owner is not set, it defaults to the caller's principal.
     ethereum_address : (owner: opt principal) -> (text);
 
+    // Returns the balance of the given Ethereum address.
+    get_balance : (address: text) -> (Wei);
+
     // Returns the transaction count for the Ethereum address derived for the given principal.
     //
     // If the owner is not set, it defaults to the caller's principal.


### PR DESCRIPTION
The basic ethereum example shows how ETH can be sent to a canister and back.
However, once ETH are sent to the canister, a block explorer has to be used to see the balance of the canister.

This PR adds an endpoint to query the ETH balance of any account so that the use of a block explorer is not necessary.