### PR TITLE
chore(IDX): replace PAT with GitHub App

### DIFF
--- a/.github/workflows/update-ic-commit.yml
+++ b/.github/workflows/update-ic-commit.yml
@@ -11,6 +11,13 @@ jobs:
   ic-update:
     runs-on: ubuntu-latest
     steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+          
       - uses: actions/checkout@v4
 
         # First, check if there is a newer version and update the file referencing the version
@@ -68,7 +75,7 @@ jobs:
         if: ${{ steps.update.outputs.updated == '1' }}
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GIX_CREATE_PR_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           base: master
           add-paths: ./.ic-commit
           commit-message: Update commit of IC artifacts


### PR DESCRIPTION
**Overview**
This is part of a larger effort to remove the need for PATs generated by service accounts and move them to GitHub apps.
