### PR TITLE
fix: coinbase API

### DIFF
--- a/motoko/send_http_get/src/send_http_get_backend/main.mo
+++ b/motoko/send_http_get/src/send_http_get_backend/main.mo
@@ -64,7 +64,7 @@ actor {
     let ONE_MINUTE : Nat64 = 60;
     let start_timestamp : Types.Timestamp = 1682978460; //May 1, 2023 22:01:00 GMT
     let end_timestamp : Types.Timestamp = 1682978520;//May 1, 2023 22:02:00 GMT
-    let host : Text = "api.pro.coinbase.com";
+    let host : Text = "api.exchange.coinbase.com";
     let url = "https://" # host # "/products/ICP-USD/candles?start=" # Nat64.toText(start_timestamp) # "&end=" # Nat64.toText(start_timestamp) # "&granularity=" # Nat64.toText(ONE_MINUTE);
 
     // 2.2 prepare headers for the system http_request call

--- a/rust/send_http_get/src/send_http_get_backend/src/lib.rs
+++ b/rust/send_http_get/src/send_http_get_backend/src/lib.rs
@@ -25,7 +25,7 @@ async fn get_icp_usd_exchange() -> String {
     type Timestamp = u64;
     let start_timestamp: Timestamp = 1682978460; //May 1, 2023 22:01:00 GMT
     let seconds_of_time: u64 = 60; //we start with 60 seconds
-    let host = "api.pro.coinbase.com";
+    let host = "api.exchange.coinbase.com";
     let url = format!(
         "https://{}/products/ICP-USD/candles?start={}&end={}&granularity={}",
         host,


### PR DESCRIPTION
The `api.pro.coinbase.com` has been deprecated and thus this PR replaces `api.pro.coinbase.com` by `api.exchange.coinbase.com` in canister http outcall examples.