### PR TITLE
refactor: apply modern Motoko style to ninja-devs examples

### DIFF
--- a/motoko/nft-creator/mops.toml
+++ b/motoko/nft-creator/mops.toml
@@ -1,5 +1,20 @@
+# Motoko dependencies (https://mops.one/)
+
+# NOTE: Pinned to moc 1.2.0 (latest version compatible with icrc7-mo@0.5.0).
+# icrc7-mo@0.5.0 transitively depends on motoko-base@0.7.3, whose
+# ExperimentalCycles.mo is incompatible with moc >= 1.3.0 (Cycles.accept
+# return type changed). Once icrc7-mo migrates to mo:core, bump to moc = "1.5.1".
+[toolchain]
+moc = "1.2.0"
+
 [dependencies]
 core = "2.4.0"
 icrc7-mo = "0.5.0"
 class-plus = "0.0.1"
 vector = "0.2.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/send_http_get/mops.toml
+++ b/motoko/send_http_get/mops.toml
@@ -1,4 +1,13 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
 core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/send_http_post/mops.toml
+++ b/motoko/send_http_post/mops.toml
@@ -1,4 +1,13 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
 core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/superheroes/mops.toml
+++ b/motoko/superheroes/mops.toml
@@ -1,4 +1,13 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
 core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/superheroes/src/superheroes/Main.mo
+++ b/motoko/superheroes/src/superheroes/Main.mo
@@ -17,23 +17,23 @@ persistent actor Superheroes {
   public func create(superhero : Superhero) : async SuperheroId {
     let superheroId = next;
     next += 1;
-    Map.add(map, Nat32.compare, superheroId, superhero);
+    map.add(superheroId, superhero);
     return superheroId
   };
 
   public query func read(superheroId : SuperheroId) : async ?Superhero {
-    Map.get(map, Nat32.compare, superheroId)
+    map.get(superheroId)
   };
 
   public func update(superheroId : SuperheroId, superhero : Superhero) : async Bool {
-    let exists = Map.get(map, Nat32.compare, superheroId) != null;
+    let exists = map.get(superheroId) != null;
     if (exists) {
-      Map.add(map, Nat32.compare, superheroId, superhero);
+      map.add(superheroId, superhero);
     };
     return exists
   };
 
   public func delete(superheroId : SuperheroId) : async Bool {
-    Map.delete(map, Nat32.compare, superheroId)
+    map.delete(superheroId)
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1324 applying the modern Motoko style introduced in PR #1325.

- **superheroes**, **send_http_get**, **send_http_post**: add `[toolchain] moc = "1.5.1"` and annotated `[moc]` warning flags (M0236, M0237, M0223)
- **superheroes**: apply context dot notation and implicit compare — e.g. `Map.get(map, Nat32.compare, k)` → `map.get(k)`
- **nft-creator**: pin `moc = "1.2.0"` with a comment explaining why — `icrc7-mo@0.5.0` transitively depends on `motoko-base@0.7.3`, which is incompatible with moc ≥ 1.3.0 (`Cycles.accept` return type changed). Once `icrc7-mo` migrates to `mo:core`, this can be bumped to `1.5.1`

> **Note:** `send_http_get` and `send_http_post` fail `mops check` with `import error [M0008], cannot import canister urls without --actor-idl param` — this is a pre-existing limitation of running `mops check` outside of `dfx` context (the `ic:aaaaa-aa` management canister import requires `--actor-idl`). Not caused by this PR.

**Codeowner:** @dfinity/ninja-devs

## Test plan

- [ ] `mops install` succeeds in each example directory
- [ ] `dfx build` succeeds for all four examples
- [ ] `superheroes` CRUD operations work end-to-end
- [ ] `nft-creator` minting flow works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)