### PR TITLE
fix: update II wasm artifact name from dev to production

### DIFF
--- a/motoko/filevault/dfx.json
+++ b/motoko/filevault/dfx.json
@@ -22,7 +22,7 @@
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
         }
       },
-      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz"
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_production.wasm.gz"
     },
     "internet_identity_frontend": {
       "candid": "https://raw.githubusercontent.com/dfinity/internet-identity/refs/heads/main/src/internet_identity_frontend/internet_identity_frontend.did",

--- a/motoko/nft-creator/dfx.json
+++ b/motoko/nft-creator/dfx.json
@@ -9,7 +9,7 @@
             },
             "type": "custom",
             "specified_id": "rdmx6-jaaaa-aaaaa-aaadq-cai",
-            "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz"
+            "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_production.wasm.gz"
         },
         "internet_identity_frontend": {
             "candid": "https://raw.githubusercontent.com/dfinity/internet-identity/refs/heads/main/src/internet_identity_frontend/internet_identity_frontend.did",

--- a/motoko/tokenmania/dfx.json
+++ b/motoko/tokenmania/dfx.json
@@ -22,7 +22,7 @@
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
         }
       },
-      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz"
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_production.wasm.gz"
     },
     "internet_identity_frontend": {
       "candid": "https://raw.githubusercontent.com/dfinity/internet-identity/refs/heads/main/src/internet_identity_frontend/internet_identity_frontend.did",

--- a/motoko/who_am_i/dfx.json
+++ b/motoko/who_am_i/dfx.json
@@ -21,7 +21,7 @@
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
         }
       },
-      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz"
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_production.wasm.gz"
     },
     "internet_identity_frontend": {
       "candid": "https://raw.githubusercontent.com/dfinity/internet-identity/refs/heads/main/src/internet_identity_frontend/internet_identity_frontend.did",

--- a/rust/tokenmania/dfx.json
+++ b/rust/tokenmania/dfx.json
@@ -19,7 +19,7 @@
     "internet_identity": {
       "type": "custom",
       "candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
-      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_production.wasm.gz",
       "specified_id": "rdmx6-jaaaa-aaaaa-aaadq-cai",
       "remote": {
         "id": {

--- a/rust/who_am_i/dfx.json
+++ b/rust/who_am_i/dfx.json
@@ -22,7 +22,7 @@
           "ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
         }
       },
-      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz"
+      "wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_production.wasm.gz"
     },
     "internet_identity_frontend": {
       "candid": "https://raw.githubusercontent.com/dfinity/internet-identity/refs/heads/main/src/internet_identity_frontend/internet_identity_frontend.did",


### PR DESCRIPTION
## Summary

The Internet Identity release restructured its artifacts, renaming `internet_identity_dev.wasm.gz` to `internet_identity_production.wasm.gz` (see dfinity/internet-identity#3758).

This PR updates the six examples that already have the II backend/frontend canister split in place:

- `motoko/who_am_i`
- `rust/who_am_i`
- `motoko/tokenmania`
- `rust/tokenmania`
- `motoko/nft-creator`
- `motoko/filevault`

Only these examples are updated because they already reference both the `internet_identity` (backend) and `internet_identity_frontend` canisters separately. Examples still using the old single-canister II setup are left unchanged as they require a separate migration.

> **Note:** The `internet_identity_frontend` canister's candid interface is currently referenced directly from the `main` branch (`https://raw.githubusercontent.com/dfinity/internet-identity/refs/heads/main/src/internet_identity_frontend/internet_identity_frontend.did`) rather than as a release artifact. See the question raised in [dfinity/internet-identity#3758 (comment)](https://github.com/dfinity/internet-identity/issues/3758#issuecomment-4208867884).