### PR TITLE
chore: Use parentheticals to attach cycles

### DIFF
--- a/motoko/send_http_get/src/send_http_get_backend/main.mo
+++ b/motoko/send_http_get/src/send_http_get_backend/main.mo
@@ -1,5 +1,4 @@
 import Blob "mo:base/Blob";
-import Cycles "mo:base/ExperimentalCycles";
 import Nat64 "mo:base/Nat64";
 import Text "mo:base/Text";
 import IC "ic:aaaaa-aa";

--- a/motoko/send_http_get/src/send_http_get_backend/main.mo
+++ b/motoko/send_http_get/src/send_http_get_backend/main.mo
@@ -58,22 +58,10 @@ actor {
       };
     };
 
-    //2. ADD CYCLES TO PAY FOR HTTP REQUEST
+    //2. MAKE HTTPS REQUEST AND WAIT FOR RESPONSE, BUT MAKE SURE TO ADD CYCLES.
+    let http_response : IC.http_request_result = await (with cycles = 230_949_972_000) IC.http_request(http_request);
 
-    //IC management canister will make the HTTP request so it needs cycles
-    //See: https://internetcomputer.org/docs/current/motoko/main/cycles
-
-    //The way Cycles.add() works is that it adds those cycles to the next asynchronous call
-    //See:
-    // - https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-http_request
-    // - https://internetcomputer.org/docs/current/references/https-outcalls-how-it-works#pricing
-    // - https://internetcomputer.org/docs/current/developer-docs/gas-cost
-    Cycles.add<system>(230_949_972_000);
-
-    //3. MAKE HTTPS REQUEST AND WAIT FOR RESPONSE
-    let http_response : IC.http_request_result = await IC.http_request(http_request);
-
-    //4. DECODE THE RESPONSE
+    //3. DECODE THE RESPONSE
 
     //As per the type declarations, the BODY in the HTTP response
     //comes back as Blob. Type signature:
@@ -93,7 +81,7 @@ actor {
       case (?y) { y };
     };
 
-    //5. RETURN RESPONSE OF THE BODY
+    //4. RETURN RESPONSE OF THE BODY
     //The API response will looks like this:
     //
     // ("[[1682978460,5.714,5.718,5.714,5.714,243.5678]]")

--- a/motoko/send_http_post/src/send_http_post_backend/main.mo
+++ b/motoko/send_http_post/src/send_http_post_backend/main.mo
@@ -1,5 +1,4 @@
 import Blob "mo:base/Blob";
-import Cycles "mo:base/ExperimentalCycles";
 import Text "mo:base/Text";
 import IC "ic:aaaaa-aa";
 

--- a/motoko/send_http_post/src/send_http_post_backend/main.mo
+++ b/motoko/send_http_post/src/send_http_post_backend/main.mo
@@ -56,22 +56,10 @@ actor {
       };
     };
 
-    //2. ADD CYCLES TO PAY FOR HTTP REQUEST
+    //2. MAKE HTTPS REQUEST AND WAIT FOR RESPONSE, BUT MAKE SURE TO ADD CYCLES.
+    let http_response : IC.http_request_result = await (with cycles = 230_949_972_000) IC.http_request(http_request);
 
-    //IC management canister will make the HTTP request so it needs cycles
-    //See: https://internetcomputer.org/docs/current/motoko/main/cycles
-
-    //The way Cycles.add() works is that it adds those cycles to the next asynchronous call
-    //See: 
-    // - https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-http_request
-    // - https://internetcomputer.org/docs/current/references/https-outcalls-how-it-works#pricing
-    // - https://internetcomputer.org/docs/current/developer-docs/gas-cost
-    Cycles.add<system>(230_850_258_000);
-
-    //3. MAKE HTTPS REQUEST AND WAIT FOR RESPONSE
-    let http_response : IC.http_request_result = await IC.http_request(http_request);
-
-    //4. DECODE THE RESPONSE
+    //3. DECODE THE RESPONSE
 
     //As per the type declarations, the BODY in the HTTP response
     //comes back as Blob. Type signature:
@@ -91,7 +79,7 @@ actor {
       case (?y) { y };
     };
 
-    //5. RETURN RESPONSE OF THE BODY
+    //4. RETURN RESPONSE OF THE BODY
     let result : Text = decoded_text # ". See more info of the request sent at: " # url # "/inspect";
     result;
   };


### PR DESCRIPTION
This PR updates the motoko http outcall examples to use the parenthetical notation instead of the deprecated way to attach cycles.

