### PR TITLE
chore: migrate defi examples to mo:core 2.4.0

### DIFF
--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/BitcoinApi.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/BitcoinApi.mo
@@ -1,5 +1,3 @@
-import ExperimentalCycles "mo:base/ExperimentalCycles";
-
 import Types "Types";
 
 module {
@@ -36,8 +34,7 @@ module {
   /// Relies on the `bitcoin_get_balance` endpoint.
   /// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance
   public func get_balance(network : Network, address : BitcoinAddress) : async Satoshi {
-    ExperimentalCycles.add<system>(GET_BALANCE_COST_CYCLES);
-    await management_canister_actor.bitcoin_get_balance({
+    await (with cycles = GET_BALANCE_COST_CYCLES) management_canister_actor.bitcoin_get_balance({
         address;
         network;
         min_confirmations = null;
@@ -49,8 +46,7 @@ module {
   /// NOTE: Relies on the `bitcoin_get_utxos` endpoint.
   /// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_utxos
   public func get_utxos(network : Network, address : BitcoinAddress) : async GetUtxosResponse {
-    ExperimentalCycles.add<system>(GET_UTXOS_COST_CYCLES);
-    await management_canister_actor.bitcoin_get_utxos({
+    await (with cycles = GET_UTXOS_COST_CYCLES) management_canister_actor.bitcoin_get_utxos({
         address;
         network;
         filter = null;
@@ -63,8 +59,7 @@ module {
   /// Relies on the `bitcoin_get_current_fee_percentiles` endpoint.
   /// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_current_fee_percentiles
   public func get_current_fee_percentiles(network : Network) : async [MillisatoshiPerVByte] {
-    ExperimentalCycles.add<system>(GET_CURRENT_FEE_PERCENTILES_COST_CYCLES);
-    await management_canister_actor.bitcoin_get_current_fee_percentiles({
+    await (with cycles = GET_CURRENT_FEE_PERCENTILES_COST_CYCLES) management_canister_actor.bitcoin_get_current_fee_percentiles({
         network;
     })
   };
@@ -74,11 +69,7 @@ module {
   /// Relies on the `bitcoin_send_transaction` endpoint.
   /// See https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_send_transaction
   public func send_transaction(network : Network, transaction : [Nat8]) : async () {
-    let transaction_fee =
-        SEND_TRANSACTION_BASE_COST_CYCLES + transaction.size() * SEND_TRANSACTION_COST_CYCLES_PER_BYTE;
-
-    ExperimentalCycles.add<system>(transaction_fee);
-    await management_canister_actor.bitcoin_send_transaction({
+    await (with cycles = SEND_TRANSACTION_BASE_COST_CYCLES + transaction.size() * SEND_TRANSACTION_COST_CYCLES_PER_BYTE) management_canister_actor.bitcoin_send_transaction({
         network;
         transaction;
     })

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/EcdsaApi.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/EcdsaApi.mo
@@ -1,5 +1,3 @@
-import ExperimentalCycles "mo:base/ExperimentalCycles";
-
 import Types "Types";
 
 module {
@@ -30,8 +28,7 @@ module {
   };
 
   public func sign_with_ecdsa(ecdsa_canister_actor: EcdsaCanisterActor, key_name : Text, derivation_path : [Blob], message_hash : Blob) : async Blob {
-    ExperimentalCycles.add<system>(SIGN_WITH_ECDSA_COST_CYCLES);
-    let res = await ecdsa_canister_actor.sign_with_ecdsa({
+    let res = await (with cycles = SIGN_WITH_ECDSA_COST_CYCLES) ecdsa_canister_actor.sign_with_ecdsa({
       message_hash;
       derivation_path;
       key_id = {

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/Main.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/Main.mo
@@ -1,7 +1,5 @@
-import Principal "mo:base/Principal";
-import Text "mo:base/Text";
-import Array "mo:base/Array";
-import Blob "mo:base/Blob";
+import Array "mo:core/Array";
+import Blob "mo:core/Blob";
 
 import BitcoinApi "BitcoinApi";
 import P2pkh "P2pkh";
@@ -43,8 +41,8 @@ persistent actor class BasicBitcoin(network : Types.Network) {
 
   // Threshold signing APIs instantiated with the management canister ID. Can be
   // replaced for cheaper testing.
-  transient var ecdsa_canister_actor : EcdsaCanisterActor = actor ("aaaaa-aa");
-  transient var schnorr_canister_actor : SchnorrCanisterActor = actor ("aaaaa-aa");
+  transient let ecdsa_canister_actor : EcdsaCanisterActor = actor ("aaaaa-aa");
+  transient let schnorr_canister_actor : SchnorrCanisterActor = actor ("aaaaa-aa");
 
   /// Returns the balance of the given Bitcoin address.
   public func get_balance(address : BitcoinAddress) : async Satoshi {
@@ -109,6 +107,6 @@ persistent actor class BasicBitcoin(network : Types.Network) {
   };
 
   func derivationPathWithSuffix(suffix : Blob) : [[Nat8]] {
-    Array.flatten([DERIVATION_PATH, [Blob.toArray(suffix)]]);
+    [DERIVATION_PATH, [suffix.toArray()]].flatten();
   };
 };

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/P2pkh.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/P2pkh.mo
@@ -8,14 +8,13 @@
 //! * Caching spent UTXOs so that they are not reused in future transactions.
 //! * Option to set the fee.
 
-import Debug "mo:base/Debug";
-import Array "mo:base/Array";
-import Nat8 "mo:base/Nat8";
-import Nat32 "mo:base/Nat32";
-import Nat64 "mo:base/Nat64";
-import Iter "mo:base/Iter";
-import Blob "mo:base/Blob";
-import Nat "mo:base/Nat";
+import Debug "mo:core/Debug";
+import Runtime "mo:core/Runtime";
+import Array "mo:core/Array";
+import Nat8 "mo:core/Nat8";
+import Nat32 "mo:core/Nat32";
+import Nat64 "mo:core/Nat64";
+import Blob "mo:core/Blob";
 
 import EcdsaTypes "mo:bitcoin/ecdsa/Types";
 import P2pkh "mo:bitcoin/bitcoin/P2pkh";
@@ -50,10 +49,10 @@ module {
     /// Returns the P2PKH address of this canister at the given derivation path.
     public func get_address(ecdsa_canister_actor : EcdsaCanisterActor, network : Network, key_name : Text, derivation_path : [[Nat8]]) : async BitcoinAddress {
         // Fetch the public key of the given derivation path.
-        let public_key = await EcdsaApi.ecdsa_public_key(ecdsa_canister_actor, key_name, Array.map(derivation_path, Blob.fromArray));
+        let public_key = await EcdsaApi.ecdsa_public_key(ecdsa_canister_actor, key_name, derivation_path.map(Blob.fromArray));
 
         // Compute the address.
-        public_key_to_p2pkh_address(network, Blob.toArray(public_key));
+        public_key_to_p2pkh_address(network, public_key.toArray());
     };
 
     /// Sends a transaction to the network that transfers the given amount to the
@@ -74,7 +73,7 @@ module {
         };
 
         // Fetch our public key, P2PKH address, and UTXOs.
-        let own_public_key = Blob.toArray(await EcdsaApi.ecdsa_public_key(ecdsa_canister_actor, key_name, Array.map(derivation_path, Blob.fromArray)));
+        let own_public_key = (await EcdsaApi.ecdsa_public_key(ecdsa_canister_actor, key_name, derivation_path.map(Blob.fromArray))).toArray();
         let own_address = public_key_to_p2pkh_address(network, own_public_key);
 
         // Note that pagination may have to be used to get all UTXOs for the given address.
@@ -84,11 +83,11 @@ module {
 
         // Build the transaction that sends `amount` to the destination address.
         let tx_bytes = await build_transaction(ecdsa_canister_actor, own_public_key, own_address, own_utxos, dst_address, amount, fee_per_vbyte);
-        let transaction = Utils.get_ok(Transaction.fromBytes(Iter.fromArray(tx_bytes)));
+        let transaction = Utils.get_ok(Transaction.fromBytes(tx_bytes.vals()));
 
         // Sign the transaction.
-        let signed_transaction_bytes = await sign_transaction(ecdsa_canister_actor, own_public_key, own_address, transaction, key_name, Array.map(derivation_path, Blob.fromArray), EcdsaApi.sign_with_ecdsa);
-        let signed_transaction = Utils.get_ok(Transaction.fromBytes(Iter.fromArray(signed_transaction_bytes)));
+        let signed_transaction_bytes = await sign_transaction(ecdsa_canister_actor, own_public_key, own_address, transaction, key_name, derivation_path.map(Blob.fromArray), EcdsaApi.sign_with_ecdsa);
+        let signed_transaction = Utils.get_ok(Transaction.fromBytes(signed_transaction_bytes.vals()));
 
         Debug.print("Sending transaction");
         await BitcoinApi.send_transaction(network, signed_transaction_bytes);
@@ -117,7 +116,7 @@ module {
         // We solve this problem iteratively. We start with a fee of zero, build
         // and sign a transaction, see what its size is, and then update the fee,
         // rebuild the transaction, until the fee is set to the correct amount.
-        let fee_per_vbyte_nat = Nat64.toNat(fee_per_vbyte);
+        let fee_per_vbyte_nat = fee_per_vbyte.toNat();
         Debug.print("Building transaction...");
         var total_fee : Nat = 0;
         loop {
@@ -166,10 +165,10 @@ module {
         // scriptPubKey of the Tx output being spent.
         switch (Address.scriptPubKey(#p2pkh own_address)) {
             case (#ok scriptPubKey) {
-                let scriptSigs = Array.init<Script>(transaction.txInputs.size(), []);
+                let scriptSigs = Array.repeat([] : Script, transaction.txInputs.size()).toVarArray<Script>();
 
                 // Obtain scriptSigs for each Tx input.
-                for (i in Iter.range(0, transaction.txInputs.size() - 1)) {
+                for (i in transaction.txInputs.keys()) {
                     let sighash = transaction.createP2pkhSignatureHash(
                         scriptPubKey,
                         Nat32.fromIntWrap(i),
@@ -177,16 +176,16 @@ module {
                     );
 
                     let signature_sec = await signer(ecdsa_canister_actor, key_name, derivation_path, Blob.fromArray(sighash));
-                    let signature_der = Blob.toArray(Der.encodeSignature(signature_sec));
+                    let signature_der = Der.encodeSignature(signature_sec).toArray();
 
                     // Append the sighash type.
-                    let encodedSignatureWithSighashType = Array.tabulate<Nat8>(
+                    let encodedSignatureWithSighashType = Array.tabulate(
                         signature_der.size() + 1,
-                        func(n) {
+                        func(n : Nat) : Nat8 {
                             if (n < signature_der.size()) {
                                 signature_der[n];
                             } else {
-                                Nat8.fromNat(Nat32.toNat(SIGHASH_ALL));
+                                Nat8.fromNat(SIGHASH_ALL.toNat());
                             };
                         },
                     );
@@ -200,12 +199,12 @@ module {
                     scriptSigs[i] := script;
                 };
                 // Assign ScriptSigs to their associated TxInputs.
-                for (i in Iter.range(0, scriptSigs.size() - 1)) {
+                for (i in scriptSigs.keys()) {
                     transaction.txInputs[i].script := scriptSigs[i];
                 };
             };
             // Verify that our own address is P2PKH.
-            case (#err msg) Debug.trap("This example supports signing p2pkh addresses only: " # msg);
+            case (#err msg) Runtime.trap("This example supports signing p2pkh addresses only: " # msg);
         };
 
         transaction.toBytes();

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/P2tr.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/P2tr.mo
@@ -13,15 +13,14 @@
 //! one key for spending. The key in the script is different from the internal
 //! key, but both are derived using the ICP.
 
-import Debug "mo:base/Debug";
-import Array "mo:base/Array";
-import Nat8 "mo:base/Nat8";
-import Nat32 "mo:base/Nat32";
-import Nat64 "mo:base/Nat64";
-import Iter "mo:base/Iter";
-import Blob "mo:base/Blob";
-import Nat "mo:base/Nat";
-import Option "mo:base/Option";
+import Debug "mo:core/Debug";
+import Runtime "mo:core/Runtime";
+import Array "mo:core/Array";
+import Nat8 "mo:core/Nat8";
+import Nat32 "mo:core/Nat32";
+import Nat64 "mo:core/Nat64";
+import Blob "mo:core/Blob";
+import Option "mo:core/Option";
 
 import Address "mo:bitcoin/bitcoin/Address";
 import Bitcoin "mo:bitcoin/bitcoin/Bitcoin";
@@ -100,17 +99,16 @@ module {
         // We solve this problem iteratively. We start with a fee of zero, build
         // and sign a transaction, see what its size is, and then update the fee,
         // rebuild the transaction, until the fee is set to the correct amount.
-        let fee_per_vbyte_nat = Nat64.toNat(fee_per_vbyte);
+        let fee_per_vbyte_nat = fee_per_vbyte.toNat();
         var total_fee : Nat = 0;
 
         loop {
             let transaction = Utils.get_ok_expect(Bitcoin.buildTransaction(2, own_utxos, [(dst_address_typed, amount)], #p2tr_key own_address, Nat64.fromNat(total_fee)), "Error building transaction.");
-            let tx_in_outpoints = Array.map<TxInput.TxInput, Types.OutPoint>(transaction.txInputs, func(txin) { txin.prevOutput });
+            let tx_in_outpoints = transaction.txInputs.map(func(txin : TxInput.TxInput) : Types.OutPoint { txin.prevOutput });
 
-            let amounts = Array.mapFilter<Utxo, Satoshi>(
-                own_utxos,
-                func(utxo) {
-                    if (Option.isSome(Array.find<Types.OutPoint>(tx_in_outpoints, func(tx_in_outpoint) { tx_in_outpoint == utxo.outpoint }))) {
+            let amounts = own_utxos.filterMap(
+                func(utxo : Utxo) : ?Satoshi {
+                    if (tx_in_outpoints.find(func(tx_in_outpoint : Types.OutPoint) : Bool { tx_in_outpoint == utxo.outpoint }).isSome()) {
                         ?utxo.value;
                     } else {
                         null;
@@ -166,19 +164,19 @@ module {
                 assert scriptPubKey.size() == 2;
 
                 // Obtain a witness for each Tx input.
-                for (i in Iter.range(0, transaction.txInputs.size() - 1)) {
+                for (i in transaction.txInputs.keys()) {
                     let sighash = transaction.createTaprootKeySpendSignatureHash(
                         amounts,
                         scriptPubKey,
                         Nat32.fromIntWrap(i),
                     );
 
-                    let signature = Blob.toArray(await signer(schnorr_canister_actor, key_name, derivation_path, Blob.fromArray(sighash), aux));
+                    let signature = (await signer(schnorr_canister_actor, key_name, derivation_path, Blob.fromArray(sighash), aux)).toArray();
                     transaction.witnesses[i] := [signature];
                 };
             };
             // Verify that our own address is P2TR key spend address.
-            case (#err msg) Debug.trap("This example supports signing p2tr key spend addresses only: " # msg);
+            case (#err msg) Runtime.trap("This example supports signing p2tr key spend addresses only: " # msg);
         };
 
         transaction.toBytes();
@@ -211,7 +209,7 @@ module {
         let script_bytes_sized = Script.toBytes(leaf_script);
         let script_len : Nat = script_bytes_sized.size() - 1;
         // remove the size prefix
-        let script_bytes = Array.subArray(script_bytes_sized, 1, script_len);
+        let script_bytes = script_bytes_sized.sliceToArray(1, 1 + script_len);
 
         let control_block_bytes = control_block(tweaked_key_is_even, internal_public_key);
         // Obtain the scriptPubKey of the source address which is also the
@@ -221,7 +219,7 @@ module {
                 assert scriptPubKey.size() == 2;
 
                 // Obtain a witness for each Tx input.
-                for (i in Iter.range(0, transaction.txInputs.size() - 1)) {
+                for (i in transaction.txInputs.keys()) {
                     let sighash = transaction.createTaprootScriptSpendSignatureHash(
                         amounts,
                         scriptPubKey,
@@ -231,12 +229,12 @@ module {
 
                     Debug.print("Signing sighash: " # debug_show (sighash));
 
-                    let signature = Blob.toArray(await signer(schnorr_canister_actor, key_name, derivation_path, Blob.fromArray(sighash), null));
+                    let signature = (await signer(schnorr_canister_actor, key_name, derivation_path, Blob.fromArray(sighash), null)).toArray();
                     transaction.witnesses[i] := [signature, script_bytes, control_block_bytes];
                 };
             };
             // Verify that our own address is P2TR key spend address.
-            case (#err msg) Debug.trap("This example supports signing p2tr key spend addresses only: " # msg);
+            case (#err msg) Runtime.trap("This example supports signing p2tr key spend addresses only: " # msg);
         };
 
         transaction.toBytes();
@@ -284,14 +282,13 @@ module {
 
         // Build the transaction that sends `amount` to the destination address.
         let tx_bytes = await build_transaction(schnorr_canister_actor, own_address, own_utxos, dst_address, amount, fee_per_vbyte);
-        let transaction = Utils.get_ok(Transaction.fromBytes(Iter.fromArray(tx_bytes)));
+        let transaction = Utils.get_ok(Transaction.fromBytes(tx_bytes.vals()));
 
-        let tx_in_outpoints = Array.map<TxInput.TxInput, Types.OutPoint>(transaction.txInputs, func(txin) { txin.prevOutput });
+        let tx_in_outpoints = transaction.txInputs.map(func(txin : TxInput.TxInput) : Types.OutPoint { txin.prevOutput });
 
-        let amounts = Array.mapFilter<Utxo, Satoshi>(
-            own_utxos,
-            func(utxo) {
-                if (Option.isSome(Array.find<Types.OutPoint>(tx_in_outpoints, func(tx_in_outpoint) { tx_in_outpoint == utxo.outpoint }))) {
+        let amounts = own_utxos.filterMap(
+            func(utxo : Utxo) : ?Satoshi {
+                if (tx_in_outpoints.find(func(tx_in_outpoint : Types.OutPoint) : Bool { tx_in_outpoint == utxo.outpoint }).isSome()) {
                     ?utxo.value;
                 } else {
                     null;
@@ -299,10 +296,10 @@ module {
             },
         );
 
-        let signed_transaction_bytes = await sign_key_spend_transaction(schnorr_canister_actor, own_address, transaction, amounts, key_name, Array.map(signer_derivation_path, Blob.fromArray), aux, SchnorrApi.sign_with_schnorr);
+        let signed_transaction_bytes = await sign_key_spend_transaction(schnorr_canister_actor, own_address, transaction, amounts, key_name, signer_derivation_path.map(Blob.fromArray), aux, SchnorrApi.sign_with_schnorr);
 
         Debug.print("Sending transaction : " # debug_show (signed_transaction_bytes));
-        let signed_transaction = Utils.get_ok(Transaction.fromBytes(Iter.fromArray(signed_transaction_bytes)));
+        let signed_transaction = Utils.get_ok(Transaction.fromBytes(signed_transaction_bytes.vals()));
 
         Debug.print("Sending transaction...");
         await BitcoinApi.send_transaction(network, signed_transaction_bytes);
@@ -342,14 +339,13 @@ module {
 
         // Build the transaction that sends `amount` to the destination address.
         let tx_bytes = await build_transaction(schnorr_canister_actor, own_tweaked_address, own_utxos, dst_address, amount, fee_per_vbyte);
-        let transaction = Utils.get_ok(Transaction.fromBytes(Iter.fromArray(tx_bytes)));
+        let transaction = Utils.get_ok(Transaction.fromBytes(tx_bytes.vals()));
 
-        let tx_in_outpoints = Array.map<TxInput.TxInput, Types.OutPoint>(transaction.txInputs, func(txin) { txin.prevOutput });
+        let tx_in_outpoints = transaction.txInputs.map(func(txin : TxInput.TxInput) : Types.OutPoint { txin.prevOutput });
 
-        let amounts = Array.mapFilter<Utxo, Satoshi>(
-            own_utxos,
-            func(utxo) {
-                if (Option.isSome(Array.find<Types.OutPoint>(tx_in_outpoints, func(tx_in_outpoint) { tx_in_outpoint == utxo.outpoint }))) {
+        let amounts = own_utxos.filterMap(
+            func(utxo : Utxo) : ?Satoshi {
+                if (tx_in_outpoints.find(func(tx_in_outpoint : Types.OutPoint) : Bool { tx_in_outpoint == utxo.outpoint }).isSome()) {
                     ?utxo.value;
                 } else {
                     null;
@@ -367,12 +363,12 @@ module {
             transaction,
             amounts,
             key_name,
-            Array.map(derivation_paths.script_path_derivation_path, Blob.fromArray),
+            derivation_paths.script_path_derivation_path.map(Blob.fromArray),
             SchnorrApi.sign_with_schnorr,
         );
 
         Debug.print("Sending transaction : " # debug_show (signed_transaction_bytes));
-        let signed_transaction = Utils.get_ok(Transaction.fromBytes(Iter.fromArray(signed_transaction_bytes)));
+        let signed_transaction = Utils.get_ok(Transaction.fromBytes(signed_transaction_bytes.vals()));
 
         Debug.print("Sending transaction...");
         await BitcoinApi.send_transaction(network, signed_transaction_bytes);
@@ -386,13 +382,13 @@ module {
         let first_byte = [leaf_version | parity];
 
         if (internal_public_key.size() != 32) {
-            Debug.trap("Internal public key must be 32 bytes long to be used in control block.");
+            Runtime.trap("Internal public key must be 32 bytes long to be used in control block.");
         };
 
-        let result = Array.flatten([first_byte, internal_public_key]);
+        let result = [first_byte, internal_public_key].flatten();
 
         if (result.size() != 33) {
-            Debug.trap("Control block must be 33 bytes long.");
+            Runtime.trap("Control block must be 33 bytes long.");
         };
 
         result;
@@ -412,7 +408,7 @@ module {
 
         switch (Segwit.encode(hrp, { version; program = bip340_public_key_bytes })) {
             case (#ok address) address;
-            case (#err msg) Debug.trap("Error encoding segwit address: " # msg);
+            case (#err msg) Runtime.trap("Error encoding segwit address: " # msg);
         };
     };
 
@@ -421,7 +417,7 @@ module {
     };
 
     public func fetch_bip340_public_key(schnorr_canister_actor : SchnorrCanisterActor, key_name : Text, derivation_path : [[Nat8]]) : async [Nat8] {
-        let sec1_public_key = Blob.toArray(await SchnorrApi.schnorr_public_key(schnorr_canister_actor, key_name, Array.map(derivation_path, Blob.fromArray)));
-        Array.subArray(sec1_public_key, 1, 32);
+        let sec1_public_key = (await SchnorrApi.schnorr_public_key(schnorr_canister_actor, key_name, derivation_path.map(Blob.fromArray))).toArray();
+        sec1_public_key.sliceToArray(1, 33);
     };
 };

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/P2trKeyOnly.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/P2trKeyOnly.mo
@@ -10,8 +10,8 @@
 //! * Caching spent UTXOs so that they are not reused in future transactions.
 //! * Option to set the fee.
 
-import Nat8 "mo:base/Nat8";
-import Blob "mo:base/Blob";
+import Nat8 "mo:core/Nat8";
+import Blob "mo:core/Blob";
 
 import Script "mo:bitcoin/bitcoin/Script";
 import Transaction "mo:bitcoin/bitcoin/Transaction";

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/SchnorrApi.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/SchnorrApi.mo
@@ -1,6 +1,3 @@
-import ExperimentalCycles "mo:base/ExperimentalCycles";
-import Blob "mo:base/Blob";
-
 import Types "Types";
 
 module {
@@ -31,8 +28,7 @@ module {
   };
 
   public func sign_with_schnorr(schnorr_canister_actor : SchnorrCanisterActor, key_name : Text, derivation_path : [Blob], message : Blob, aux : ?Types.SchnorrAux) : async Blob {
-    ExperimentalCycles.add<system>(SIGN_WITH_SCHNORR_COST_CYCLES);
-    let res = await schnorr_canister_actor.sign_with_schnorr({
+    let res = await (with cycles = SIGN_WITH_SCHNORR_COST_CYCLES) schnorr_canister_actor.sign_with_schnorr({
       message;
       derivation_path;
       key_id = {

--- a/motoko/basic_bitcoin/src/basic_bitcoin/src/Utils.mo
+++ b/motoko/basic_bitcoin/src/basic_bitcoin/src/Utils.mo
@@ -1,11 +1,11 @@
-import Result "mo:base/Result";
-import Debug "mo:base/Debug";
-import Iter "mo:base/Iter";
-import Nat8 "mo:base/Nat8";
-import Prelude "mo:base/Prelude";
-import Text "mo:base/Text";
-import Blob "mo:base/Blob";
-import Array "mo:base/Array";
+import Result "mo:core/Result";
+import Debug "mo:core/Debug";
+import Iter "mo:core/Iter";
+import Nat8 "mo:core/Nat8";
+import Runtime "mo:core/Runtime";
+import Text "mo:core/Text";
+import Blob "mo:core/Blob";
+import Array "mo:core/Array";
 import Types "Types";
 
 module {
@@ -18,7 +18,7 @@ module {
     public func get_ok<T>(result : Result<T, Text>) : T {
         switch result {
             case (#ok value) value;
-            case (#err error) Debug.trap("pattern failed: " # error);
+            case (#err error) Runtime.trap("pattern failed: " # error);
         };
     };
 
@@ -27,7 +27,7 @@ module {
         switch result {
             case (#ok value) value;
             case (#err error) {
-                Debug.trap(expect # " pattern failed: " # error);
+                Runtime.trap(expect # " pattern failed: " # error);
             };
         };
     };
@@ -36,7 +36,7 @@ module {
     public func unwrap<T>(option : ?T) : T {
         switch option {
             case (?value) value;
-            case null Prelude.unreachable();
+            case null Runtime.unreachable();
         };
     };
 
@@ -60,7 +60,7 @@ module {
                 case 13 'd';
                 case 14 'e';
                 case 15 'f';
-                case _ Prelude.unreachable();
+                case _ Runtime.unreachable();
             }
         );
     };
@@ -74,16 +74,16 @@ module {
 
     /// Returns the hexadecimal representation of a byte array.
     public func bytesToText(bytes : [Nat8]) : Text {
-        Text.join("", Iter.map<Nat8, Text>(Iter.fromArray(bytes), func(n) { nat8ToText(n) }));
+        bytes.vals().map(func(n : Nat8) : Text { nat8ToText(n) }).join("");
     };
 
     /// A mock for rubber-stamping 64B ECDSA signatures.
     public func ecdsa_mock_signer(_ecdsa_canister_actor : EcdsaCanisterActor, _key_name : Text, _derivation_path : [Blob], _message_hash : Blob) : async Blob {
-        Blob.fromArray(Array.freeze(Array.init<Nat8>(64, 255)));
+        Blob.fromArray(Array.repeat(255 : Nat8, 64));
     };
 
     /// A mock for rubber-stamping 64B Schnorr signatures.
     public func schnorr_mock_signer(_schnorr_canister_actor : SchnorrCanisterActor, _key_name : Text, _derivation_path : [Blob], _message_hash : Blob, _aux : ?SchnorrAux) : async Blob {
-        Blob.fromArray(Array.freeze(Array.init<Nat8>(64, 255)));
+        Blob.fromArray(Array.repeat(255 : Nat8, 64));
     };
 };

--- a/motoko/icp_transfer/README.md
+++ b/motoko/icp_transfer/README.md
@@ -97,7 +97,7 @@ Don't forget to add the `icp_ledger_canister` as a dependency for `icp_transfer_
     "defaults": {
         "build": {
             "args": "",
-            "packtool": ""
+            "packtool": "mops sources"
         }
     },
     "output_env_file": ".env",
@@ -177,10 +177,10 @@ Replace the contents of the `src/icp_transfer_backend/main.mo` file with the fol
 
 ```motoko
 import IcpLedger "canister:icp_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
+import Principal "mo:core/Principal";
 
 persistent actor {
   type Tokens = {
@@ -213,7 +213,7 @@ persistent actor {
       // we are transferring from the canisters default subaccount, therefore we don't need to specify it
       from_subaccount = null;
       // we take the principal and subaccount from the arguments and convert them into an account identifier
-      to = Principal.toLedgerAccount(args.toPrincipal, args.toSubaccount);
+      to = args.toPrincipal.toLedgerAccount(args.toSubaccount);
       // a timestamp indicating when the transaction was created by the caller; if it is not specified by the caller then this is set to the current ICP time
       created_at_time = null;
     };
@@ -231,7 +231,7 @@ persistent actor {
       };
     } catch (error : Error) {
       // catch any errors that might occur during the transfer
-      return #err("Reject message: " # Error.message(error));
+      return #err("Reject message: " # error.message());
     };
   };
 };

--- a/motoko/icp_transfer/dfx.json
+++ b/motoko/icp_transfer/dfx.json
@@ -21,7 +21,7 @@
   "defaults": {
     "build": {
       "args": "",
-      "packtool": ""
+      "packtool": "mops sources"
     }
   },
   "output_env_file": ".env",

--- a/motoko/icp_transfer/mops.toml
+++ b/motoko/icp_transfer/mops.toml
@@ -3,7 +3,6 @@ moc = "1.5.1"
 
 [dependencies]
 core = "2.4.0"
-bitcoin = "0.1.0"
 
 [moc]
 # M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))

--- a/motoko/icp_transfer/src/icp_transfer_backend/main.mo
+++ b/motoko/icp_transfer/src/icp_transfer_backend/main.mo
@@ -1,8 +1,8 @@
 import IcpLedger "canister:icp_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
-import Principal "mo:base/Principal";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
+import Principal "mo:core/Principal";
 
 persistent actor {
   type Tokens = {
@@ -35,7 +35,7 @@ persistent actor {
       // we are transferring from the canisters default subaccount, therefore we don't need to specify it
       from_subaccount = null;
       // we take the principal and subaccount from the arguments and convert them into an account identifier
-      to = Principal.toLedgerAccount(args.toPrincipal, args.toSubaccount);
+      to = args.toPrincipal.toLedgerAccount(args.toSubaccount);
       // a timestamp indicating when the transaction was created by the caller; if it is not specified by the caller then this is set to the current ICP time
       created_at_time = null;
     };
@@ -53,7 +53,7 @@ persistent actor {
       };
     } catch (error : Error) {
       // catch any errors that might occur during the transfer
-      return #err("Reject message: " # Error.message(error));
+      return #err("Reject message: " # error.message());
     };
   };
 };

--- a/motoko/token_transfer/README.md
+++ b/motoko/token_transfer/README.md
@@ -66,7 +66,7 @@ Replace its contents with this but adapt the URLs to be the ones you determined 
     "defaults": {
         "build": {
             "args": "",
-            "packtool": ""
+            "packtool": "mops sources"
         }
     },
     "output_env_file": ".env",
@@ -159,9 +159,9 @@ Replace the contents of the `src/token_transfer_backend/main.mo` file with the f
 
 ```motoko
 import Icrc1Ledger "canister:icrc1_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
 
 persistent actor {
 
@@ -206,7 +206,7 @@ persistent actor {
       };
     } catch (error : Error) {
       // catch any errors that might occur during the transfer
-      return #err("Reject message: " # Error.message(error));
+      return #err("Reject message: " # error.message());
     };
   };
 };

--- a/motoko/token_transfer/dfx.json
+++ b/motoko/token_transfer/dfx.json
@@ -16,7 +16,7 @@
   "defaults": {
     "build": {
       "args": "",
-      "packtool": ""
+      "packtool": "mops sources"
     }
   },
   "output_env_file": ".env",

--- a/motoko/token_transfer/mops.toml
+++ b/motoko/token_transfer/mops.toml
@@ -3,7 +3,6 @@ moc = "1.5.1"
 
 [dependencies]
 core = "2.4.0"
-bitcoin = "0.1.0"
 
 [moc]
 # M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))

--- a/motoko/token_transfer/src/token_transfer_backend/main.mo
+++ b/motoko/token_transfer/src/token_transfer_backend/main.mo
@@ -1,7 +1,7 @@
 import Icrc1Ledger "canister:icrc1_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
 
 persistent actor {
 
@@ -46,7 +46,7 @@ persistent actor {
       };
     } catch (error : Error) {
       // catch any errors that might occur during the transfer
-      return #err("Reject message: " # Error.message(error));
+      return #err("Reject message: " # error.message());
     };
   };
 };

--- a/motoko/token_transfer_from/README.md
+++ b/motoko/token_transfer_from/README.md
@@ -66,7 +66,7 @@ Replace its contents with this but adapt the URLs to be the ones you determined 
     "defaults": {
         "build": {
             "args": "",
-            "packtool": ""
+            "packtool": "mops sources"
         }
     },
     "output_env_file": ".env",
@@ -173,9 +173,9 @@ Replace the contents of the `src/token_transfer_from_backend/main.mo` file with 
 
 ```motoko
 import Icrc1Ledger "canister:icrc1_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
 
 persistent actor {
 
@@ -225,7 +225,7 @@ persistent actor {
       };
     } catch (error : Error) {
       // catch any errors that might occur during the transfer
-      return #err("Reject message: " # Error.message(error));
+      return #err("Reject message: " # error.message());
     };
   };
 };

--- a/motoko/token_transfer_from/dfx.json
+++ b/motoko/token_transfer_from/dfx.json
@@ -15,7 +15,7 @@
   "defaults": {
     "build": {
       "args": "",
-      "packtool": ""
+      "packtool": "mops sources"
     }
   },
   "output_env_file": ".env",

--- a/motoko/token_transfer_from/mops.toml
+++ b/motoko/token_transfer_from/mops.toml
@@ -3,7 +3,6 @@ moc = "1.5.1"
 
 [dependencies]
 core = "2.4.0"
-bitcoin = "0.1.0"
 
 [moc]
 # M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))

--- a/motoko/token_transfer_from/src/token_transfer_from_backend/main.mo
+++ b/motoko/token_transfer_from/src/token_transfer_from_backend/main.mo
@@ -1,7 +1,7 @@
 import Icrc1Ledger "canister:icrc1_ledger_canister";
-import Debug "mo:base/Debug";
-import Result "mo:base/Result";
-import Error "mo:base/Error";
+import Debug "mo:core/Debug";
+import Result "mo:core/Result";
+import Error "mo:core/Error";
 
 persistent actor {
 
@@ -51,7 +51,7 @@ persistent actor {
       };
     } catch (error : Error) {
       // catch any errors that might occur during the transfer
-      return #err("Reject message: " # Error.message(error));
+      return #err("Reject message: " # error.message());
     };
   };
 };


### PR DESCRIPTION
## Summary

- Migrates `basic_bitcoin`, `icp_transfer`, `token_transfer`, and `token_transfer_from` from `mo:base` to `mo:core 2.4.0`
- Adds `mops.toml` (with `[moc] args = ["-W=M0236,M0237,M0223"]`) to the three DeFi examples that had none before
- Updates `dfx.json` to set `"packtool": "mops sources"` for the three examples that previously had no mops dependency
- Applies modern Motoko style: `persistent actor`, `transient let`, context dot notation, `await (with cycles = ...)`, `Runtime.trap` instead of `Debug.trap`
- Updates embedded Motoko code snippets in all four READMEs to reflect the new imports and API usage