### PR TITLE
fix: simplify ninja CI

### DIFF
--- a/.github/workflows/ninja_pr_checks.yml
+++ b/.github/workflows/ninja_pr_checks.yml
@@ -103,6 +103,5 @@ jobs:
       - name: Start dfx and build project
         working-directory: ${{ matrix.example.path }}
         run: |
-          # Note: Running these commands in the same step and with verbose output magically fixes the 502 Bad Gateway issue in dfx/pocketic for the LLM Chatbot example
-          RUST_LOG=trace dfx start --background --verbose
+          dfx start --background
           dfx deploy


### PR DESCRIPTION
This PR simplifies `RUST_LOG=trace dfx start --background --verbose` to `dfx start --background` because verbose output is actually not needed. What is needed is to run `dfx start --background` in the same step as `dfx deploy` (otherwise, the background process is terminated when the step that spawned it finishes before `dfx deploy` has completed). 