### PR TITLE
Pub sub "reloaded" --> new version of the pub-sub app

### DIFF
--- a/motoko/pub-sub-reloaded/Makefile
+++ b/motoko/pub-sub-reloaded/Makefile
@@ -1,0 +1,38 @@
+.PHONY: all
+all: build
+
+.PHONY: build
+.SILENT: build
+build:
+	dfx canister create --all
+	dfx build
+
+.PHONY: install
+.SILENT: install
+install: build
+	dfx canister install --all
+
+.PHONY: upgrade
+.SILENT: upgrade
+upgrade: build
+	dfx canister install --all --mode=upgrade
+
+.PHONY: test
+.SILENT: test
+test: install
+	dfx canister call sub init '("Apples")'
+	dfx canister call sub getCount \
+		| grep '(0 : nat)' && echo 'PASS'
+	dfx canister call pub publish '(record { "topic" = "Apples"; "value" = 2 })'
+	sleep 2 # Wait for update.
+	dfx canister call sub getCount \
+		| grep '(2 : nat)' && echo 'PASS'
+	dfx canister call pub publish '(record { "topic" = "Bananas"; "value" = 3 })'
+	sleep 2 # Wait for update.
+	dfx canister call sub getCount \
+		| grep '(2 : nat)' && echo 'PASS'
+
+.PHONY: clean
+.SILENT: clean
+clean:
+	rm -fr .dfx

--- a/motoko/pub-sub-reloaded/README.md
+++ b/motoko/pub-sub-reloaded/README.md
@@ -85,7 +85,7 @@ For example, the topic could be "Astronauts" and the value "5". Every time a mes
 
 So if a subscriber subscribes to "Astronauts", and then a Counter message is published with an "Astronauts" topic and a value of 5, and then another message with topic of "Astronauts" is published with value 3, the internal counter of the subscriber will be 8. Note that if a subscriber subscribes to multiple topics, the counter will maintain a unique sum for all of them.
 
-## Proposed Enhancements
+## Enhancements
 
 To make this small application more realistic, we will change the type of the broadcasted message to NewsMessage:
 
@@ -104,6 +104,89 @@ This change makes the example more intuitive by:
 - Replacing the arbitrary `value` field with a meaningful `readingTime` field that represents the estimated time to read the message
 
 The `readingTime` field maintains the original example's counter functionality (subscribers can track total reading time for their topics) while making the application represent a more realistic news broadcasting scenario.
+
+Therefore, the `count` state of the subscriber has been changed to `totalReadingTime`, which represents the time subscribers would have spent if they had read all the messages they subscribed to. In this context, it makes sense to have an increasing counter even if the subscriber subscribes to multiple topics, as it tracks total reading time across all subscriptions.
+
+The function `init` has been renamed to `subscribeToTopic` as it better reflects its purpose - it's not really initializing anything and can be called multiple times. The new name makes the function's behavior more explicit and self-documenting.
+
+Similarly, `updateCount` becomes `updateTotalReadingTime` to align with the new message type and state variable. This function now adds the reading time of each new message to the subscriber's total, providing a meaningful metric of content consumption.
+
+Finally, the query function `getCount` is renamed to `getTotalReadingTime` to maintain consistency with the new terminology and provide a clearer indication of what information it returns.
+
+### Summary of Changes
+
+1. Message Type:
+
+```motoko
+// OLD
+type Counter = {
+    topic : Text;
+    value : Nat;
+};
+
+// NEW
+type NewsMessage = {
+    topic : Text;
+    content : Text;
+    readingTime : Nat;
+};
+```
+
+2. Subscriber State:
+
+```motoko
+// OLD
+var count: Nat = 0;
+
+// NEW
+var totalReadingTime: Nat = 0;
+```
+
+3. Subscriber Functions:
+
+```motoko
+// OLD
+public func init(topic0 : Text)
+
+// NEW
+public func subscribeToTopic(subscribedTopic : Text)
+```
+
+```motoko
+// OLD
+public func updateCount(counter : Counter) {
+    count += counter.value;
+};
+
+// NEW
+public func updateTotalReadingTime(message : NewsMessage) {
+    totalReadingTime += message.readingTime;
+};
+```
+
+```motoko
+// OLD
+public query func getCount() : async Nat
+
+// NEW
+public query func getTotalReadingTime() : async Nat
+```
+
+4. Publisher Type:
+
+```motoko
+// OLD
+type Subscriber = {
+    topic : Text;
+    callback : shared Counter -> ();
+};
+
+// NEW
+type Subscriber = {
+    topic : Text;
+    callback : shared NewsMessage -> ();
+};
+```
 
 ## Prerequisites
 

--- a/motoko/pub-sub-reloaded/README.md
+++ b/motoko/pub-sub-reloaded/README.md
@@ -197,6 +197,14 @@ This example requires an installation of:
 
 Begin by opening a terminal window.
 
+In this example, we'll demonstrate how the pub/sub system works with three subscribers:
+
+- sub1: Will subscribe to both "Astronauts" and "Aliens" topics
+- sub2: Will subscribe only to "Astronauts" topic
+- sub3: Will subscribe only to "Aliens" topic
+
+This setup will show how subscribers can handle multiple topics and how different subscribers can receive updates for the same topic.
+
 ## Step 1: Setup the project environment
 
 Navigate into the folder containing the project's files and start a local instance of the Internet Computer with the commands:
@@ -212,29 +220,91 @@ dfx start --background
 dfx deploy
 ```
 
-## Step 3: Subscribe to the "Apples" topic
+## Step 3: Subscribe to the "Astronauts" topic
 
 ```bash
-dfx canister call sub init '("Apples")'
+dfx canister call sub1 subscribeToTopic '("Astronauts")'
 ```
 
-## Step 4: Publish to the "Apples" topic
+## Step 4: Publish news about the Moon landing
 
 ```bash
-dfx canister call pub publish '(record { "topic" = "Apples"; "value" = 2 })'
+dfx canister call pub publish '(record {
+    "topic" = "Astronauts";
+    "content" = "Historic moment: Humans first landed on the Moon!";
+    "readingTime" = 3
+})'
 ```
 
-## Step 5: Receive your subscription
+## Step 5: Check sub1's reading time
 
 ```bash
-dfx canister call sub getCount
+dfx canister call sub1 getTotalReadingTime
 ```
 
-The output should resemble the following:
+The output should be `(3 : nat)`, indicating 3 time units spent reading about the Moon landing.
+
+## Step 6: Add another subscriber to Astronauts
 
 ```bash
-(2 : nat)
+dfx canister call sub2 subscribeToTopic '("Astronauts")'
 ```
+
+## Step 7: Publish Mars mission news
+
+```bash
+dfx canister call pub publish '(record {
+    "topic" = "Astronauts";
+    "content" = "Elon Musk announces plans for first human Mars landing";
+    "readingTime" = 5
+})'
+```
+
+## Step 8: Check both subscribers' reading times
+
+```bash
+dfx canister call sub1 getTotalReadingTime
+dfx canister call sub2 getTotalReadingTime
+```
+
+Sub1 should show `(8 : nat)` (Moon + Mars news), while sub2 shows `(5 : nat)` (only Mars news).
+
+## Step 9: Subscribe to Aliens news
+
+```bash
+dfx canister call sub1 subscribeToTopic '("Aliens")'
+dfx canister call sub3 subscribeToTopic '("Aliens")'
+```
+
+## Step 10: Publish Aliens news
+
+```bash
+dfx canister call pub publish '(record {
+    "topic" = "Aliens";
+    "content" = "Today aliens have visited the Earth. They are green as expected. They came in peace";
+    "readingTime" = 4
+})'
+```
+
+## Step 11: Final reading time check
+
+```bash
+dfx canister call sub1 getTotalReadingTime
+dfx canister call sub2 getTotalReadingTime
+dfx canister call sub3 getTotalReadingTime
+```
+
+You should see:
+
+- sub1: `(12 : nat)` (Moon + Mars + Aliens news)
+- sub2: `(5 : nat)` (only Mars news)
+- sub3: `(4 : nat)` (only Aliens news)
+
+This demonstrates how:
+
+1. Subscribers can subscribe to multiple topics (sub1)
+2. Multiple subscribers can subscribe to the same topic (sub1 and sub2 for Astronauts)
+3. Reading times accumulate across all subscribed topics
 
 ## Security considerations and best practices
 

--- a/motoko/pub-sub-reloaded/README.md
+++ b/motoko/pub-sub-reloaded/README.md
@@ -1,0 +1,73 @@
+# PubSub Reloaded
+
+This project enhances the original [PubSub example](link-to-original) to provide a clearer demonstration of inter-canister calls on the Internet Computer, specifically showing how functions can be passed as arguments between canisters. While maintaining the simplicity of the original design, this version improves the architecture by:
+
+1. Clearly defining the three key roles in a pub/sub system:
+
+   - Publisher: manages subscriptions and broadcasts messages
+   - Subscribers: receive and process messages for their topics of interest
+   - Content Creator: generates the content to be published (previously implicit in the original design)
+
+2. Implementing a more intuitive message type: replacing the `Counter` type with a `NewsMessage` type that better represents a real-world pub/sub scenario
+
+3. Supporting multiple subscribers out of the box, with a pre-configured setup that demonstrates how multiple subscribers can receive updates for the same topics
+
+The example try to maintain the original's simplicity while providing a more practical and comprehensive demonstration of pub/sub principles.
+
+## Prerequisites
+
+This example requires an installation of:
+
+- [x] Install the [IC SDK](https://internetcomputer.org/docs/current/developer-docs/setup/install/index.mdx).
+- [x] Clone the example dapp project: `git clone https://github.com/dfinity/examples`
+
+Begin by opening a terminal window.
+
+## Step 1: Setup the project environment
+
+Navigate into the folder containing the project's files and start a local instance of the Internet Computer with the commands:
+
+```bash
+cd examples/motoko/pub-sub
+dfx start --background
+```
+
+## Step 2: Deploy the canisters:
+
+```bash
+dfx deploy
+```
+
+## Step 3: Subscribe to the "Apples" topic
+
+```bash
+dfx canister call sub init '("Apples")'
+```
+
+## Step 4: Publish to the "Apples" topic
+
+```bash
+dfx canister call pub publish '(record { "topic" = "Apples"; "value" = 2 })'
+```
+
+## Step 5: Receive your subscription
+
+```bash
+dfx canister call sub getCount
+```
+
+The output should resemble the following:
+
+```bash
+(2 : nat)
+```
+
+## Security considerations and best practices
+
+If you base your application on this example, we recommend you familiarize yourself with and adhere to the [security best practices](https://internetcomputer.org/docs/current/references/security/) for developing on the Internet Computer. This example may not implement all the best practices.
+
+For example, the following aspects are particularly relevant for this app, since it makes inter-canister calls:
+
+- [Be aware that state may change during inter-canister calls.](https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/overview)
+- [Only make inter-canister calls to trustworthy canisters.](https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/overview)
+- [Don't panic after await and don't lock shared resources across await boundaries.](https://internetcomputer.org/docs/current/developer-docs/security/security-best-practices/overview)

--- a/motoko/pub-sub-reloaded/dfx.json
+++ b/motoko/pub-sub-reloaded/dfx.json
@@ -1,0 +1,12 @@
+{
+  "canisters": {
+    "pub": {
+      "type": "motoko",
+      "main": "src/pub/Main.mo"
+    },
+    "sub": {
+      "type": "motoko",
+      "main": "src/sub/Main.mo"
+    }
+  }
+}

--- a/motoko/pub-sub-reloaded/dfx.json
+++ b/motoko/pub-sub-reloaded/dfx.json
@@ -4,7 +4,15 @@
       "type": "motoko",
       "main": "src/pub/Main.mo"
     },
-    "sub": {
+    "sub1": {
+      "type": "motoko",
+      "main": "src/sub/Main.mo"
+    },
+    "sub2": {
+      "type": "motoko",
+      "main": "src/sub/Main.mo"
+    },
+    "sub3": {
       "type": "motoko",
       "main": "src/sub/Main.mo"
     }

--- a/motoko/pub-sub-reloaded/src/pub/Main.mo
+++ b/motoko/pub-sub-reloaded/src/pub/Main.mo
@@ -1,0 +1,29 @@
+// Publisher
+import List "mo:base/List";
+
+actor Publisher {
+
+  type Counter = {
+    topic : Text;
+    value : Nat;
+  };
+
+  type Subscriber = {
+    topic : Text;
+    callback : shared Counter -> ();
+  };
+
+  stable var subscribers = List.nil<Subscriber>();
+
+  public func subscribe(subscriber : Subscriber) {
+    subscribers := List.push(subscriber, subscribers);
+  };
+
+  public func publish(counter : Counter) {
+    for (subscriber in List.toArray(subscribers).vals()) {
+      if (subscriber.topic == counter.topic) {
+        subscriber.callback(counter);
+      };
+    };
+  };
+}

--- a/motoko/pub-sub-reloaded/src/pub/Main.mo
+++ b/motoko/pub-sub-reloaded/src/pub/Main.mo
@@ -3,14 +3,15 @@ import List "mo:base/List";
 
 actor Publisher {
 
-  type Counter = {
+  type NewsMessage = {
     topic : Text;
-    value : Nat;
+    content : Text;
+    readingTime : Nat;
   };
 
   type Subscriber = {
     topic : Text;
-    callback : shared Counter -> ();
+    callback : shared NewsMessage -> ();
   };
 
   stable var subscribers = List.nil<Subscriber>();
@@ -19,10 +20,10 @@ actor Publisher {
     subscribers := List.push(subscriber, subscribers);
   };
 
-  public func publish(counter : Counter) {
+  public func publish(newsMessage : NewsMessage) {
     for (subscriber in List.toArray(subscribers).vals()) {
-      if (subscriber.topic == counter.topic) {
-        subscriber.callback(counter);
+      if (subscriber.topic == newsMessage.topic) {
+        subscriber.callback(newsMessage);
       };
     };
   };

--- a/motoko/pub-sub-reloaded/src/sub/Main.mo
+++ b/motoko/pub-sub-reloaded/src/sub/Main.mo
@@ -1,0 +1,28 @@
+// Subscriber
+
+import Publisher "canister:pub";
+
+actor Subscriber {
+
+  type Counter = {
+    topic : Text;
+    value : Nat;
+  };
+
+  var count: Nat = 0;
+
+  public func init(topic0 : Text) {
+    Publisher.subscribe({
+      topic = topic0;
+      callback = updateCount;
+    });
+  };
+
+  public func updateCount(counter : Counter) {
+    count += counter.value;
+  };
+
+  public query func getCount() : async Nat {
+    count;
+  };
+}

--- a/motoko/pub-sub-reloaded/src/sub/Main.mo
+++ b/motoko/pub-sub-reloaded/src/sub/Main.mo
@@ -20,8 +20,8 @@ type NewsMessage = {
     });
   };
 
-  public func updateCount(newsMessage : NewsMessage) {
-    totalReadingTime += newsMessage.readingTime;
+  public func updateTotalReadingTime(message : NewsMessage) {
+    totalReadingTime += message.readingTime;
   };
 
   public query func getTotalReadingTime() : async Nat {

--- a/motoko/pub-sub-reloaded/src/sub/Main.mo
+++ b/motoko/pub-sub-reloaded/src/sub/Main.mo
@@ -4,25 +4,28 @@ import Publisher "canister:pub";
 
 actor Subscriber {
 
-  type Counter = {
+
+type NewsMessage = {
     topic : Text;
-    value : Nat;
+    content : Text;
+    readingTime : Nat;
   };
 
-  var count: Nat = 0;
+  var totalReadingTime: Nat = 0;
 
-  public func init(topic0 : Text) {
+  public func subscribeToTopic(subscribedTopic : Text) {
     Publisher.subscribe({
-      topic = topic0;
-      callback = updateCount;
+      topic = subscribedTopic;
+      callback = updateTotalReadingTime;
     });
   };
 
-  public func updateCount(counter : Counter) {
-    count += counter.value;
+  public func updateCount(newsMessage : NewsMessage) {
+    totalReadingTime += newsMessage.readingTime;
   };
 
-  public query func getCount() : async Nat {
-    count;
+  public query func getTotalReadingTime() : async Nat {
+    totalReadingTime;
   };
 }
+


### PR DESCRIPTION
I tested it, it seems to work. 

**Overview**
Why do we need this feature? What are we trying to accomplish?

While working on the [2.2 of the "Motoko Developer Liftoff"](https://internetcomputer.org/docs/current/tutorials/developer-liftoff/level-2/2.2-advanced-canister-calls) I had some hard time to understand the example app. The course was pretty good till to this point. So I tried to rewrite the example in a more understandable way, without making too complicate, and also adding some documentation in the README to understand the PubSub app. Since the PubSub app is tied to the video, probably it doesn't make sense to replace them. But maybe this version could be added as a note at the end of the lesson. 

An explanation of the changes are in the README itself. 

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
