### PR TITLE
fix(ci): use macos-15 instead of deprecated macos-12

### DIFF
--- a/.github/workflows/rust-threshold-mock-example.yml
+++ b/.github/workflows/rust-threshold-mock-example.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   rust-threshold-mock-darwin:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v1
       - name: Provision Darwin

--- a/.github/workflows/rust-x509-example.yml
+++ b/.github/workflows/rust-x509-example.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   rust-x509-darwin:
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v1
       - name: Provision Darwin


### PR DESCRIPTION
macos-12 runners have been deprecated and their CI jobs are [failing](https://github.com/dfinity/examples/actions/runs/11895652584/job/33147567361) by now