### PR TITLE
chore: migrate low_wasm_memory to mo:core 2.4.0

### DIFF
--- a/motoko/low_wasm_memory/mops.toml
+++ b/motoko/low_wasm_memory/mops.toml
@@ -1,0 +1,13 @@
+# Motoko dependencies (https://mops.one/)
+
+[toolchain]
+moc = "1.5.1"
+
+[dependencies]
+core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/low_wasm_memory/src/low_wasm_memory_hook/main.mo
+++ b/motoko/low_wasm_memory/src/low_wasm_memory_hook/main.mo
@@ -1,6 +1,6 @@
-import Array "mo:base/Array";
-import Deque "mo:base/Deque";
-import Buffer "mo:base/Buffer";
+import Array "mo:core/Array";
+import Queue "mo:core/Queue";
+import List "mo:core/List";
 
 persistent actor {
   // Types
@@ -10,13 +10,13 @@ persistent actor {
   };
 
   // State
-  transient var fnOrderBuffer = Buffer.Buffer<FnType>(30);
-  transient var bytes : Deque.Deque<[Nat]> = Deque.empty();
+  transient let fnOrderBuffer = List.empty<FnType>();
+  transient let bytes = Queue.empty<[Nat]>();
   transient var hookExecuted : Bool = false;
 
   // Query function to get execution order
   public query func getExecutedFunctionsOrder() : async [FnType] {
-    Buffer.toArray(fnOrderBuffer);
+    fnOrderBuffer.toArray()
   };
 
   // Heartbeat function that increases memory usage
@@ -24,8 +24,8 @@ persistent actor {
     if (not hookExecuted) {
       fnOrderBuffer.add(#heartbeat);
       // Allocate more memory by creating a large array
-      let chunk = Array.tabulate<Nat>(10_000, func _ = 0);
-      bytes := Deque.pushBack(bytes, chunk);
+      let chunk = Array.tabulate(10_000, func _ = 0);
+      bytes.pushBack(chunk);
     };
   };
 


### PR DESCRIPTION
## Summary

Missed in #1325 (same @dfinity/languages batch).

- Add `mops.toml` with `moc = "1.5.1"` and annotated `[moc]` warning flags
- Replace `mo:base/Array`, `mo:base/Buffer`, `mo:base/Deque` with `mo:core/Array`, `mo:core/List`, `mo:core/Queue`
- Apply context dot notation (`fnOrderBuffer.add`, `fnOrderBuffer.toArray`, `bytes.pushBack`)
- Remove redundant type annotations

**Codeowner:** @dfinity/languages