### PR TITLE
fix: Fix link in ICP Ninja deployment of guards example

### DIFF
--- a/rust/guards/README.md
+++ b/rust/guards/README.md
@@ -27,7 +27,7 @@ until completion directly, everything will be executed in a single message.
 
 ## Deploying from ICP Ninja
 
-[![](https://icp.ninja/assets/open.svg)](https://icp.ninja/editor?g=https://github.com/dfinity/examples/tree/master/rust/counter)
+[![](https://icp.ninja/assets/open.svg)](https://icp.ninja/editor?g=https://github.com/dfinity/examples/tree/master/rust/guards)
 
 ## Build and deploy from the command-line
 


### PR DESCRIPTION
Currently, the ICP Ninja deployment link for the `guards` example mistakenly points to the `counter` example code. Fix this so that the right project is deployed to ICP Ninja.