### PR TITLE
chore: Fixing the ECDSA test key name for local deployment of the basic Bitcoin dapp

### DIFF
--- a/rust/basic_bitcoin/src/basic_bitcoin/src/lib.rs
+++ b/rust/basic_bitcoin/src/basic_bitcoin/src/lib.rs
@@ -40,7 +40,7 @@ pub fn init(network: BitcoinNetwork) {
     KEY_NAME.with(|key_name| {
         key_name.replace(String::from(match network {
             // For local development, we use a special test key.
-            BitcoinNetwork::Regtest => "insecure_test_key_1",
+            BitcoinNetwork::Regtest => "dfx_test_key",
             // On the IC we're using a test ECDSA key.
             BitcoinNetwork::Mainnet | BitcoinNetwork::Testnet => "test_key_1",
         }))


### PR DESCRIPTION
The key `dfx_test_key` should be used for local development of Bitcoin dapps using `regtest` mode. This was changed when working on threshold Schnorr. As Schnorr signatures are supported now, the key name can be reverted to `dfx_test_key`.