### PR TITLE
fix bitcoin config in rust basic_bitcoin

### DIFF
--- a/rust/basic_bitcoin/dfx.json
+++ b/rust/basic_bitcoin/dfx.json
@@ -26,5 +26,10 @@
       "packtool": "",
       "args": ""
     }
+  },
+  "networks": {
+    "local": {
+      "bind": "127.0.0.1:4943"
+    }
   }
 }


### PR DESCRIPTION
`dfx start` didn't instantiate the bitcoin canister unless `--enable-bitcoin` was passed. The change in the config fixes this.

Closes CRP-2566.