### PR TITLE
refactor: migrate remaining ninja-devs examples to mo:core 2.4.0

### DIFF
--- a/motoko/daily_planner/backend/app.mo
+++ b/motoko/daily_planner/backend/app.mo
@@ -1,12 +1,10 @@
 import Array "mo:core/Array";
 import Blob "mo:core/Blob";
-import Int "mo:core/Int";
 import Iter "mo:core/Iter";
 import Text "mo:core/Text";
 import Nat "mo:core/Nat";
 import Result "mo:core/Result";
 import JSON "mo:json";
-import Option "mo:core/Option";
 import HashMap "mo:map/Map";
 import { thash } "mo:map/Map";
 import IC "ic:aaaaa-aa";
@@ -33,7 +31,7 @@ persistent actor DailyPlanner {
   public type AddNoteResult = Result.Result<Text, Text>;
 
   // HashMap to store the data for each day.
-  var dayData = HashMap.new<Text, DayData>();
+  let dayData = HashMap.new<Text, DayData>();
 
   // Query function to get data for a specific date.
   // Returns null if the date does not contain any data.
@@ -44,15 +42,13 @@ persistent actor DailyPlanner {
   // Query function to get data for an entire month.
   // Returns a
   public query func getMonthData(year : Nat, month : Nat) : async [(Text, DayData)] {
-    let monthPrefix = Int.toText(year) # "-" # Int.toText(month) # "-";
-    Iter.toArray(
-      Iter.filter(
-        HashMap.entries(dayData),
-        func((k, _) : (Text, DayData)) : Bool {
-          Text.startsWith(k, #text monthPrefix);
-        },
-      )
-    );
+    let monthPrefix = year.toText() # "-" # month.toText() # "-";
+    Iter.filter(
+      HashMap.entries(dayData),
+      func((k, _) : (Text, DayData)) : Bool {
+        k.startsWith(#text monthPrefix);
+      },
+    ).toArray();
   };
 
   // Update function to add a new note
@@ -116,9 +112,9 @@ persistent actor DailyPlanner {
 
     // Perform HTTPS outcall only if needed.
     if (currentData.onThisDay == null) {
-      let parts = Iter.toArray(Text.split(date, #char '-'));
-      let month = Option.get(Nat.fromText(parts[1]), 1);
-      let day = Option.get(Nat.fromText(parts[2]), 1);
+      let parts = date.split(#char '-').toArray();
+      let month = Nat.fromText(parts[1]).get(1);
+      let day = Nat.fromText(parts[2]).get(1);
 
       // Prepare the https request.
       // "transform" is used to specify how the HTTP response is processed before consensus tries to agree on a response.

--- a/motoko/daily_planner/backend/app.mo
+++ b/motoko/daily_planner/backend/app.mo
@@ -1,14 +1,12 @@
-import Array "mo:base/Array";
-import Blob "mo:base/Blob";
-import Bool "mo:base/Bool";
-import Cycles "mo:base/ExperimentalCycles";
-import Int "mo:base/Int";
-import Iter "mo:base/Iter";
-import Text "mo:base/Text";
-import Nat "mo:base/Nat";
-import Result "mo:base/Result";
+import Array "mo:core/Array";
+import Blob "mo:core/Blob";
+import Int "mo:core/Int";
+import Iter "mo:core/Iter";
+import Text "mo:core/Text";
+import Nat "mo:core/Nat";
+import Result "mo:core/Result";
 import JSON "mo:json";
-import Option "mo:base/Option";
+import Option "mo:core/Option";
 import HashMap "mo:map/Map";
 import { thash } "mo:map/Map";
 import IC "ic:aaaaa-aa";
@@ -46,7 +44,7 @@ persistent actor DailyPlanner {
   // Query function to get data for an entire month.
   // Returns a
   public query func getMonthData(year : Nat, month : Nat) : async [(Text, DayData)] {
-    let monthPrefix = Text.concat(Int.toText(year), "-" # Int.toText(month) # "-");
+    let monthPrefix = Int.toText(year) # "-" # Int.toText(month) # "-";
     Iter.toArray(
       Iter.filter(
         HashMap.entries(dayData),
@@ -65,12 +63,12 @@ persistent actor DailyPlanner {
     };
 
     let newNote : Note = {
-      id = Array.size(currentData.notes);
+      id = currentData.notes.size();
       content = content;
       isCompleted = false;
     };
 
-    let updatedNotes = Array.append(currentData.notes, [newNote]);
+    let updatedNotes = currentData.notes.concat([newNote]);
     let updatedData : DayData = {
       notes = updatedNotes;
       onThisDay = currentData.onThisDay;
@@ -87,9 +85,8 @@ persistent actor DailyPlanner {
     switch (HashMap.get(dayData, thash, date)) {
       case null { /* Do nothing if no data for this date */ };
       case (?data) {
-        let updatedNotes = Array.map<Note, Note>(
-          data.notes,
-          func(note) {
+        let updatedNotes = data.notes.map(
+          func(note : Note) : Note {
             if (note.id == noteId) {
               return {
                 id = note.id;
@@ -144,10 +141,7 @@ persistent actor DailyPlanner {
       // Perform HTTPS outcall using roughly 100B cycles.
       // See https outcall cost calculator: https://7joko-hiaaa-aaaal-ajz7a-cai.icp0.io.
       // Unused cycles are returned.
-      Cycles.add<system>(100_000_000_000);
-
-      // Execute the https outcall
-      let http_response : IC.http_request_result = await IC.http_request(http_request);
+      let http_response : IC.http_request_result = await (with cycles = 100_000_000_000) IC.http_request(http_request);
 
       // Parse response into JSON
       let decoded_text : Text = switch (Text.decodeUtf8(http_response.body)) {

--- a/motoko/daily_planner/backend/app.mo
+++ b/motoko/daily_planner/backend/app.mo
@@ -1,6 +1,7 @@
 import Array "mo:core/Array";
 import Blob "mo:core/Blob";
 import Iter "mo:core/Iter";
+import Option "mo:core/Option";
 import Text "mo:core/Text";
 import Nat "mo:core/Nat";
 import Result "mo:core/Result";

--- a/motoko/daily_planner/mops.toml
+++ b/motoko/daily_planner/mops.toml
@@ -1,7 +1,15 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"
 json = "1.0.0"
 map = "9.0.1"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/evm_block_explorer/backend/app.mo
+++ b/motoko/evm_block_explorer/backend/app.mo
@@ -2,10 +2,8 @@ import EvmRpc "canister:evm_rpc";
 import IC "ic:aaaaa-aa";
 import Sha256 "mo:sha2/Sha256";
 import Base16 "mo:base16/Base16";
-import Debug "mo:base/Debug";
-import Blob "mo:base/Blob";
-import Text "mo:base/Text";
-import Cycles "mo:base/ExperimentalCycles";
+import Runtime "mo:core/Runtime";
+import Text "mo:core/Text";
 
 persistent actor EvmBlockExplorer {
   transient let key_name = "test_key_1"; // Use "key_1" for production and "dfx_test_key" locally
@@ -32,8 +30,7 @@ persistent actor EvmBlockExplorer {
     // };
 
     // Call `eth_getBlockByNumber` RPC method (unused cycles will be refunded)
-    Cycles.add<system>(10_000_000_000);
-    let result = await EvmRpc.eth_getBlockByNumber(services, null, #Number(height));
+    let result = await (with cycles = 10_000_000_000) EvmRpc.eth_getBlockByNumber(services, null, #Number(height));
 
     switch result {
       // Consistent, successful results.
@@ -42,11 +39,11 @@ persistent actor EvmBlockExplorer {
       };
       // All RPC providers return the same error.
       case (#Consistent(#Err error)) {
-        Debug.trap("Error: " # debug_show error);
+        Runtime.trap("Error: " # debug_show error);
       };
       // Inconsistent results between RPC providers. Should not happen if a single RPC provider is used.
       case (#Inconsistent(results)) {
-        Debug.trap("Inconsistent results" # debug_show results);
+        Runtime.trap("Inconsistent results" # debug_show results);
       };
     };
   };
@@ -62,8 +59,7 @@ persistent actor EvmBlockExplorer {
 
   public func sign_message_with_ecdsa(message : Text) : async Text {
     let message_hash : Blob = Sha256.fromBlob(#sha256, Text.encodeUtf8(message));
-    Cycles.add<system>(25_000_000_000);
-    let { signature } = await IC.sign_with_ecdsa({
+    let { signature } = await (with cycles = 25_000_000_000) IC.sign_with_ecdsa({
       message_hash;
       derivation_path = [];
       key_id = { curve = #secp256k1; name = key_name };
@@ -81,8 +77,7 @@ persistent actor EvmBlockExplorer {
   };
 
   public func sign_message_with_schnorr(message : Text) : async Text {
-    Cycles.add<system>(25_000_000_000);
-    let { signature } = await IC.sign_with_schnorr({
+    let { signature } = await (with cycles = 25_000_000_000) IC.sign_with_schnorr({
       message = Text.encodeUtf8(message);
       derivation_path = [];
       key_id = { algorithm = #ed25519; name = key_name };

--- a/motoko/evm_block_explorer/mops.toml
+++ b/motoko/evm_block_explorer/mops.toml
@@ -1,7 +1,15 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"
 sha2 = "0.1.0"
 base16 = "1.0.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/filevault/backend/app.mo
+++ b/motoko/filevault/backend/app.mo
@@ -1,13 +1,11 @@
-import Bool "mo:base/Bool";
-import Array "mo:base/Array";
-import Blob "mo:base/Blob";
+import Array "mo:core/Array";
+import Blob "mo:core/Blob";
 import HashMap "mo:map/Map";
 import { phash; thash } "mo:map/Map";
-import Iter "mo:base/Iter";
-import Nat "mo:base/Nat";
-import Principal "mo:base/Principal";
-import Text "mo:base/Text";
-import Option "mo:base/Option";
+import Iter "mo:core/Iter";
+import Option "mo:core/Option";
+import Principal "mo:core/Principal";
+import Text "mo:core/Text";
 
 persistent actor Filevault {
 
@@ -29,7 +27,7 @@ persistent actor Filevault {
   type UserFiles = HashMap.Map<Text, File>;
 
   // HashMap to store the user data
-  private var files = HashMap.new<Principal, UserFiles>();
+  private let files = HashMap.new<Principal, UserFiles>();
 
   // Return files associated with a user's principal.
   private func getUserFiles(user : Principal) : UserFiles {
@@ -45,7 +43,7 @@ persistent actor Filevault {
 
   // Check if a file name already exists for the user.
   public shared (msg) func checkFileExists(name : Text) : async Bool {
-    Option.isSome(HashMap.get(getUserFiles(msg.caller), thash, name));
+    HashMap.get(getUserFiles(msg.caller), thash, name).isSome();
   };
 
   // Upload a file in chunks.
@@ -58,7 +56,7 @@ persistent actor Filevault {
         let _ = HashMap.put(userFiles, thash, name, { name = name; chunks = [fileChunk]; totalSize = chunk.size(); fileType = fileType });
       };
       case (?existingFile) {
-        let updatedChunks = Array.append(existingFile.chunks, [fileChunk]);
+        let updatedChunks = existingFile.chunks.concat([fileChunk]);
         let _ = HashMap.put(
           userFiles,
           thash,
@@ -76,18 +74,15 @@ persistent actor Filevault {
 
   // Return list of files for a user.
   public shared (msg) func getFiles() : async [{ name : Text; size : Nat; fileType : Text }] {
-    Iter.toArray(
-      Iter.map(
-        HashMap.vals(getUserFiles(msg.caller)),
-        func(file : File) : { name : Text; size : Nat; fileType : Text } {
-          {
-            name = file.name;
-            size = file.totalSize;
-            fileType = file.fileType;
-          };
-        }
-      )
-    );
+    HashMap.vals(getUserFiles(msg.caller)).map(
+      func(file : File) : { name : Text; size : Nat; fileType : Text } {
+        {
+          name = file.name;
+          size = file.totalSize;
+          fileType = file.fileType;
+        };
+      }
+    ).toArray();
   };
 
   // Return total chunks for a file
@@ -103,7 +98,7 @@ persistent actor Filevault {
     switch (HashMap.get(getUserFiles(msg.caller), thash, name)) {
       case null null;
       case (?file) {
-        switch (Array.find(file.chunks, func(chunk : FileChunk) : Bool { chunk.index == index })) {
+        switch (file.chunks.find(func(chunk : FileChunk) : Bool { chunk.index == index })) {
           case null null;
           case (?foundChunk) ?foundChunk.chunk;
         };
@@ -121,6 +116,6 @@ persistent actor Filevault {
 
   // Delete a file.
   public shared (msg) func deleteFile(name : Text) : async Bool {
-    Option.isSome(HashMap.remove(getUserFiles(msg.caller), thash, name));
+    HashMap.remove(getUserFiles(msg.caller), thash, name).isSome();
   };
 };

--- a/motoko/filevault/mops.toml
+++ b/motoko/filevault/mops.toml
@@ -1,6 +1,14 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"
 map = "9.0.1"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/flying_ninja/BUILD.md
+++ b/motoko/flying_ninja/BUILD.md
@@ -4,7 +4,7 @@ Projects deployed through ICP Ninja are temporary; they will only be live for 30
 
 ### 1. Install developer tools
 
-Install [Node.js](https://nodejs.org/en/download/) and [icp-cli](https://cli.icp.build):
+Install [Node.js](https://nodejs.org/en/download/) and [icp-cli](https://cli.internetcomputer.org):
 
 ```bash
 npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm

--- a/motoko/flying_ninja/README.md
+++ b/motoko/flying_ninja/README.md
@@ -12,14 +12,14 @@ This example can be deployed directly from [ICP Ninja](https://icp.ninja), a bro
 
 [![Open in ICP Ninja](https://icp.ninja/assets/open.svg)](https://icp.ninja/i?g=https://github.com/dfinity/examples/motoko/flying_ninja)
 
-> **Note:** ICP Ninja currently uses `dfx` under the hood, which is why this example includes a `dfx.json` configuration file. `dfx` is the legacy CLI, being superseded by [icp-cli](https://cli.icp.build), which is what developers should use for local development.
+> **Note:** ICP Ninja currently uses `dfx` under the hood, which is why this example includes a `dfx.json` configuration file. `dfx` is the legacy CLI, being superseded by [icp-cli](https://cli.internetcomputer.org), which is what developers should use for local development.
 
 ## Build and deploy from the command line
 
 ### Prerequisites
 
 - [x] Install [Node.js](https://nodejs.org/en/download/)
-- [x] Install [icp-cli](https://cli.icp.build): `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`
+- [x] Install [icp-cli](https://cli.internetcomputer.org): `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`
 
 ### Install
 

--- a/motoko/flying_ninja/backend/app.mo
+++ b/motoko/flying_ninja/backend/app.mo
@@ -3,6 +3,7 @@ import Nat "mo:core/Nat";
 import Random "mo:core/Random";
 
 persistent actor FlyingNinja {
+  type Order = { #less; #equal; #greater };
   type LeaderboardEntry = {
     name : Text;
     score : Nat;
@@ -26,7 +27,7 @@ persistent actor FlyingNinja {
 
     // Add the new entry and sort the leaderboard
     leaderboard := leaderboard.concat([newEntry]).sort(
-      func(a : LeaderboardEntry, b : LeaderboardEntry) : { #less; #equal; #greater } { Nat.compare(b.score, a.score) }
+      func(a : LeaderboardEntry, b : LeaderboardEntry) : Order { Nat.compare(b.score, a.score) }
     );
 
     // Keep only the top 10 scores

--- a/motoko/flying_ninja/backend/app.mo
+++ b/motoko/flying_ninja/backend/app.mo
@@ -1,6 +1,6 @@
-import Array "mo:base/Array";
-import Int "mo:base/Int";
-import Random "mo:base/Random";
+import Array "mo:core/Array";
+import Nat "mo:core/Nat";
+import Random "mo:core/Random";
 
 persistent actor FlyingNinja {
   type LeaderboardEntry = {
@@ -25,16 +25,13 @@ persistent actor FlyingNinja {
     let newEntry : LeaderboardEntry = { name = name; score = score };
 
     // Add the new entry and sort the leaderboard
-    leaderboard := Array.sort<LeaderboardEntry>(
-      Array.append<LeaderboardEntry>(leaderboard, [newEntry]),
-      func(a : LeaderboardEntry, b : LeaderboardEntry) {
-        Int.compare(b.score, a.score);
-      }
+    leaderboard := leaderboard.concat([newEntry]).sort(
+      func(a : LeaderboardEntry, b : LeaderboardEntry) : { #less; #equal; #greater } { Nat.compare(b.score, a.score) }
     );
 
     // Keep only the top 10 scores
     if (leaderboard.size() > 10) {
-      leaderboard := Array.subArray(leaderboard, 0, 10);
+      leaderboard := leaderboard.sliceToArray(0, 10);
     };
 
     return leaderboard;

--- a/motoko/flying_ninja/mops.toml
+++ b/motoko/flying_ninja/mops.toml
@@ -1,5 +1,13 @@
+# Motoko dependencies (https://mops.one/)
+
 [toolchain]
-moc = "1.2.0"
+moc = "1.5.1"
 
 [dependencies]
-base = "0.14.9"
+core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]

--- a/motoko/tokenmania/backend/app.mo
+++ b/motoko/tokenmania/backend/app.mo
@@ -2,15 +2,15 @@
 // Please visit https://github.com/dfinity/ICRC-1 to find
 // the latest version of the ICP token standards.
 
-import Array "mo:base/Array";
-import Blob "mo:base/Blob";
-import Buffer "mo:base/Buffer";
-import Principal "mo:base/Principal";
-import Option "mo:base/Option";
-import Time "mo:base/Time";
-import Int "mo:base/Int";
-import Nat8 "mo:base/Nat8";
-import Nat64 "mo:base/Nat64";
+import Blob "mo:core/Blob";
+import List "mo:core/List";
+import VarArray "mo:core/VarArray";
+import Principal "mo:core/Principal";
+import Option "mo:core/Option";
+import Time "mo:core/Time";
+import Int "mo:core/Int";
+import Nat8 "mo:core/Nat8";
+import Nat64 "mo:core/Nat64";
 
 persistent actor class Tokenmania() = this {
 
@@ -50,7 +50,7 @@ persistent actor class Tokenmania() = this {
       return #Err("Token not created");
     };
 
-    if (not Principal.equal(caller, init.minting_account.owner)) {
+    if (caller != init.minting_account.owner) {
       return #Err("Caller is not the token creator");
     };
 
@@ -85,7 +85,7 @@ persistent actor class Tokenmania() = this {
       return #Err("Token already created");
     };
 
-    if (Principal.isAnonymous(caller)) {
+    if (caller.isAnonymous()) {
       return #Err("Cannot create token with anonymous principal");
     };
 
@@ -130,14 +130,14 @@ persistent actor class Tokenmania() = this {
   public type Timestamp = Nat64;
   public type Duration = Nat64;
   public type TxIndex = Nat;
-  public type TxLog = Buffer.Buffer<Transaction>;
+  public type TxLog = List.List<Transaction>;
 
   public type Value = { #Nat : Nat; #Int : Int; #Blob : Blob; #Text : Text };
 
   transient let maxMemoSize = 32;
   transient let permittedDriftNanos : Duration = 60_000_000_000;
   transient let transactionWindowNanos : Duration = 24 * 60 * 60 * 1_000_000_000;
-  transient let defaultSubaccount : Subaccount = Blob.fromArrayMut(Array.init(32, 0 : Nat8));
+  transient let defaultSubaccount : Subaccount = Blob.fromVarArray(VarArray.repeat(0 : Nat8, 32));
 
   public type Operation = {
     #Approve : Approve;
@@ -212,19 +212,16 @@ persistent actor class Tokenmania() = this {
 
   // Checks whether two accounts are semantically equal.
   func accountsEqual(lhs : Account, rhs : Account) : Bool {
-    let lhsSubaccount = Option.get(lhs.subaccount, defaultSubaccount);
-    let rhsSubaccount = Option.get(rhs.subaccount, defaultSubaccount);
+    let lhsSubaccount = lhs.subaccount.get(defaultSubaccount);
+    let rhsSubaccount = rhs.subaccount.get(defaultSubaccount);
 
-    Principal.equal(lhs.owner, rhs.owner) and Blob.equal(
-      lhsSubaccount,
-      rhsSubaccount,
-    );
+    lhs.owner == rhs.owner and lhsSubaccount == rhsSubaccount;
   };
 
   // Computes the balance of the specified account.
   func balance(account : Account, log : TxLog) : Nat {
     var sum = 0;
-    for (tx in log.vals()) {
+    for (tx in log.values()) {
       switch (tx.operation) {
         case (#Burn(args)) {
           if (accountsEqual(args.from, account)) { sum -= args.amount };
@@ -249,7 +246,7 @@ persistent actor class Tokenmania() = this {
   // Computes the total token supply.
   func totalSupply(log : TxLog) : Tokens {
     var total = 0;
-    for (tx in log.vals()) {
+    for (tx in log.values()) {
       switch (tx.operation) {
         case (#Burn(args)) { total -= args.amount };
         case (#Mint(args)) { total += args.amount };
@@ -263,7 +260,7 @@ persistent actor class Tokenmania() = this {
   // Finds a transaction in the transaction log.
   func findTransfer(transfer : Transfer, log : TxLog) : ?TxIndex {
     var i = 0;
-    for (tx in log.vals()) {
+    for (tx in log.values()) {
       switch (tx.operation) {
         case (#Burn(args)) { if (args == transfer) { return ?i } };
         case (#Mint(args)) { if (args == transfer) { return ?i } };
@@ -278,7 +275,7 @@ persistent actor class Tokenmania() = this {
   // Finds an approval in the transaction log.
   func findApproval(approval : Approve, log : TxLog) : ?TxIndex {
     var i = 0;
-    for (tx in log.vals()) {
+    for (tx in log.values()) {
       switch (tx.operation) {
         case (#Approve(args)) { if (args == approval) { return ?i } };
         case (_) {};
@@ -293,7 +290,7 @@ persistent actor class Tokenmania() = this {
     var allowance : Nat = 0;
     var lastApprovalTs : ?Nat64 = null;
 
-    for (tx in log.vals()) {
+    for (tx in log.values()) {
       // Reset expired approvals, if any.
       switch (lastApprovalTs) {
         case (?expires_at) {
@@ -340,8 +337,8 @@ persistent actor class Tokenmania() = this {
     validateSubaccount(init.minting_account.subaccount);
 
     let now = Nat64.fromNat(Int.abs(Time.now()));
-    let log = Buffer.Buffer<Transaction>(100);
-    for ({ account; amount } in Array.vals(init.initial_mints)) {
+    let log = List.empty<Transaction>();
+    for ({ account; amount } in init.initial_mints.vals()) {
       validateSubaccount(account.subaccount);
       let tx : Transaction = {
         operation = #Mint({
@@ -364,7 +361,7 @@ persistent actor class Tokenmania() = this {
 
   // Traps if the specified blob is not a valid subaccount.
   func validateSubaccount(s : ?Subaccount) {
-    let subaccount = Option.get(s, defaultSubaccount);
+    let subaccount = s.get(defaultSubaccount);
     assert (subaccount.size() == 32);
   };
 
@@ -376,7 +373,7 @@ persistent actor class Tokenmania() = this {
   };
 
   func checkTxTime(created_at_time : ?Timestamp, now : Timestamp) : Result<(), DeduplicationError> {
-    let txTime : Timestamp = Option.get(created_at_time, now);
+    let txTime : Timestamp = created_at_time.get(now);
 
     if ((txTime > now) and (txTime - now > permittedDriftNanos)) {
       return #Err(#CreatedInFuture { ledger_time = now });
@@ -401,10 +398,7 @@ persistent actor class Tokenmania() = this {
   };
 
   system func postupgrade() {
-    log := Buffer.Buffer(persistedLog.size());
-    for (tx in Array.vals(persistedLog)) {
-      log.add(tx);
-    };
+    log := List.fromArray(persistedLog);
   };
 
   func recordTransaction(tx : Transaction) : TxIndex {
@@ -416,7 +410,7 @@ persistent actor class Tokenmania() = this {
   func classifyTransfer(log : TxLog, transfer : Transfer) : Result<(Operation, Tokens), TransferError> {
     let minter = init.minting_account;
 
-    if (Option.isSome(transfer.created_at_time)) {
+    if (transfer.created_at_time.isSome()) {
       switch (findTransfer(transfer, log)) {
         case (?txid) { return #Err(#Duplicate { duplicate_of = txid }) };
         case null {};
@@ -424,12 +418,12 @@ persistent actor class Tokenmania() = this {
     };
 
     let result = if (accountsEqual(transfer.from, minter)) {
-      if (Option.get(transfer.fee, 0) != 0) {
+      if (transfer.fee.get(0) != 0) {
         return #Err(#BadFee { expected_fee = 0 });
       };
       (#Mint(transfer), 0);
     } else if (accountsEqual(transfer.to, minter)) {
-      if (Option.get(transfer.fee, 0) != 0) {
+      if (transfer.fee.get(0) != 0) {
         return #Err(#BadFee { expected_fee = 0 });
       };
 
@@ -445,7 +439,7 @@ persistent actor class Tokenmania() = this {
       (#Burn(transfer), 0);
     } else {
       let effectiveFee = init.transfer_fee;
-      if (Option.get(transfer.fee, effectiveFee) != effectiveFee) {
+      if (transfer.fee.get(effectiveFee) != effectiveFee) {
         return #Err(#BadFee { expected_fee = init.transfer_fee });
       };
 
@@ -539,7 +533,7 @@ persistent actor class Tokenmania() = this {
     [
       ("icrc1:name", #Text(init.token_name)),
       ("icrc1:symbol", #Text(init.token_symbol)),
-      ("icrc1:decimals", #Nat(Nat8.toNat(init.decimals))),
+      ("icrc1:decimals", #Nat(init.decimals.toNat())),
       ("icrc1:fee", #Nat(init.transfer_fee)),
       ("icrc1:logo", #Text(logo)), /* Here we add the token logo to the metadata. */
     ];
@@ -592,7 +586,7 @@ persistent actor class Tokenmania() = this {
       memo = memo;
     };
 
-    if (Option.isSome(created_at_time)) {
+    if (created_at_time.isSome()) {
       switch (findApproval(approval, log)) {
         case (?txid) { return #Err(#Duplicate { duplicate_of = txid }) };
         case (null) {};
@@ -608,7 +602,7 @@ persistent actor class Tokenmania() = this {
 
     let effectiveFee = init.transfer_fee;
 
-    if (Option.get(fee, effectiveFee) != effectiveFee) {
+    if (fee.get(effectiveFee) != effectiveFee) {
       return #Err(#BadFee({ expected_fee = effectiveFee }));
     };
 

--- a/motoko/tokenmania/mops.toml
+++ b/motoko/tokenmania/mops.toml
@@ -1,5 +1,13 @@
 # Motoko dependencies (https://mops.one/)
 
+[toolchain]
+moc = "1.5.1"
+
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
+# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
+# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
+args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]


### PR DESCRIPTION
## Summary

- Migrates `daily_planner`, `evm_block_explorer`, `filevault`, `flying_ninja`, and `tokenmania` to `mo:core 2.4.0`, completing the `@dfinity/ninja-devs` batch started in #1326
- Applies `persistent actor`, context dot notation (M0236), `await (with cycles = N)` syntax, and updated APIs (`List`/`Queue`/`VarArray`, `Runtime.trap`, `Blob.fromVarArray`)
- Pins all examples to `moc = "1.5.1"` with style warning flags (`-W M0236/M0237/M0223`)
- Fixes outdated `icp-cli` URL (`cli.icp.build` → `cli.internetcomputer.org`) in `flying_ninja/README.md`

Note: `daily_planner` and `evm_block_explorer` import canisters (`ic:aaaaa-aa`, `canister:evm_rpc`) that require `dfx` to supply `--actor-idl`; they cannot be checked standalone with `mops check` but compile correctly via `dfx deploy`.