### PR TITLE
chore: remove unused @dfinity/* deps from motoko frontends

### DIFF
--- a/motoko/daily_planner/frontend/package.json
+++ b/motoko/daily_planner/frontend/package.json
@@ -8,11 +8,7 @@
     "dev": "vite"
   },
   "dependencies": {
-    "@dfinity/agent": "2.4.1",
     "@icp-sdk/core": "~5.2.0",
-    "@dfinity/auth-client": "2.4.1",
-    "@dfinity/candid": "2.4.1",
-    "@dfinity/principal": "2.4.1",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/motoko/evm_block_explorer/frontend/package.json
+++ b/motoko/evm_block_explorer/frontend/package.json
@@ -8,10 +8,6 @@
     "dev": "vite"
   },
   "dependencies": {
-    "@dfinity/agent": "2.4.1",
-    "@dfinity/auth-client": "2.4.1",
-    "@dfinity/candid": "2.4.1",
-    "@dfinity/principal": "2.4.1",
     "@icp-sdk/core": "~5.2.0",
     "react-json-view-lite": "2.3.0",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary

- Remove unused `@dfinity/agent`, `@dfinity/auth-client`, `@dfinity/candid`, `@dfinity/principal` from `motoko/daily_planner` and `motoko/evm_block_explorer` frontend `package.json`
- These were left behind in #1317 when `@icp-sdk/core` was added. Neither frontend imports from `@dfinity/*` directly.