### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@
 /rust/hello_world/ @dfinity/ninja-devs
 /rust/icp_transfer/ @dfinity/growth
 /rust/image-classification/ @dfinity/team-dsm
-/rust/inter-canister-calls/ @dfinity/ic-message-routing-owners
+/rust/inter-canister-calls/ @dfinity/team-dsm
 /rust/llm_chatbot/ @dfinity/ninja-devs
 /rust/low_wasm_memory/ @dfinity/team-dsm
 /rust/parallel_calls/ @dfinity/research


### PR DESCRIPTION
This PR replaces `@dfinity/execution` and `@dfinity/ic-message-routing-owners` with `@dfinity/team-dsm` in CODEOWNERS.
