### PR TITLE
Update Motoko examples to use new standard library

### DIFF
--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/BitcoinApi.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/BitcoinApi.mo
@@ -1,4 +1,4 @@
-import ExperimentalCycles "mo:base/ExperimentalCycles";
+import ExperimentalCycles "mo:core/Cycles";
 
 import Types "Types";
 

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/EcdsaApi.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/EcdsaApi.mo
@@ -1,4 +1,4 @@
-import ExperimentalCycles "mo:base/ExperimentalCycles";
+import ExperimentalCycles "mo:core/ExperimentalCycles";
 
 import Types "Types";
 

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/Main.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/Main.mo
@@ -1,4 +1,4 @@
-import Principal "mo:base/Principal";
+import Princimo:core/base/Principal";
 import Text "mo:base/Text";
 import Array "mo:base/Array";
 import Blob "mo:base/Blob";

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/Utils.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/Utils.mo
@@ -1,9 +1,9 @@
-import Result "mo:base/Result";
-import Debug "mo:base/Debug";
-import Iter "mo:base/Iter";
-import Nat8 "mo:base/Nat8";
-import Prelude "mo:base/Prelude";
-import Text "mo:base/Text";
+import Result "mo:core/Result";
+import Debug "mo:core/Debug";
+import Iter "mo:core/Iter";
+import Nat8 "mo:core/Nat8";
+import Prelude "mo:core/Prelude";
+import Text "mo:core/Text";
 import Blob "mo:base/Blob";
 import Array "mo:base/Array";
 import Types "Types";

--- a/motoko/cert-var/src/cert_var/main.mo
+++ b/motoko/cert-var/src/cert_var/main.mo
@@ -1,10 +1,10 @@
-/// Simple counter (see `Counter.mo`), but uses `mo:base/CertifiedData` to
+/// Simple counter (see `Counter.mo`), but uses `mo:core/CertifiedData` to
 /// implement the counter value as a certified variable.
-import CD "mo:base/CertifiedData";
-import Blob "mo:base/Blob";
-import Nat8 "mo:base/Nat8";
-import Nat32 "mo:base/Nat32";
-import Debug "mo:base/Debug";
+import CD "mo:core/CertifiedData";
+import Blob "mo:core/Blob";
+import Nat8 "mo:core/Nat8";
+import Nat32 "mo:core/Nat32";
+import Debug "mo:core/Debug";
 
 actor Variable {
 

--- a/motoko/classes/src/map/Buckets.mo
+++ b/motoko/classes/src/map/Buckets.mo
@@ -1,5 +1,5 @@
-import Nat "mo:base/Nat";
-import Map "mo:base/RBTree";
+import Nat "mo:core/Nat";
+import Map "mo:core/RBTree";
 
 actor class Bucket(n : Nat, i : Nat) {
 

--- a/motoko/classes/src/map/Map.mo
+++ b/motoko/classes/src/map/Map.mo
@@ -1,5 +1,5 @@
-import Array "mo:base/Array";
-import Cycles "mo:base/ExperimentalCycles";
+import Array "mo:core/Array";
+import Cycles "mo:core/Cycles";
 import Buckets "Buckets";
 
 actor Map {

--- a/motoko/classes/src/test/Test.mo
+++ b/motoko/classes/src/test/Test.mo
@@ -1,4 +1,4 @@
-import Debug "mo:base/Debug";
+import Debug "mo:core/Debug";
 import Map "canister:map";
 
 actor Test {

--- a/motoko/composite_query/src/map/Buckets.mo
+++ b/motoko/composite_query/src/map/Buckets.mo
@@ -1,5 +1,5 @@
-import Nat "mo:base/Nat";
-import Map "mo:base/RBTree";
+import Nat "mo:core/Nat";
+import Map "mo:core/RBTree";
 
 actor class Bucket(n : Nat, i : Nat) {
 

--- a/motoko/composite_query/src/map/Map.mo
+++ b/motoko/composite_query/src/map/Map.mo
@@ -1,6 +1,6 @@
-import Debug "mo:base/Debug";
-import Array "mo:base/Array";
-import Cycles "mo:base/ExperimentalCycles";
+import Debug "mo:core/Debug";
+import Array "mo:core/Array";
+import Cycles "mo:core/Cycles";
 import Buckets "Buckets";
 
 actor Map {

--- a/motoko/hello_cycles/src/hello_cycles/main.mo
+++ b/motoko/hello_cycles/src/hello_cycles/main.mo
@@ -1,6 +1,6 @@
-import Nat "mo:base/Nat";
-import Nat64 "mo:base/Nat64";
-import Cycles "mo:base/ExperimentalCycles";
+import Nat "mo:core/Nat";
+import Nat64 "mo:core/Nat64";
+import Cycles "mo:core/Cycles";
 
 actor HelloCycles  {
 

--- a/motoko/ic-pos/src/icpos/main.mo
+++ b/motoko/ic-pos/src/icpos/main.mo
@@ -1,21 +1,21 @@
 // Importing base modules
-import Array "mo:base/Array";
-import Blob "mo:base/Blob";
-import Cycles "mo:base/ExperimentalCycles";
-import Debug "mo:base/Debug";
-import Nat "mo:base/Nat";
-import Nat64 "mo:base/Nat64";
-import Principal "mo:base/Principal";
-import Text "mo:base/Text";
-import Time "mo:base/Time";
-import Trie "mo:base/Trie";
-import Buffer "mo:base/Buffer";
-
-// Importing local modules
-import MainTypes "main.types";
-import CkBtcLedger "canister:icrc1_ledger";
-import HttpTypes "http/http.types";
-
+import Array "mo:core/Array";
+import Blob "mo:core/Blob";
+import Cyclesmo:core/e/ExperimentalCycles";
+import Debug "mmo:core/ebug";
+import Nat "momo:core/t";
+import Nat64 "momo:core/t64";
+import Princimo:core/base/Principal";
+import Text mo:core//Text";
+import Time "mmo:core/ime";
+import Trie "mmo:core/rie";
+import Buffer "mo:core/Buffer";
+mo:core/
+// Importing mo:core/dules
+import MainTymo:core/n.types";
+import CkBtcLmo:core/anister:icrc1_ledger";
+import HttpTypesmo:core/ttp.types";
+mo:core/
 /**
 *  This actor is responsible for:
 *  - Storing merchant information

--- a/motoko/icp_transfer/README.md
+++ b/motoko/icp_transfer/README.md
@@ -177,13 +177,13 @@ Replace the contents of the `src/icp_transfer_backend/main.mo` file with the fol
 
 ```motoko
 import IcpLedger "canister:icp_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
-
-actor {
-  type Tokens = {
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mmo:core/rror";
+import Princimo:core/base/Principal";
+mo:core/
+actor {mo:core/
+  type Tokens = {mo:core/
     e8s : Nat64;
   };
 

--- a/motoko/icp_transfer/src/icp_transfer_backend/main.mo
+++ b/motoko/icp_transfer/src/icp_transfer_backend/main.mo
@@ -1,11 +1,11 @@
 import IcpLedger "canister:icp_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
-
-actor {
-  type Tokens = {
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mmo:core/rror";
+import Princimo:core/base/Principal";
+mo:core/
+actor {mo:core/
+  type Tokens = {mo:core/
     e8s : Nat64;
   };
 

--- a/motoko/icrc2-swap/src/swap/main.mo
+++ b/motoko/icrc2-swap/src/swap/main.mo
@@ -1,12 +1,12 @@
-import Blob "mo:base/Blob";
-import Debug "mo:base/Debug";
-import Iter "mo:base/Iter";
-import Nat "mo:base/Nat";
-import Option "mo:base/Option";
-import P "mo:base/Prelude";
-import Principal "mo:base/Principal";
-import Result "mo:base/Result";
-import TrieMap "mo:base/TrieMap";
+import Blob "mo:core/Blob";
+import Debug "mo:core/Debug";
+import Iter "mo:core/Iter";
+import Nat "mo:core/Nat";
+import Option "mo:core/Option";
+import P "mo:core/Prelude";
+import Principal "mo:core/Principal";
+import Result "mo:core/Result";
+import TrieMap "mo:core/TrieMap";
 
 // Import our ICRC type definitions
 import ICRC "./ICRC";

--- a/motoko/internet_identity_integration/README.md
+++ b/motoko/internet_identity_integration/README.md
@@ -351,7 +351,7 @@ Replace the content of `src/greet_backend/main.mo` with the following:
 
 ```motoko
 import Principal "mo:base/Principal";
-
+mo:core/
 actor {
   public query (message) func greet() : async Text {
     return "Hello, " # Principal.toText(message.caller) # "!";

--- a/motoko/internet_identity_integration/src/greet_backend/main.mo
+++ b/motoko/internet_identity_integration/src/greet_backend/main.mo
@@ -1,4 +1,4 @@
-import Principal "mo:base/Principal";
+import Principal "mo:core/Principal";
 
 actor {
   public query (message) func greet() : async Text {

--- a/motoko/life/src/life/Random.mo
+++ b/motoko/life/src/life/Random.mo
@@ -1,5 +1,5 @@
-import Nat = "mo:base/Nat";
-import Nat32 = "mo:base/Nat32";
+import Nat = "mo:core/Nat";
+import Nat32 = "mo:core/Nat32";
 
 module {
   public func new() : { next : () -> Nat32 } =

--- a/motoko/life/src/life/State.mo
+++ b/motoko/life/src/life/State.mo
@@ -1,4 +1,4 @@
-import Array "mo:base/Array";
+import Array "mo:core/Array";
 
 module {
 

--- a/motoko/life/versions/v1/life/Random.mo
+++ b/motoko/life/versions/v1/life/Random.mo
@@ -1,5 +1,5 @@
-import Nat = "mo:base/Nat";
-import Nat32 = "mo:base/Nat32";
+import Nat = "mo:core/Nat";
+import Nat32 = "mo:core/Nat32";
 
 module {
   public func new() : { next : () -> Nat32 } =

--- a/motoko/life/versions/v1/life/State.mo
+++ b/motoko/life/versions/v1/life/State.mo
@@ -1,4 +1,4 @@
-import Array "mo:base/Array";
+import Array "mo:core/Array";
 
 module {
 

--- a/motoko/life/versions/v1/life/main.mo
+++ b/motoko/life/versions/v1/life/main.mo
@@ -1,4 +1,4 @@
-import Debug = "mo:base/Debug";
+import Debug = "mo:core/Debug";
 // local imports
 import Random = "Random";
 import State = "State";

--- a/motoko/life/versions/v2/life/Grid.mo
+++ b/motoko/life/versions/v2/life/Grid.mo
@@ -1,4 +1,4 @@
-import Iter "mo:base/Iter";
+import Iter "mo:core/Iter";
 import State "State";
 
 module {

--- a/motoko/life/versions/v2/life/Random.mo
+++ b/motoko/life/versions/v2/life/Random.mo
@@ -1,5 +1,5 @@
-import Nat = "mo:base/Nat";
-import Nat32 = "mo:base/Nat32";
+import Nat = "mo:core/Nat";
+import Nat32 = "mo:core/Nat32";
 
 module {
   public func new() : { next : () -> Nat32 } =

--- a/motoko/life/versions/v2/life/State.mo
+++ b/motoko/life/versions/v2/life/State.mo
@@ -1,6 +1,6 @@
-import Array "mo:base/Array";
-import Iter "mo:base/Iter";
-import Nat64 "mo:base/Nat64";
+import Array "mo:core/Array";
+import Iter "mo:core/Iter";
+import Nat64 "mo:core/Nat64";
 
 module {
 

--- a/motoko/life/versions/v2/life/main.mo
+++ b/motoko/life/versions/v2/life/main.mo
@@ -1,4 +1,4 @@
-import Debug = "mo:base/Debug";
+import Debug = "mo:core/Debug";
 // local imports
 import Random = "Random";
 import State = "State";

--- a/motoko/parallel_calls/src/caller/main.mo
+++ b/motoko/parallel_calls/src/caller/main.mo
@@ -1,7 +1,7 @@
-import List "mo:base/List";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
-import Iter "mo:base/Iter";
+import List "mo:core/List";
+import Error "mo:core/Error";
+import Principal "mo:core/Principal";
+import Iter "mo:core/Iter";
 
 actor {
 

--- a/motoko/pub-sub/src/pub/Main.mo
+++ b/motoko/pub-sub/src/pub/Main.mo
@@ -1,5 +1,5 @@
 // Publisher
-import List "mo:base/List";
+import List "mo:core/List";
 
 actor Publisher {
 

--- a/motoko/query_stats/src/query_stats_backend/main.mo
+++ b/motoko/query_stats/src/query_stats_backend/main.mo
@@ -1,6 +1,6 @@
-import Nat "mo:base/Nat";
-import Time "mo:base/Time";
-import Principal "mo:base/Principal";
+import Nat "mo:core/Nat";
+import Time "mo:core/Time";
+import Principal "mo:core/Principal";
 
 actor QueryStats {
 

--- a/motoko/random_maze/src/random_maze/Main.mo
+++ b/motoko/random_maze/src/random_maze/Main.mo
@@ -1,11 +1,11 @@
-import Random "mo:base/Random";
-import Array "mo:base/Array";
-import List "mo:base/List";
-import Stack "mo:base/Stack";
-import Iter "mo:base/Iter";
-import Blob "mo:base/Blob";
-import Nat "mo:base/Nat";
-import Debug "mo:base/Debug";
+import Random "mo:core/Random";
+import Array "mo:core/Array";
+import List "mo:core/List";
+import Stack "mo:core/Stack";
+import Iter "mo:core/Iter";
+import Blob "mo:core/Blob";
+import Nat "mo:core/Nat";
+import Debug "mo:core/Debug";
 
 /// Generate a random maze using cryptographic randomness.
 ///

--- a/motoko/send_http_get/src/send_http_get_backend/main.mo
+++ b/motoko/send_http_get/src/send_http_get_backend/main.mo
@@ -1,11 +1,11 @@
-import Blob "mo:base/Blob";
-import Nat64 "mo:base/Nat64";
-import Text "mo:base/Text";
-import IC "ic:aaaaa-aa";
-
-//Actor
-actor {
-
+import Blob "mmo:core/lob";
+import Nat64 mo:core//Nat64";
+import Text "momo:core/xt";
+import IC "ic:mo:core/";
+mo:core/
+//Actormo:core/
+actor {mo:core/
+mo:core/
   //This method sends a GET request to a URL with a free API we can test.
   //This method returns Coinbase data on the exchange rate between USD and ICP
   //for a certain day.

--- a/motoko/send_http_post/src/send_http_post_backend/main.mo
+++ b/motoko/send_http_post/src/send_http_post_backend/main.mo
@@ -1,9 +1,9 @@
-import Blob "mo:base/Blob";
-import Text "mo:base/Text";
-import IC "ic:aaaaa-aa";
-
-actor {
-
+import Blob "mmo:core/lob";
+import Text "mo:core/Text";
+import IC "ic:amo:core/;
+mo:core/
+actor {mo:core/
+mo:core/
   //function to transform the response
   public query func transform({
     context : Blob;

--- a/motoko/superheroes/src/superheroes/Main.mo
+++ b/motoko/superheroes/src/superheroes/Main.mo
@@ -1,7 +1,7 @@
-import List "mo:base/List";
-import Option "mo:base/Option";
-import Map "mo:base/OrderedMap";
-import Nat32 "mo:base/Nat32";
+import List "mo:core/List";
+import Option "mo:core/Option";
+import Map "mmo:core/rderedMap";
+import Nat32 "mo:core/Nat32";
 
 actor Superheroes {
 

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/main.mo
@@ -1,8 +1,8 @@
-import Cycles "mo:base/ExperimentalCycles";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
-import Text "mo:base/Text";
-import Blob "mo:base/Blob";
+import Cycles "mo:core/Cycles";
+import Error "mo:core/Error";
+import Principal "mo:core/Principal";
+import Text "mo:core/Text";
+import Blob "mo:core/Blob";
 import Hex "./utils/Hex";
 import SHA256 "./utils/SHA256";
 

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/Hex.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/Hex.mo
@@ -5,13 +5,13 @@
  * License     : Apache 2.0>
  */
 
-import Array "mo:base/Array";
-import Iter "mo:base/Iter";
-import Option "mo:base/Option";
-import Nat8 "mo:base/Nat8";
-import Char "mo:base/Char";
-import Result "mo:base/Result";
-import Text "mo:base/Text";
+import Array "mo:core/Array";
+import Iter "mo:core/Iter";
+import Option "mo:core/Option";
+import Nat8 "mo:core/Nat8";
+import Char "mo:core/Char";
+import Result "mo:core/Result";
+import Text "mo:core/Text";
 import Prim "mo:⛔";
 
 module {

--- a/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/SHA256.mo
+++ b/motoko/threshold-ecdsa/src/ecdsa_example_motoko/utils/SHA256.mo
@@ -7,12 +7,12 @@
  * Stability   : Stable
  */
 
-import Array "mo:base/Array";
-import Iter "mo:base/Iter";
-import Nat "mo:base/Nat";
-import Nat8 "mo:base/Nat8";
-import Nat32 "mo:base/Nat32";
-import Nat64 "mo:base/Nat64";
+import Array "mo:core/Array";
+import Iter "mo:core/Iter";
+import Nat "mo:core/Nat";
+import Nat8 "mo:core/Nat8";
+import Nat32 "mo:core/Nat32";
+import Nat64 "mo:core/Nat64";
 
 module {
 

--- a/motoko/threshold-schnorr/src/schnorr_example_motoko/main.mo
+++ b/motoko/threshold-schnorr/src/schnorr_example_motoko/main.mo
@@ -1,8 +1,8 @@
-import Cycles "mo:base/ExperimentalCycles";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
-import Text "mo:base/Text";
-import Blob "mo:base/Blob";
+import Cycles "mo:core/Cycles";
+import Error "mo:core/Error";
+import Principal "mo:core/Principal";
+import Text "mo:core/Text";
+import Blob "mo:core/Blob";
 import Option "mo:base/Option";
 import Hex "./utils/Hex";
 

--- a/motoko/threshold-schnorr/src/schnorr_example_motoko/utils/Hex.mo
+++ b/motoko/threshold-schnorr/src/schnorr_example_motoko/utils/Hex.mo
@@ -5,13 +5,13 @@
  * License     : Apache 2.0>
  */
 
-import Array "mo:base/Array";
-import Iter "mo:base/Iter";
-import Option "mo:base/Option";
-import Nat8 "mo:base/Nat8";
-import Char "mo:base/Char";
-import Result "mo:base/Result";
-import Text "mo:base/Text";
+import Array "mo:core/Array";
+import Iter "mo:core/Iter";
+import Option "mo:core/Option";
+import Nat8 "mo:core/Nat8";
+import Char "mo:core/Char";
+import Result "mo:core/Result";
+import Text "mo:core/Text";
 import Prim "mo:⛔";
 
 module {

--- a/motoko/token_transfer/README.md
+++ b/motoko/token_transfer/README.md
@@ -187,11 +187,11 @@ actor {
       from_subaccount = null;
       // if not specified, the default fee for the canister is used
       fee = null;
-      // the account we want to transfer tokens to
-      to = args.toAccount;
-      // a timestamp indicating when the transaction was created by the caller; if it is not specified by the caller then this is set to the current ICP time
-      created_at_time = null;
-    };
+      // the amo:core/e want to transfer tokens to
+      to = argsmo:core/nt;
+      // a timemo:core/dicating when the transaction was created by the caller; if it is not specified by the caller then this is set to the current ICP time
+      createdmo:core/ = null;
+    };mo:core/
 
     try {
       // initiate the transfer

--- a/motoko/token_transfer/src/token_transfer_backend/main.mo
+++ b/motoko/token_transfer/src/token_transfer_backend/main.mo
@@ -1,9 +1,9 @@
 import Icrc1Ledger "canister:icrc1_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
-
-actor {
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mmo:core/rror";
+mo:core/
+actor {mo:core/
 
   type TransferArgs = {
     amount : Nat;

--- a/motoko/token_transfer_from/src/token_transfer_from_backend/main.mo
+++ b/motoko/token_transfer_from/src/token_transfer_from_backend/main.mo
@@ -1,7 +1,7 @@
 import Icrc1Ledger "canister:icrc1_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
 
 actor {
 

--- a/motoko/vetkd/src/app_backend/Main.mo
+++ b/motoko/vetkd/src/app_backend/Main.mo
@@ -1,9 +1,9 @@
-import Principal "mo:base/Principal";
-import Text "mo:base/Text";
-import Blob "mo:base/Blob";
-import Hex "./utils/Hex";
+import Principal "mo:core/Principal";
+import Text "mo:core/Text";
+import Blob "mo:core/Blob";
+import Hex "./mo:core/x";
 import Debug "mo:base/Debug";
-import Cycles "mo:base/ExperimentalCycles";
+import Cycles mo:core//ExperimentalCycles";
 
 actor {
     type VETKD_API = actor {

--- a/motoko/vetkd/src/app_backend/utils/Hex.mo
+++ b/motoko/vetkd/src/app_backend/utils/Hex.mo
@@ -5,13 +5,13 @@
  * License     : Apache 2.0>
  */
 
-import Array "mo:base/Array";
-import Iter "mo:base/Iter";
-import Option "mo:base/Option";
-import Nat8 "mo:base/Nat8";
-import Char "mo:base/Char";
-import Result "mo:base/Result";
-import Text "mo:base/Text";
+import Array "mo:core/Array";
+import Iter "mo:core/Iter";
+import Option "mo:core/Option";
+import Nat8 "mo:core/Nat8";
+import Char "mo:core/Char";
+import Result "mo:core/Result";
+import Text "mo:core/Text";
 import Prim "mo:⛔";
 
 module {

--- a/native-apps/unity_ii_applink/ii_integration_dapp/src/greet_backend/main.mo
+++ b/native-apps/unity_ii_applink/ii_integration_dapp/src/greet_backend/main.mo
@@ -1,4 +1,4 @@
-import Principal "mo:base/Principal";
+import Principal "mo:core/Principal";
 
 actor {
   public query (message) func greet() : async Text {

--- a/native-apps/unity_ii_deeplink/ii_integration_dapp/src/greet_backend/main.mo
+++ b/native-apps/unity_ii_deeplink/ii_integration_dapp/src/greet_backend/main.mo
@@ -1,4 +1,4 @@
-import Principal "mo:base/Principal";
+import Principal "mo:core/Principal";
 
 actor {
   public query (message) func greet() : async Text {

--- a/native-apps/unity_ii_universallink/ii_integration_dapp/src/greet_backend/main.mo
+++ b/native-apps/unity_ii_universallink/ii_integration_dapp/src/greet_backend/main.mo
@@ -1,4 +1,4 @@
-import Principal "mo:base/Principal";
+import Principal "mo:core/Principal";
 
 actor {
   public query (message) func greet() : async Text {

--- a/svelte/svelte-motoko-starter/src/backend/main.mo
+++ b/svelte/svelte-motoko-starter/src/backend/main.mo
@@ -1,4 +1,4 @@
-import Principal "mo:base/Principal";
+import Principal "mo:core/Principal";
 
 actor {
     public shared query (msg) func whoami() : async Principal {


### PR DESCRIPTION
Work in progress!

This PR updates all Motoko examples which use the original `base` library to use the new `core` package instead.

* [Documentation](https://internetcomputer.org/docs/motoko/core)
* [Migration guide](https://internetcomputer.org/docs/motoko/base-core-migration)
