### PR TITLE
chore(motoko): migrate send_http_get, send_http_post, nft-creator, superheroes to mo:core 2.4.0

### DIFF
--- a/motoko/nft-creator/backend/app.mo
+++ b/motoko/nft-creator/backend/app.mo
@@ -3,8 +3,7 @@
 
 // --- Standard Library Imports ---
 import Principal "mo:core/Principal";
-import Nat "mo:core/Nat";
-import D "mo:core/Debug";
+import Runtime "mo:core/Runtime";
 
 // --- Third-Party/External Imports ---
 import Vec "mo:vector";
@@ -125,7 +124,7 @@ shared (init_msg) persistent actor class NftCanister() : async (ICRC7.Service.Se
   public query func icrc7_owner_of(token_ids : ICRC7.Service.OwnerOfRequest) : async ICRC7.Service.OwnerOfResponse {
     switch (icrc7().get_token_owners(token_ids)) {
       case (#ok(val)) val;
-      case (#err(err)) D.trap(err);
+      case (#err(err)) Runtime.trap(err);
     };
   };
 
@@ -194,7 +193,7 @@ shared (init_msg) persistent actor class NftCanister() : async (ICRC7.Service.Se
         nextTokenId += 1;
         val;
       };
-      case (#err(err)) D.trap(err);
+      case (#err(err)) Runtime.trap(err);
     };
   };
 

--- a/motoko/nft-creator/backend/app.mo
+++ b/motoko/nft-creator/backend/app.mo
@@ -2,9 +2,9 @@
 // NFT Canister implementing ICRC-7 standard with minting functionality
 
 // --- Standard Library Imports ---
-import Principal "mo:base/Principal";
-import Nat "mo:base/Nat";
-import D "mo:base/Debug";
+import Principal "mo:core/Principal";
+import Nat "mo:core/Nat";
+import D "mo:core/Debug";
 
 // --- Third-Party/External Imports ---
 import Vec "mo:vector";

--- a/motoko/nft-creator/mops.toml
+++ b/motoko/nft-creator/mops.toml
@@ -1,6 +1,5 @@
 [dependencies]
-base = "0.14.8"
-core = "1.0.0"
+core = "2.4.0"
 icrc7-mo = "0.5.0"
 class-plus = "0.0.1"
 vector = "0.2.0"

--- a/motoko/send_http_get/mops.toml
+++ b/motoko/send_http_get/mops.toml
@@ -1,5 +1,4 @@
 # Motoko dependencies (https://mops.one/)
 
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"

--- a/motoko/send_http_get/src/send_http_get_backend/main.mo
+++ b/motoko/send_http_get/src/send_http_get_backend/main.mo
@@ -1,5 +1,5 @@
-import Blob "mo:base/Blob";
-import Text "mo:base/Text";
+import Blob "mo:core/Blob";
+import Text "mo:core/Text";
 import IC "ic:aaaaa-aa";
 
 persistent actor {

--- a/motoko/send_http_post/mops.toml
+++ b/motoko/send_http_post/mops.toml
@@ -1,5 +1,4 @@
 # Motoko dependencies (https://mops.one/)
 
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"

--- a/motoko/send_http_post/src/send_http_post_backend/main.mo
+++ b/motoko/send_http_post/src/send_http_post_backend/main.mo
@@ -1,5 +1,5 @@
-import Blob "mo:base/Blob";
-import Text "mo:base/Text";
+import Blob "mo:core/Blob";
+import Text "mo:core/Text";
 import IC "ic:aaaaa-aa";
 
 persistent actor {

--- a/motoko/superheroes/Makefile
+++ b/motoko/superheroes/Makefile
@@ -14,10 +14,10 @@ deploy: node_modules
 .PHONY: test
 .SILENT: test
 test: deploy
-	$(eval ID := $(shell dfx canister call superheroes create '(record {name = "Superman"; superpowers = opt record { 0 = "invulnerability"; 1 = opt record { 0 = "superhuman strength"; 1 = null; }; }; })' | tr -d '()'))
+	$(eval ID := $(shell dfx canister call superheroes create '(record {name = "Superman"; superpowers = vec { "invulnerability"; "superhuman strength" }})' | tr -d '()'))
 	dfx canister call superheroes read '($(ID))' \
 		| grep 'Superman' && echo 'PASS'
-	dfx canister call superheroes update '($(ID), record {name = "Superman"; superpowers = opt record { 0 = "invulnerability"; 1 = opt record { 0 = "superhuman strength"; 1 = opt record { 0 = "flight"; 1 = opt record { 0 = "x-ray vision"; 1 = null; }; }; }; }; })' \
+	dfx canister call superheroes update '($(ID), record {name = "Superman"; superpowers = vec { "invulnerability"; "superhuman strength"; "flight"; "x-ray vision" }})' \
 		| grep 'true' && echo 'PASS'
 	dfx canister call superheroes read '($(ID))' \
 		| grep 'x-ray vision' && echo 'PASS'

--- a/motoko/superheroes/mops.toml
+++ b/motoko/superheroes/mops.toml
@@ -1,5 +1,4 @@
 # Motoko dependencies (https://mops.one/)
 
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"

--- a/motoko/superheroes/src/superheroes/Main.mo
+++ b/motoko/superheroes/src/superheroes/Main.mo
@@ -1,68 +1,42 @@
-import List "mo:base/List";
-import Option "mo:base/Option";
-import Map "mo:base/OrderedMap";
-import Nat32 "mo:base/Nat32";
+import Map "mo:core/Map";
+import Nat32 "mo:core/Nat32";
 
 persistent actor Superheroes {
 
-  /**
-   * Types
-   */
-
-  // The type of a superhero identifier.
   public type SuperheroId = Nat32;
 
-  // The type of a superhero.
   public type Superhero = {
     name : Text;
-    superpowers : List.List<Text>
+    superpowers : [Text];
   };
 
-  /**
-   * Application State
-   */
-
-  // The next available superhero identifier.
   var next : SuperheroId = 0;
 
-  // The superhero data store.
-  transient let Ops = Map.Make<SuperheroId>(Nat32.compare);
-  var map : Map.Map<SuperheroId, Superhero> = Ops.empty();
+  let map = Map.empty<SuperheroId, Superhero>();
 
-  /**
-   * High-Level API
-   */
-
-  // Create a superhero.
   public func create(superhero : Superhero) : async SuperheroId {
     let superheroId = next;
     next += 1;
-    map := Ops.put(map, superheroId, superhero);
+    Map.add(map, Nat32.compare, superheroId, superhero);
     return superheroId
   };
 
-  // Read a superhero.
   public query func read(superheroId : SuperheroId) : async ?Superhero {
-    let result = Ops.get(map, superheroId);
-    return result
+    Map.get(map, Nat32.compare, superheroId)
   };
 
-  // Update a superhero.
   public func update(superheroId : SuperheroId, superhero : Superhero) : async Bool {
-    let (result, old_value) = Ops.replace(map, superheroId, superhero);
-    let exists = Option.isSome(old_value);
+    let exists = Map.get(map, Nat32.compare, superheroId) != null;
     if (exists) {
-      map := result
+      Map.add(map, Nat32.compare, superheroId, superhero);
     };
     return exists
   };
 
-  // Delete a superhero.
   public func delete(superheroId : SuperheroId) : async Bool {
-    let (result, old_value) = Ops.remove(map, superheroId);
-    let exists = Option.isSome(old_value);
+    let exists = Map.get(map, Nat32.compare, superheroId) != null;
     if (exists) {
-      map := result
+      Map.delete(map, Nat32.compare, superheroId);
     };
     return exists
   }

--- a/motoko/superheroes/src/superheroes/Main.mo
+++ b/motoko/superheroes/src/superheroes/Main.mo
@@ -34,10 +34,6 @@ persistent actor Superheroes {
   };
 
   public func delete(superheroId : SuperheroId) : async Bool {
-    let exists = Map.get(map, Nat32.compare, superheroId) != null;
-    if (exists) {
-      Map.delete(map, Nat32.compare, superheroId);
-    };
-    return exists
+    Map.delete(map, Nat32.compare, superheroId)
   }
 }

--- a/motoko/superheroes/src/www/components/create.jsx
+++ b/motoko/superheroes/src/www/components/create.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { superheroes } from "../../declarations/superheroes";
 
 const $ = document.getElementById.bind(document);
-const idl = require('../utilities/idl');
 
 class Create extends React.Component {
 
@@ -22,7 +21,6 @@ class Create extends React.Component {
       superpowers.push(superpower);
     };
     const superhero = { name, superpowers };
-    superhero.superpowers = idl.toList(superhero.superpowers);
     superheroes.create(superhero).then((superheroId) => {
       this.setState({ superheroId });
     });

--- a/motoko/superheroes/src/www/components/delete.jsx
+++ b/motoko/superheroes/src/www/components/delete.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { superheroes } from "../../declarations/superheroes";
 
 const $ = document.getElementById.bind(document);
-const idl = require('../utilities/idl');
 
 class Delete extends React.Component {
 

--- a/motoko/superheroes/src/www/components/read.jsx
+++ b/motoko/superheroes/src/www/components/read.jsx
@@ -17,9 +17,6 @@ class Read extends React.Component {
     const superheroId = parseInt($('read-superhero-id').value, 10);
     superheroes.read(superheroId).then((result) => {
       const superhero = idl.fromOptional(result);
-      if (superhero) {
-        superhero.superpowers = idl.fromList(superhero.superpowers);
-      };
       this.setState({ superhero });
     });
   }

--- a/motoko/superheroes/src/www/components/update.jsx
+++ b/motoko/superheroes/src/www/components/update.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { superheroes } from "../../declarations/superheroes";
 
 const $ = document.getElementById.bind(document);
-const idl = require('../utilities/idl');
 
 class Update extends React.Component {
 
@@ -23,7 +22,6 @@ class Update extends React.Component {
       superpowers.push(superpower);
     };
     const superhero = { name, superpowers };
-    superhero.superpowers = idl.toList(superhero.superpowers);
     superheroes.update(superheroId, superhero).then((success) => {
       this.setState({ success });
     });

--- a/motoko/superheroes/src/www/utilities/idl.js
+++ b/motoko/superheroes/src/www/utilities/idl.js
@@ -1,22 +1,3 @@
-// Convert a Motoko list to a JavaScript array.
-export function fromList(list) {
-  if (list.length == 0) {
-    return [];
-  } else {
-    const tuple = list[0];
-    const array = fromList(tuple[1]);
-    array.unshift(tuple[0]);
-    return array;
-  }
-}
-
-// Convert a JavaScript array to a Motoko list.
-export function toList(array) {
-  return array.reduceRight((accum, x) => {
-    return [[x, accum]];
-  }, []);
-}
-
 // Convert a Motoko optional to a JavaScript object.
 export function fromOptional(optional) {
   return optional.length > 0 ? optional[0] : null;


### PR DESCRIPTION
## Summary

- Remove `mo:base` dependency from `send_http_get`, `send_http_post`, `nft-creator`, and `superheroes`
- Bump `mo:core` to `2.4.0` in each example's `mops.toml`
- Notable migrations:
  - `send_http_get` / `send_http_post`: `mo:base/Blob`, `mo:base/Text` → `mo:core` equivalents
  - `nft-creator`: `mo:core/Debug` has no `trap` — replaced with `mo:core/Runtime`; removed unused `Nat` import
  - `superheroes`: `mo:base/OrderedMap` + `mo:base/List` → mutable `mo:core/Map`; `superpowers` type simplified from linked list to `[Text]`; frontend list-conversion helpers removed

**Codeowner:** @dfinity/ninja-devs

> `send_http_get` and `send_http_post` are live snippet sources in the docs — these are the highest priority examples to get off `mo:base`.

## Test plan

- [ ] `mops install` succeeds in each example directory
- [ ] `dfx build` succeeds for each example
- [ ] Verify live doc snippets no longer reference `mo:base`
- [ ] Superheroes frontend CRUD operations work with the new `[Text]` superpowers type

🤖 Generated with [Claude Code](https://claude.com/claude-code)