### PR TITLE
Switching from Ankr to PublicNode as the single EVM RPC service

### DIFF
--- a/rust/basic_ethereum/basic_ethereum.did
+++ b/rust/basic_ethereum/basic_ethereum.did
@@ -9,7 +9,6 @@ type InitArg = record {
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
-    // The public Ethereum Sepolia testnet.
     Sepolia;
 };
 
@@ -43,7 +42,8 @@ service : (opt InitArg) -> {
     ethereum_address : (owner: opt principal) -> (text);
 
     // Returns the balance of the given Ethereum address.
-    get_balance : (address: text) -> (Wei);
+    // If no address is provided, the address derived from the caller's principal is used.
+    get_balance : (address: opt text) -> (Wei);
 
     // Returns the transaction count for the Ethereum address derived for the given principal.
     //

--- a/rust/basic_ethereum/basic_ethereum.did
+++ b/rust/basic_ethereum/basic_ethereum.did
@@ -9,6 +9,7 @@ type InitArg = record {
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
+    // The public Sepolia testnet.
     Sepolia;
 };
 

--- a/rust/basic_ethereum/basic_ethereum.did
+++ b/rust/basic_ethereum/basic_ethereum.did
@@ -9,7 +9,7 @@ type InitArg = record {
 type EthereumNetwork = variant {
     // The public Ethereum mainnet.
     Mainnet;
-    // The public Sepolia testnet.
+    // The public Ethereum Sepolia testnet.
     Sepolia;
 };
 

--- a/rust/basic_ethereum/src/lib.rs
+++ b/rust/basic_ethereum/src/lib.rs
@@ -37,8 +37,9 @@ pub async fn ethereum_address(owner: Option<Principal>) -> String {
 }
 
 #[update]
-pub async fn get_balance(address: String) -> Nat {
-    let _caller = validate_caller_not_anonymous();
+pub async fn get_balance(address: Option<String>) -> Nat {
+    let address = address.unwrap_or(ethereum_address(None).await);
+
     let json = format!(
         r#"{{ "jsonrpc": "2.0", "method": "eth_getBalance", "params": ["{}", "latest"], "id": 1 }}"#,
         address

--- a/rust/basic_ethereum/src/state.rs
+++ b/rust/basic_ethereum/src/state.rs
@@ -50,10 +50,10 @@ impl State {
     pub fn single_evm_rpc_service(&self) -> RpcServices {
         match self.ethereum_network {
             EthereumNetwork::Mainnet => {
-                RpcServices::EthMainnet(Some(vec![EthMainnetService::Ankr]))
+                RpcServices::EthMainnet(Some(vec![EthMainnetService::PublicNode]))
             }
             EthereumNetwork::Sepolia => {
-                RpcServices::EthSepolia(Some(vec![EthSepoliaService::Ankr]))
+                RpcServices::EthSepolia(Some(vec![EthSepoliaService::PublicNode]))
             }
         }
     }


### PR DESCRIPTION
Since `Ankr` stopped working, the `basic_ethereum` example should use a different provider.
This PR `changes` the provider to `PublicNode`.

The PR further makes the `address` parameter of `get_balance` optional for the sake of consistency.