### PR TITLE
Add `llvm` with `wasm32-unknown-unknown` as requirement to rust basic bitcoin

### DIFF
--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -27,6 +27,9 @@ For a deeper understanding of the ICP < > BTC integration, see the [Bitcoin inte
   SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
   For local testing, `dfx >= 0.22.0-beta.0` is required.
 
+On Mac, `llvm` with the `wasm32-unknown-unknown` target (which is not included in the XCode installation by default) is required.
+To install, run `brew install llvm`.
+
 ## Step 1: Building and deploying sample code
 
 ### Clone the smart contract

--- a/rust/basic_bitcoin/README.md
+++ b/rust/basic_bitcoin/README.md
@@ -26,8 +26,7 @@ For a deeper understanding of the ICP < > BTC integration, see the [Bitcoin inte
 * [x] Install the [IC
   SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
   For local testing, `dfx >= 0.22.0-beta.0` is required.
-
-On Mac, `llvm` with the `wasm32-unknown-unknown` target (which is not included in the XCode installation by default) is required.
+* [x] On macOS, `llvm` with the `wasm32-unknown-unknown` target (which is not included in the XCode installation by default) is required.
 To install, run `brew install llvm`.
 
 ## Step 1: Building and deploying sample code


### PR DESCRIPTION
If `llvm` with `wasm32-unknown-unknown` is not installed, the compilation would error with something similar to
```
warning: error: unable to create target: 'No available targets are compatible with triple "wasm32-unknown-unknown"'
warning: 1 error generated.
warning: error: unable to create target: 'No available targets are compatible with triple "wasm32-unknown-unknown"'
warning: 1 error generated.

error: failed to run custom build command for `secp256k1-sys v0.9.2`
```

See https://github.com/rust-bitcoin/rust-bitcoin/issues/2331 for more details.