### PR TITLE
Upgrade to Node 22

### DIFF
--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -6,8 +6,8 @@ set -ex
 pushd /tmp
 
 # Install Node.
-wget --output-document install-node.sh "https://deb.nodesource.com/setup_14.x"
-sudo bash install-node.sh
+wget --output-document nodesource_setup.sh "https://deb.nodesource.com/setup_lts.x"
+sudo bash nodesource_setup.sh
 sudo apt-get install --yes nodejs
 rm install-node.sh
 
@@ -15,20 +15,20 @@ rm install-node.sh
 wget --output-document install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
 DFX_VERSION=${DFX_VERSION:=0.24.3} DFXVM_INIT_YES=true bash install-dfx.sh
 rm install-dfx.sh
-echo "$HOME/.local/share/dfx/bin" >> $GITHUB_PATH
+echo "$HOME/.local/share/dfx/bin" >>$GITHUB_PATH
 source "$HOME/.local/share/dfx/env"
 dfx cache install
 # check the current ic-commit found in the main branch, check if it differs from the one in this PR branch
 # if so, update the  dfx cache with the latest ic artifacts
 if [ -f "${GITHUB_WORKSPACE}/.ic-commit" ]; then
-    stable_sha=$(curl https://raw.githubusercontent.com/dfinity/examples/master/.ic-commit)
-    current_sha=$(sed <"$GITHUB_WORKSPACE/.ic-commit" 's/#.*$//' | sed '/^$/d')
-    arch="x86_64-linux"
-    if [ "$current_sha" != "$stable_sha" ]; then
-      export current_sha
-      export arch
-      sh "$GITHUB_WORKSPACE/.github/workflows/update-dfx-cache.sh"
-    fi
+  stable_sha=$(curl https://raw.githubusercontent.com/dfinity/examples/master/.ic-commit)
+  current_sha=$(sed <"$GITHUB_WORKSPACE/.ic-commit" 's/#.*$//' | sed '/^$/d')
+  arch="x86_64-linux"
+  if [ "$current_sha" != "$stable_sha" ]; then
+    export current_sha
+    export arch
+    sh "$GITHUB_WORKSPACE/.github/workflows/update-dfx-cache.sh"
+  fi
 fi
 
 # Install ic-repl
@@ -47,14 +47,14 @@ rustup target add wasm32-unknown-unknown
 
 # Install matchers
 matchers_version=1.2.0
-curl -fsSLO "https://github.com/kritzcreek/motoko-matchers/archive/refs/tags/v${matchers_version}.tar.gz" 
+curl -fsSLO "https://github.com/kritzcreek/motoko-matchers/archive/refs/tags/v${matchers_version}.tar.gz"
 tar -xzf "v${matchers_version}.tar.gz" --directory "$(dfx cache show)"
 rm "v${matchers_version}.tar.gz"
 mv "$(dfx cache show)/motoko-matchers-${matchers_version}" "$(dfx cache show)/motoko-matchers"
 
 # Install wasmtime
 wasmtime_version=0.33.1
-curl -fsSLO "https://github.com/bytecodealliance/wasmtime/releases/download/v${wasmtime_version}/wasmtime-v${wasmtime_version}-x86_64-linux.tar.xz" 
+curl -fsSLO "https://github.com/bytecodealliance/wasmtime/releases/download/v${wasmtime_version}/wasmtime-v${wasmtime_version}-x86_64-linux.tar.xz"
 mkdir -p "${HOME}/bin"
 tar -xf "wasmtime-v${wasmtime_version}-x86_64-linux.tar.xz" --directory "${HOME}/bin/"
 mv "${HOME}/bin/wasmtime-v${wasmtime_version}-x86_64-linux/wasmtime" "${HOME}/bin/wasmtime"
@@ -66,13 +66,13 @@ cargo install --path wasi2ic --root "${HOME}"
 
 # Install wasm-opt
 version=117
-curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_${version}-x86_64-linux.tar.gz" 
+curl -fsSLO "https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_${version}-x86_64-linux.tar.gz"
 tar -xzf "binaryen-version_${version}-x86_64-linux.tar.gz" --directory "${HOME}/" --strip-components 1
 rm "binaryen-version_${version}-x86_64-linux.tar.gz"
 
 # Set environment variables.
-echo "$HOME/bin" >> $GITHUB_PATH
-echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+echo "$HOME/bin" >>$GITHUB_PATH
+echo "$HOME/.cargo/bin" >>$GITHUB_PATH
 
 # Exit temporary directory.
 popd

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -9,7 +9,7 @@ pushd /tmp
 wget --output-document nodesource_setup.sh "https://deb.nodesource.com/setup_lts.x"
 sudo bash nodesource_setup.sh
 sudo apt-get install --yes nodejs
-rm install-node.sh
+rm nodesource_setup.sh
 
 # Install DFINITY SDK.
 wget --output-document install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"


### PR DESCRIPTION
This PR upgrades the node version to v22 in the `.github/workflows/provision-linux.sh` action. This resolves the CI issue for the `rust/parallel_calls` example. 

4/125 checks finished. The failing 4 are related to other issues, see for instance PR #1075.