### PR TITLE
feat(basic_bitcoin): cache ecdsa

### DIFF
--- a/rust/basic_bitcoin/src/basic_bitcoin/src/ecdsa_api.rs
+++ b/rust/basic_bitcoin/src/basic_bitcoin/src/ecdsa_api.rs
@@ -2,9 +2,22 @@ use ic_cdk::api::management_canister::ecdsa::{
     ecdsa_public_key, sign_with_ecdsa, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument,
     SignWithEcdsaArgument,
 };
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+// stores the ecdsa to maintain state across different calls to the canister (not across updates)
+thread_local! {
+    /* flexible */ static ECDSA: RefCell<Option<HashMap<Vec<Vec<u8>> /*derivation path*/, Vec<u8> /*public key*/>>> = RefCell::default();
+}
 
 /// Returns the ECDSA public key of this canister at the given derivation path.
 pub async fn get_ecdsa_public_key(key_name: String, derivation_path: Vec<Vec<u8>>) -> Vec<u8> {
+    // Retrieve already stored public key
+    if let Some(key) = ECDSA.with(|ecdsa| {
+        ecdsa.borrow().as_ref().and_then(|map| map.get(&derivation_path).cloned())
+    }) {
+        return key;
+    }
     // Retrieve the public key of this canister at the given derivation path
     // from the ECDSA API.
     let canister_id = None;
@@ -15,12 +28,23 @@ pub async fn get_ecdsa_public_key(key_name: String, derivation_path: Vec<Vec<u8>
 
     let res = ecdsa_public_key(EcdsaPublicKeyArgument {
         canister_id,
-        derivation_path,
+        derivation_path: derivation_path.clone(),
         key_id,
     })
     .await;
 
-    res.unwrap().0.public_key
+    let public_key = res.unwrap().0.public_key;
+
+    // Cache the public key
+    ECDSA.with(|ecdsa| {
+        let mut map = ecdsa.borrow_mut();
+        if map.is_none() {
+            *map = Some(HashMap::new());
+        }
+        map.as_mut().unwrap().insert(derivation_path, public_key.clone());
+    });
+
+    public_key
 }
 
 pub async fn get_ecdsa_signature(


### PR DESCRIPTION

**Overview**
Why do we need this feature? What are we trying to accomplish?

The current process for retrieving a public key (via schnorr_public_key or ecdsa_public_key) takes approximately 9 seconds each time a user requests an address.  By storing public keys in a static variable, I want to improve performance and minimize cycle burn rate in the canister. It can serve as a good example for developers.

**Requirements**
What requirements are necessary to consider this problem solved?

Public keys should be stored in a static variable, allowing retrieval without calling the key generation functions every time.

**Considered Solutions**
What solutions were considered?

thread_local storage with static variables that do persist across calls, but not across updates. 

**Recommended Solution**
What solution are you recommending? Why?

Storing public keys in a static variable with HashMap for different derivation_paths

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

This solution will significantly improve performance and lower cycle burn rate
