### PR TITLE
fixed frontend for llm chatbot upgrade to v1

### DIFF
--- a/motoko/llm_chatbot/frontend/src/main.jsx
+++ b/motoko/llm_chatbot/frontend/src/main.jsx
@@ -49,23 +49,36 @@ const App = () => {
   };
 
   const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!inputValue.trim() || isLoading) return;
+  e.preventDefault();
+  if (!inputValue.trim() || isLoading) return;
 
-    const userMessage = {
-      role: { user: null },
-      content: inputValue
-    };
-    const thinkingMessage = {
-      role: { system: null },
-      content: 'Thinking ...'
-    };
-    setChat((prevChat) => [...prevChat, userMessage, thinkingMessage]);
-    setInputValue('');
-    setIsLoading(true);
-    const messagesToSend = chat.slice(1).concat(userMessage);
-    askAgent(messagesToSend);
+  const userMessage = {
+    role: { user: null },
+    content: inputValue
   };
+  const thinkingMessage = {
+    role: { system: null },
+    content: 'Thinking ...'
+  };
+  setChat((prevChat) => [...prevChat, userMessage, thinkingMessage]);
+  setInputValue('');
+  setIsLoading(true);
+
+  // Transform internal format to Motoko-compatible variant
+  const rawMessages = chat.slice(1).concat(userMessage);
+  const messagesToSend = rawMessages.map((msg) => {
+    if ('user' in msg.role) {
+      return { user: { content: msg.content } };
+    }
+    if ('system' in msg.role) {
+      return { system: { content: msg.content } };
+    }
+    // Fallback
+    return { system: { content: msg.content } };
+  });
+
+  askAgent(messagesToSend);
+};
 
   useEffect(() => {
     if (chatBoxRef.current) {

--- a/motoko/llm_chatbot/frontend/src/main.jsx
+++ b/motoko/llm_chatbot/frontend/src/main.jsx
@@ -61,7 +61,6 @@ const App = () => {
     setInputValue('');
     setIsLoading(true);
 
-    // No conversion needed - messages are already in backend format!
     const messagesToSend = chat.slice(1).concat(userMessage);
     askAgent(messagesToSend);
   };

--- a/rust/llm_chatbot/frontend/src/main.jsx
+++ b/rust/llm_chatbot/frontend/src/main.jsx
@@ -49,23 +49,36 @@ const App = () => {
   };
 
   const handleSubmit = (e) => {
-    e.preventDefault();
-    if (!inputValue.trim() || isLoading) return;
+  e.preventDefault();
+  if (!inputValue.trim() || isLoading) return;
 
-    const userMessage = {
-      role: { user: null },
-      content: inputValue
-    };
-    const thinkingMessage = {
-      role: { system: null },
-      content: 'Thinking ...'
-    };
-    setChat((prevChat) => [...prevChat, userMessage, thinkingMessage]);
-    setInputValue('');
-    setIsLoading(true);
-    const messagesToSend = chat.slice(1).concat(userMessage);
-    askAgent(messagesToSend);
+  const userMessage = {
+    role: { user: null },
+    content: inputValue
   };
+  const thinkingMessage = {
+    role: { system: null },
+    content: 'Thinking ...'
+  };
+  setChat((prevChat) => [...prevChat, userMessage, thinkingMessage]);
+  setInputValue('');
+  setIsLoading(true);
+
+  // Transform internal format to Motoko-compatible variant
+  const rawMessages = chat.slice(1).concat(userMessage);
+  const messagesToSend = rawMessages.map((msg) => {
+    if ('user' in msg.role) {
+      return { user: { content: msg.content } };
+    }
+    if ('system' in msg.role) {
+      return { system: { content: msg.content } };
+    }
+    // Fallback
+    return { system: { content: msg.content } };
+  });
+
+  askAgent(messagesToSend);
+};
 
   useEffect(() => {
     if (chatBoxRef.current) {

--- a/rust/llm_chatbot/frontend/src/main.jsx
+++ b/rust/llm_chatbot/frontend/src/main.jsx
@@ -61,7 +61,6 @@ const App = () => {
     setInputValue('');
     setIsLoading(true);
 
-    // No conversion needed - messages are already in backend format!
     const messagesToSend = chat.slice(1).concat(userMessage);
     askAgent(messagesToSend);
   };


### PR DESCRIPTION
Fixes the frontend issues with the llm chatbot example. The issue was that the frontend was not adapted to take care of the new backend variant.

The solution to this type incompatibility is to transform the existing type (which is still in use for the frontend) into the needed variant before calling the backend.

This has been tested with copy-pasting the main.jsx into the [Next-Ninja llm-chatbot projects](https://next-icp.ninja/projects/llm-chatbot) and deploying the dapp.