### PR TITLE
chore: use compact -W=M0236,M0237,M0223 format in languages mops.toml

### DIFF
--- a/motoko/classes/mops.toml
+++ b/motoko/classes/mops.toml
@@ -10,4 +10,4 @@ core = "2.4.0"
 # M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
 # M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
 # M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/composite_query/mops.toml
+++ b/motoko/composite_query/mops.toml
@@ -10,4 +10,4 @@ core = "2.4.0"
 # M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
 # M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
 # M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/hello_cycles/mops.toml
+++ b/motoko/hello_cycles/mops.toml
@@ -10,4 +10,4 @@ core = "2.4.0"
 # M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
 # M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
 # M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/low_wasm_memory/mops.toml
+++ b/motoko/low_wasm_memory/mops.toml
@@ -10,4 +10,4 @@ core = "2.4.0"
 # M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
 # M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
 # M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/parallel_calls/mops.toml
+++ b/motoko/parallel_calls/mops.toml
@@ -10,4 +10,4 @@ core = "2.4.0"
 # M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
 # M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
 # M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/random_maze/mops.toml
+++ b/motoko/random_maze/mops.toml
@@ -10,4 +10,4 @@ core = "2.4.0"
 # M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
 # M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
 # M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["-W", "M0236", "-W", "M0237", "-W", "M0223"]
+args = ["-W=M0236,M0237,M0223"]


### PR DESCRIPTION
## Summary

- Updates `[moc] args` in `mops.toml` from `["-W", "M0236", "-W", "M0237", "-W", "M0223"]` to the compact `["-W=M0236,M0237,M0223"]` form for all `@dfinity/languages`-owned examples
- Affected: `classes`, `composite_query`, `hello_cycles`, `low_wasm_memory`, `parallel_calls`, `random_maze`