### PR TITLE
Refactor(Rust/Hello-world): Update greet function to improve code

### DIFF
--- a/rust/hello_world/backend/lib.rs
+++ b/rust/hello_world/backend/lib.rs
@@ -32,8 +32,7 @@ fn set_greeting(prefix: String) {
 // This query method returns the currently persisted greeting with the given name.
 #[ic_cdk::query]
 fn greet(name: String) -> String {
-    let greeting = GREETING.with_borrow(|greeting| greeting.get().clone());
-    format!("{greeting}{name}!")
+    GREETING.with_borrow(|greeting| format!("{}{name}!", greeting.get()))
 }
 
 // Export the interface for the smart contract.


### PR DESCRIPTION
**Overview**
Why do we need this feature? What are we trying to accomplish?

This PR refactors the `greet` function to improve code clarity and efficiency by:

- Moving the string formatting inside the `with_borrow` closure
- Eliminating an unnecessary clone operation
- Maintaining the same functionality while reducing memory overhead

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

The change is safe because the formatted string is created and returned directly, removing the need for an intermediate variable and clone operation.
