### PR TITLE
fix(ICRC_Ledger): FI-1654: Update link to script that downloads latest ICRC ledger

### DIFF
--- a/motoko/token_transfer/README.md
+++ b/motoko/token_transfer/README.md
@@ -40,7 +40,7 @@ The URL for the ledger .did file is `https://raw.githubusercontent.com/dfinity/i
 If you want to make sure, you have the latest ICRC-1 ledger files you can run the following script.
 
 ```sh
-curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/1f1d8dd8c294d19a5551a022e3f00f25da7dc944/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
+curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/69988ae40e4cc0db7ef758da7dd5c0606075e926/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
 chmod +x download_latest_icrc1_ledger.sh
 ./download_latest_icrc1_ledger.sh
 ```

--- a/motoko/token_transfer_from/README.md
+++ b/motoko/token_transfer_from/README.md
@@ -40,7 +40,7 @@ The URL for the ledger .did file is `https://raw.githubusercontent.com/dfinity/i
 If you want to make sure, you have the latest ICRC-1 ledger files you can run the following script.
 
 ```sh
-curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/1f1d8dd8c294d19a5551a022e3f00f25da7dc944/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
+curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/69988ae40e4cc0db7ef758da7dd5c0606075e926/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
 chmod +x download_latest_icrc1_ledger.sh
 ./download_latest_icrc1_ledger.sh
 ```

--- a/rust/token_transfer/README.md
+++ b/rust/token_transfer/README.md
@@ -41,7 +41,7 @@ The URL for the ledger .did file is `https://raw.githubusercontent.com/dfinity/i
 If you want to make sure, you have the latest ICRC-1 ledger files you can run the following script.
 
 ```sh
-curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/1f1d8dd8c294d19a5551a022e3f00f25da7dc944/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
+curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/69988ae40e4cc0db7ef758da7dd5c0606075e926/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
 chmod +x download_latest_icrc1_ledger.sh
 ./download_latest_icrc1_ledger.sh
 ```

--- a/rust/token_transfer_from/README.md
+++ b/rust/token_transfer_from/README.md
@@ -40,7 +40,7 @@ The URL for the ledger .did file is `https://raw.githubusercontent.com/dfinity/i
 If you want to make sure, you have the latest ICRC-1 ledger files you can run the following script.
 
 ```sh
-curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/1f1d8dd8c294d19a5551a022e3f00f25da7dc944/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
+curl -o download_latest_icrc1_ledger.sh "https://raw.githubusercontent.com/dfinity/ic/69988ae40e4cc0db7ef758da7dd5c0606075e926/rs/rosetta-api/scripts/download_latest_icrc1_ledger.sh"
 chmod +x download_latest_icrc1_ledger.sh
 ./download_latest_icrc1_ledger.sh
 ```


### PR DESCRIPTION
The script that downloads the latest ICRC ledger `wasm` and `did` files was recently updated to download them using [the official ledger releases](https://github.com/dfinity/ic/releases?q=ledger-suite-icrc&expanded=false), rather than the latest commit on the `master` branch of the [ic](https://github.com/dfinity/ic) repository.

The links to the script in the documentation point to a specific commit in the `ic` repository. This PR proposes to update the links to the commit where the script was updated, so that users end up with an officially released ledger.