### PR TITLE
Explain how to use Rust for encrypted-notes-dapp-vetkd in README

### DIFF
--- a/motoko/encrypted-notes-dapp-vetkd/README.md
+++ b/motoko/encrypted-notes-dapp-vetkd/README.md
@@ -29,6 +29,12 @@ For **Motoko** deployment use:
 export BUILD_ENV=motoko
 ```
 
+For **Rust** deployment use:
+
+```sh
+export BUILD_ENV=rust
+```
+
 ## Step 2: To generate `$BUILD_ENV`-specific files run:
 
 ```sh


### PR DESCRIPTION
The encrypted-notes-dapp-vetkd that lives in the motoko folder can do both Rust and Motoko. The README needs to reflect this, so this PR basically re-applies https://github.com/dfinity/examples/pull/617, which apparently accidentally got lost via https://github.com/dfinity/examples/pull/705.