### PR TITLE
fix: Fix candid test and use service_equal in unit_testable_rust_canister example

### DIFF
--- a/rust/unit_testable_rust_canister/src/hello_canister/hello_canister.did
+++ b/rust/unit_testable_rust_canister/src/hello_canister/hello_canister.did
@@ -35,7 +35,7 @@ type BasicProposalInfo = record {
 };
 
 type GetProposalInfoResponse = record {
-  proposal: opt BasicProposalInfo;
+  basic_info: opt BasicProposalInfo;
   error: opt text;
 };
 
@@ -55,7 +55,7 @@ type GetProposalTitlesResponse = record {
   error: opt text;
 };
 
-service : {
+service : () -> {
   // Request/Response API for evolution support
   get_count: (GetCountRequest) -> (GetCountResponse) query;
   increment_count: (IncrementCountRequest) -> (IncrementCountResponse);

--- a/rust/unit_testable_rust_canister/src/hello_canister/src/lib.rs
+++ b/rust/unit_testable_rust_canister/src/hello_canister/src/lib.rs
@@ -69,7 +69,7 @@ ic_cdk::export_candid!();
 #[cfg(test)]
 mod tests {
     use super::*;
-    use candid_parser::utils::{service_compatible, CandidSource};
+    use candid_parser::utils::{service_equal, CandidSource};
     use std::env;
     use std::path::PathBuf;
 
@@ -96,7 +96,7 @@ mod tests {
         let declared_interface = CandidSource::Text(&declared_interface_str);
         let actual_interface = CandidSource::Text(&actual_interface_str);
 
-        let result = service_compatible(declared_interface, actual_interface);
-        assert!(result.is_ok(), "{:?}\n\n", result.unwrap_err());
+        let result = service_equal(declared_interface, actual_interface);
+        assert!(result.is_ok(), "{:?}\n\n", result);
     }
 }


### PR DESCRIPTION
**Overview**
Fix example to use service_equal, by locating and fixing the underlying error that was preventing its use.
