### PR TITLE
chore: Add Pocket-IC tests to the parallel calls example CI

### DIFF
--- a/.github/workflows/rust-parallel-calls-example.yml
+++ b/.github/workflows/rust-parallel-calls-example.yml
@@ -42,3 +42,26 @@ jobs:
           dfx start --background
           make test
           popd
+  rust-parallel-calls-pocket-ic-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
+      - name: Install PocketIC server
+        uses: dfinity/pocketic@main
+      - name: Test parallel calls with PocketIC
+        run: |
+          pushd rust/parallel_calls
+          cargo build --release --target wasm32-unknown-unknown -p callee
+          cargo build --release --target wasm32-unknown-unknown -p caller
+          export CALLER_WASM=$(cargo build --target wasm32-unknown-unknown -p caller --message-format=json \
+            | jq -r 'select(.reason == "compiler-artifact") | .filenames[] | select(endswith(".wasm"))')
+          export CALLEE_WASM=$(cargo build --target wasm32-unknown-unknown -p callee --message-format=json \
+            | jq -r 'select(.reason == "compiler-artifact") | .filenames[] | select(endswith(".wasm"))')
+          cargo run
+          popd
+          

--- a/rust/parallel_calls/Cargo.lock
+++ b/rust/parallel_calls/Cargo.lock
@@ -138,7 +138,7 @@ name = "callee"
 version = "0.1.0"
 dependencies = [
  "candid",
- "ic-cdk 0.15.1",
+ "ic-cdk",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ version = "0.1.0"
 dependencies = [
  "candid",
  "futures",
- "ic-cdk 0.15.1",
+ "ic-cdk",
 ]
 
 [[package]]
@@ -481,10 +481,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -601,63 +613,59 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.13.5"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1da6a25b045f9da3c9459c0cb2b0700ac368ee16382975a17185a23b9c18ab"
+checksum = "b2abdf9341da9f9f6b451a40609cb69645a05a8e9eb7784c16209f16f2c0f76f"
 dependencies = [
  "candid",
- "ic-cdk-macros 0.13.2",
- "ic0 0.21.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
-name = "ic-cdk"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
-dependencies = [
- "candid",
- "ic-cdk-macros 0.15.0",
- "ic0 0.23.0",
+ "ic-cdk-macros",
+ "ic0",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.13.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45800053d80a6df839a71aaea5797e723188c0b992618208ca3b941350c7355"
+checksum = "b8df41980e95dead28735ab0f748c75477b0c5eab37a09a5641c78ec406a1db0"
 dependencies = [
  "candid",
  "proc-macro2",
  "quote",
  "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af44fb4ec3a4b18831c9d3303ca8fa2ace846c4022d50cb8df4122635d3782e"
-dependencies = [
- "candid",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.2.2",
+ "serde_tokenstream",
  "syn 2.0.87",
 ]
 
 [[package]]
-name = "ic0"
-version = "0.21.1"
+name = "ic-certification"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
+checksum = "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_bytes",
+ "sha2",
+]
+
+[[package]]
+name = "ic-transport-types"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+dependencies = [
+ "candid",
+ "hex",
+ "ic-certification",
+ "leb128",
+ "serde",
+ "serde_bytes",
+ "serde_repr",
+ "sha2",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "ic0"
@@ -1069,25 +1077,31 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pocket-ic"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beff607d4dbebff8d003453ced669d2645e905de496ca93713f3d47633357e6c"
+checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
  "base64 0.13.1",
  "candid",
  "hex",
- "ic-cdk 0.13.5",
+ "ic-certification",
+ "ic-transport-types",
  "reqwest",
  "schemars",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_json",
  "sha2",
  "slog",
+ "strum",
+ "strum_macros",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "wslpath",
 ]
 
 [[package]]
@@ -1503,6 +1517,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1537,14 +1561,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_tokenstream"
-version = "0.1.7"
+name = "serde_repr"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797ba1d80299b264f3aac68ab5d12e5825a561749db4df7cd7c8083900c5d4e9"
+checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
- "serde",
- "syn 1.0.109",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1663,6 +1687,28 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2322,6 +2368,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wslpath"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
 name = "yoke"

--- a/rust/parallel_calls/src/callee/Cargo.toml
+++ b/rust/parallel_calls/src/callee/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.10"
-ic-cdk = "0.15"
+ic-cdk = "0.17"

--- a/rust/parallel_calls/src/caller/Cargo.toml
+++ b/rust/parallel_calls/src/caller/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candid = "0.10"
-ic-cdk = "0.15"
+ic-cdk = "0.17"
 futures = "0.3"

--- a/rust/parallel_calls/src/multi_subnet/Cargo.toml
+++ b/rust/parallel_calls/src/multi_subnet/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pocket-ic = "5.0.0"
+pocket-ic = "6.0.0"
 candid = "0.10"

--- a/rust/parallel_calls/src/multi_subnet/src/main.rs
+++ b/rust/parallel_calls/src/multi_subnet/src/main.rs
@@ -2,7 +2,7 @@ use candid::{decode_one, encode_one, Principal};
 use pocket_ic::{PocketIcBuilder, WasmResult};
 use std::time::Instant;
 
-const INIT_CYCLES: u128 = 2_000_000_000_000;
+const INIT_CYCLES: u128 = 10_000_000_000_000;
 
 fn main() {
     let num_calls: u64 = 90;
@@ -57,6 +57,9 @@ fn main() {
         WasmResult::Reject(code) => panic!("Unexpected reject code for parallel calls: {}", code),
     };
     let parallel_duration = parallel_start.elapsed();
+
+    assert_eq!(sequential_num_calls, num_calls, "Some sequential calls failed");
+    assert_eq!(parallel_num_calls, num_calls, "Some parallel calls failed");
 
     println!(
         "Sequential calls: {}/{} successful calls in {:?}",


### PR DESCRIPTION
The parallel calls Rust example demonstrate the performance difference between sequential and parallel calls using Pocket IC, but this hasn't been tested in CI so far (and in fact the example stopped working as expected after the cycles costs for inter-canister calls were increased).