### PR TITLE
chore: implement Internet Identity example recommendations

### DIFF
--- a/motoko/internet_identity_integration/src/greet_frontend/assets/main.css
+++ b/motoko/internet_identity_integration/src/greet_frontend/assets/main.css
@@ -10,20 +10,19 @@ img {
     margin: auto;
 }
 
-form {
+#buttons {
     display: flex;
     justify-content: center;
-    gap: 0.5em;
-    flex-flow: row wrap;
-    max-width: 40vw;
-    margin: auto;
+    gap: 1.5em;
+    flex-direction: column;
+    width: max-content;
+    margin: 1.5em auto;
     align-items: baseline;
 }
 
-button[type="submit"] {
+button {
     padding: 5px 20px;
-    margin: 10px auto;
-    float: right;
+    width: 100%;
 }
 
 #greeting {

--- a/motoko/internet_identity_integration/src/greet_frontend/src/index.html
+++ b/motoko/internet_identity_integration/src/greet_frontend/src/index.html
@@ -11,8 +11,10 @@
   <body>
     <main>
       <img src="logo2.svg" alt="DFINITY logo" />
-      <button id="login" type="button" disabled>Login!</button>
-      <button id="greet" type="button" disabled>Click Me!</button>
+      <section id="buttons">
+        <button id="login" type="button" disabled>Login!</button>
+        <button id="greet" type="button" disabled>Click Me!</button>
+      </section>
       <section id="greeting"></section>
     </main>
   </body>

--- a/motoko/internet_identity_integration/src/greet_frontend/src/index.html
+++ b/motoko/internet_identity_integration/src/greet_frontend/src/index.html
@@ -11,15 +11,8 @@
   <body>
     <main>
       <img src="logo2.svg" alt="DFINITY logo" />
-      <br />
-      <br />
-      <form>
-        <button id="login">Login!</button>
-      </form>
-      <br />
-      <form>
-        <button id="greet">Click Me!</button>
-      </form>
+      <button id="login" type="button" disabled>Login!</button>
+      <button id="greet" type="button" disabled>Click Me!</button>
       <section id="greeting"></section>
     </main>
   </body>

--- a/motoko/internet_identity_integration/src/greet_frontend/src/index.js
+++ b/motoko/internet_identity_integration/src/greet_frontend/src/index.js
@@ -1,48 +1,62 @@
-import {createActor, greet_backend} from "../../declarations/greet_backend";
-import {AuthClient} from "@dfinity/auth-client"
-import {HttpAgent} from "@dfinity/agent";
+import { createActor, greet_backend } from "../../declarations/greet_backend";
+import { AuthClient } from "@dfinity/auth-client";
+import { HttpAgent } from "@dfinity/agent";
 
-let actor = greet_backend;
+/**
+ * Put this on the window so we can access it from the console.
+ * This is helpful for learning, but it's recommended to keep it in a closure in a real app.
+ *
+ * We can use the default (not authenticated) greet_backend actor to call the greet method, and then update it once the authClient is ready, and again when the user logs in.
+ */
+window.greetActor = greet_backend;
 
 const greetButton = document.getElementById("greet");
-greetButton.onclick = async (e) => {
-    e.preventDefault();
-
-    greetButton.setAttribute("disabled", true);
-
-    // Interact with backend actor, calling the greet method
-    const greeting = await actor.greet();
-
-    greetButton.removeAttribute("disabled");
-
-    document.getElementById("greeting").innerText = greeting;
-
-    return false;
-};
-
 const loginButton = document.getElementById("login");
-loginButton.onclick = async (e) => {
-    e.preventDefault();
 
-    // create an auth client
-    let authClient = await AuthClient.create();
+AuthClient.create().then((client) => {
+  // Put this on the window so we can access it from the console. This is helpful for learning, but it's recommended to keep it in a closure in a real app.
+  window.authClient = client;
+  // We can use the authClient to check if the user is already authenticated
+  setActor(client);
 
-    // start the login process and wait for it to finish
-    await new Promise((resolve) => {
-        authClient.login({
-            identityProvider: process.env.II_URL,
-            onSuccess: resolve,
-        });
-    });
+  // Now that the auth client is created, we can enable the login and greet buttons
+  loginButton.removeAttribute("disabled");
+  greetButton.removeAttribute("disabled");
+});
 
-    // At this point we're authenticated, and we can get the identity from the auth client:
-    const identity = authClient.getIdentity();
-    // Using the identity obtained from the auth client, we can create an agent to interact with the IC.
-    const agent = new HttpAgent({identity});
-    // Using the interface description of our webapp, we create an actor that we use to call the service methods.
-    actor = createActor(process.env.GREET_BACKEND_CANISTER_ID, {
-        agent,
-    });
-
-    return false;
+loginButton.onclick = async () => {
+  // start the login process and wait for it to finish
+  window.authClient.login({
+    identityProvider: process.env.II_URL,
+    onSuccess: () => {
+      setActor(window.authClient);
+    },
+  });
 };
+
+greetButton.onclick = async () => {
+  // Disable the button to prevent multiple clicks
+  greetButton.setAttribute("disabled", true);
+
+  // Interact with backend actor, calling the greet method
+  const greeting = await window.greetActor.greet();
+
+  greetButton.removeAttribute("disabled");
+
+  document.getElementById("greeting").innerText = greeting;
+};
+
+/**
+ * Sets the actor to be used by the greet button
+ * @param {AuthClient} an initialized AuthClient, which will have the identity of the user (logged in or not)
+ */
+function setActor(authClient) {
+  // At this point we're authenticated, and we can get the identity from the auth client:
+  const identity = authClient.getIdentity();
+  // Using the identity obtained from the auth client, we can create an agent to interact with the IC.
+  const agent = new HttpAgent({ identity });
+  // Using the interface description of our webapp, we create an actor that we use to call the service methods.
+  window.greetActor = createActor(process.env.GREET_BACKEND_CANISTER_ID, {
+    agent,
+  });
+}


### PR DESCRIPTION
Here are some recommendations I have on best practices in the II example project.

## Important and functional changes
- AuthClient `create` should not be invoked during the `login` flow
  - Awaiting async behavior during the `click` event leads browsers to treat the interaction as a popup and reject it. This is a particular footgun for Safari mobile
  - fix: move AuthClient.create() into the global scope, and then update the Actor globally
- Disable `login` button and `greet` button until the authClient is ready
- Remove `Promise` wrapping of `login`
  - I get that `await` is fancy, but the actual browser API is based around callbacks and events, and `onSuccess` and `onError` are adequate.
  - Note: I would also accept the wrapping if it at least `reject`ed in the `onError` callback


## Less important (semantic HTML, a11y, and style)
- Using `window.greetActor` and `window.authClient` instead of local variables so new devs can play with the objects in the console. We **DO NOT** have to accept this change - it's just an idea I had
- The `form` elements are unnecessary without `input` elements, and don't add any semantic value. I prefer `<button type="button">` over an empty form, and then we don't need to handle `submit` events