### PR TITLE
fix: dfx port in rust-nft-wallet tests

### DIFF
--- a/.github/workflows/rust-nft-wallet-example.yml
+++ b/.github/workflows/rust-nft-wallet-example.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Rust NFT Wallet Darwin
         run: |
           pushd rust/nft-wallet
-          dfx start --background --host 127.0.0.1:8000
+          dfx start --background --host 127.0.0.1:4943
           bash ./deploy.sh
           dfx canister call nftwallet owned_nfts
           popd
@@ -44,7 +44,7 @@ jobs:
       - name: Rust NFT Wallet Linux
         run: |
           pushd rust/nft-wallet
-          dfx start --background --host 127.0.0.1:8000
+          dfx start --background --host 127.0.0.1:4943
           bash ./deploy.sh
           dfx canister call nftwallet owned_nfts
           popd


### PR DESCRIPTION
This PR fixes the dfx port from 8000 to 4943 in rust-nft-wallet tests.