### PR TITLE
feat: migrate oisy-signer-demo from @slide-computer/signer to @icp-sdk/signer

### DIFF
--- a/hosting/oisy-signer-demo/frontend/package.json
+++ b/hosting/oisy-signer-demo/frontend/package.json
@@ -15,9 +15,7 @@
   "dependencies": {
     "@icp-sdk/canisters": "~3.5.0",
     "@icp-sdk/core": "~5.0.0",
-    "@slide-computer/signer": "4.2.2",
-    "@slide-computer/signer-agent": "4.2.2",
-    "@slide-computer/signer-web": "4.2.2",
+    "@icp-sdk/signer": "5.3.0",
     "class-variance-authority": "~0.7.1",
     "lucide-react": "~0.575.0",
     "react": "~19.2.4",

--- a/hosting/oisy-signer-demo/frontend/src/App.jsx
+++ b/hosting/oisy-signer-demo/frontend/src/App.jsx
@@ -198,7 +198,7 @@ export default function App() {
                     <img src={ICPLogo} alt="TESTICP" className="h-5 w-5" />
                     <span>TESTICP</span>
                     <a
-                      href={`https://dashboard.internetcomputer.org/tokens/${TESTICP_LEDGER_ID}/account/${principal?.toString()}`}
+                      href={`https://dashboard.internetcomputer.org/tokens/${TESTICP_LEDGER_ID}/account/${accountIdentifier?.toHex()}`}
                       target="_blank"
                       rel="noreferrer"
                       className="text-blue-600 underline"
@@ -342,11 +342,11 @@ export default function App() {
             <li>
               <a
                 className="inline-flex items-center gap-1 text-blue-600 underline"
-                href="https://github.com/slide-computer/signer-js/tree/main"
+                href="https://github.com/dfinity/icp-js-signer"
                 target="_blank"
                 rel="noreferrer"
               >
-                Signer-JS Libraries <ExternalLink size={14} />
+                @icp-sdk/signer Library <ExternalLink size={14} />
               </a>
             </li>
           </ul>

--- a/hosting/oisy-signer-demo/frontend/src/hooks/useOisyWallet.js
+++ b/hosting/oisy-signer-demo/frontend/src/hooks/useOisyWallet.js
@@ -2,9 +2,9 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { IcrcLedgerCanister, decodeIcrcAccount, mapTokenMetadata } from '@icp-sdk/canisters/ledger/icrc';
 import { HttpAgent } from '@icp-sdk/core/agent';
 import { Principal } from '@icp-sdk/core/principal';
-import { Signer } from '@slide-computer/signer';
-import { SignerAgent } from '@slide-computer/signer-agent';
-import { PostMessageTransport } from '@slide-computer/signer-web';
+import { Signer } from '@icp-sdk/signer';
+import { SignerAgent } from '@icp-sdk/signer/agent';
+import { PostMessageTransport } from '@icp-sdk/signer/web';
 import { AccountIdentifier } from '@icp-sdk/canisters/ledger/icp';
 import { toBaseUnits } from '@/libs/utils';
 import { TESTICP_LEDGER_ID, TICRC1_LEDGER_ID } from '@/libs/constants';
@@ -92,7 +92,7 @@ export function useOisyWallet() {
   }, [defaultAgent, principal]);
 
   const connect = async () => {
-    const accounts = await oisySigner.accounts();
+    const accounts = await oisySigner.getAccounts();
 
     // notes:
     //    - IcrcAccount is the recommended way of dealing with accounts as it is standardized and more transparent
@@ -154,7 +154,7 @@ export function useOisyWallet() {
     if (!defaultAgent || !principal) throw new Error('Not connected');
 
     // This opens the OISY popup briefly to re-establish the signer session.
-    await oisySigner.accounts();
+    await oisySigner.getAccounts();
 
     const signerAgent = await SignerAgent.create({
       agent: defaultAgent,


### PR DESCRIPTION
## Summary

- Replace `@slide-computer/signer`, `@slide-computer/signer-agent`, and `@slide-computer/signer-web` with the unified `@icp-sdk/signer@5.3.0` package
- Update imports to use new sub-path exports (`@icp-sdk/signer`, `@icp-sdk/signer/agent`, `@icp-sdk/signer/web`)
- Rename `signer.accounts()` → `signer.getAccounts()` (API rename in the new package)
- Update footer link label and URL to point to the new `dfinity/icp-js-signer` repository
- Fix TESTICP dashboard link to use account identifier hex instead of principal (ICP ledger requires account identifier format)

## Notes

`@icp-sdk/signer` is the successor to the `@slide-computer/signer*` packages — same protocol, unified under the `@icp-sdk` namespace. Version 5.3.0 includes a `jsonCleanTransform` fix that strips `undefined` values from JSON-RPC requests before sending via `postMessage` (required for compatibility with OISY's sign endpoint).