### PR TITLE
Fixing basic_bitcoin clippy suggestions

### DIFF
--- a/rust/basic_bitcoin/src/lib.rs
+++ b/rust/basic_bitcoin/src/lib.rs
@@ -17,9 +17,9 @@ use std::cell::Cell;
 /// This struct carries network-specific context:
 /// - `network`: The ICP Bitcoin API network enum.
 /// - `bitcoin_network`: The corresponding network enum from the `bitcoin` crate, used
-///    for address formatting and transaction construction.
+///   for address formatting and transaction construction.
 /// - `key_name`: The global ECDSA key name used when requesting derived keys or making
-///    signatures. Different key names are used locally and when deployed on the IC.
+///   signatures. Different key names are used locally and when deployed on the IC.
 ///
 /// Note: Both `network` and `bitcoin_network` are needed because ICP and the
 /// Bitcoin library use distinct network enum types.

--- a/rust/basic_bitcoin/src/ordinals.rs
+++ b/rust/basic_bitcoin/src/ordinals.rs
@@ -48,7 +48,7 @@ pub(crate) async fn build_reveal_transaction(
         let transaction = build_reveal_transaction_with_fee(
             reveal_script,
             control_block,
-            &commit_tx_id,
+            commit_tx_id,
             destination_address,
             fee,
         )
@@ -93,7 +93,7 @@ pub fn build_reveal_transaction_with_fee(
 
     // Create output that sends remaining funds (minus fee) to destination.
     // The inscription is now "bound" to these satoshis according to ordinal theory.
-    // In production: Ensure the fee is smaller than the output value to avoid 
+    // In production: Ensure the fee is smaller than the output value to avoid
     // underflow scenarios.
     let output = TxOut {
         value: Amount::from_sat(INSCRIPTION_OUTPUT_VALUE - fee),

--- a/rust/basic_bitcoin/src/runes.rs
+++ b/rust/basic_bitcoin/src/runes.rs
@@ -197,19 +197,19 @@ pub fn build_etching_script(etching: &Etching) -> Result<ScriptBuf, String> {
         }
         if let Some(start) = terms.height.0 {
             payload.extend_from_slice(&encode_leb128(Tag::HeightStart as u64));
-            payload.extend_from_slice(&encode_leb128(start as u64));
+            payload.extend_from_slice(&encode_leb128(start));
         }
         if let Some(end) = terms.height.1 {
             payload.extend_from_slice(&encode_leb128(Tag::HeightEnd as u64));
-            payload.extend_from_slice(&encode_leb128(end as u64));
+            payload.extend_from_slice(&encode_leb128(end));
         }
         if let Some(start) = terms.offset.0 {
             payload.extend_from_slice(&encode_leb128(Tag::OffsetStart as u64));
-            payload.extend_from_slice(&encode_leb128(start as u64));
+            payload.extend_from_slice(&encode_leb128(start));
         }
         if let Some(end) = terms.offset.1 {
             payload.extend_from_slice(&encode_leb128(Tag::OffsetEnd as u64));
-            payload.extend_from_slice(&encode_leb128(end as u64));
+            payload.extend_from_slice(&encode_leb128(end));
         }
     }
 

--- a/rust/basic_bitcoin/src/service/etch_rune.rs
+++ b/rust/basic_bitcoin/src/service/etch_rune.rs
@@ -91,7 +91,7 @@ pub async fn etch_rune(name: String) -> String {
     // Build the runestone script containing the rune metadata.
     // This creates the OP_RETURN output that defines the new token.
     let runestone_script = build_etching_script(&etching)
-        .unwrap_or_else(|e| trap(&format!("Failed to build runestone: {}", e)));
+        .unwrap_or_else(|e| trap(format!("Failed to build runestone: {}", e)));
 
     // Build the rune etching transaction.
     // The transaction includes an OP_RETURN output with the encoded runestone.


### PR DESCRIPTION
Fixed some minor clippy suggestions on the `basic_bitcoin` example.