### PR TITLE
Update Step 3 on README.md

### DIFF
--- a/rust/dip721-nft-container/README.md
+++ b/rust/dip721-nft-container/README.md
@@ -115,7 +115,7 @@ dfx start --background --clean
 
 Deploy the canister with the command:
 ```sh
-dfx deploy --no-wallet --argument \
+dfx deploy dip721_nft_container --no-wallet --argument \
 "(record {
     name = \"Numbers One Through Fifty\";
     symbol = \"NOTF\";


### PR DESCRIPTION
the dfx.json proposes a list of cannisters, so if you don't specify which canister you refeer you won't be able to pass the argument as you'll get the following error: Error: The init argument can only be set when deploying a single canister.

**Overview**
Why do we need this feature? What are we trying to accomplish?

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
