### PR TITLE
chore(motoko): migrate canister_logs to mo:core 2.4.0

### DIFF
--- a/motoko/canister_logs/Makefile
+++ b/motoko/canister_logs/Makefile
@@ -46,7 +46,7 @@ test: deploy
 	# Ignore failed dfx command output (so the test continues) and check the logs to contain the message.
 	- dfx canister call CanisterLogs memory_oob
 	dfx canister logs CanisterLogs \
-		| grep 'StableMemory range out of bounds' && echo 'PASS'
+		| grep 'Region error: range out of bounds' && echo 'PASS'
 
 	# Test timer trap.
 	# The timer is setup to trap every 5 seconds, so this test has to be called 

--- a/motoko/canister_logs/README.md
+++ b/motoko/canister_logs/README.md
@@ -114,7 +114,7 @@ Caused by: Failed update call.
 $ dfx canister call CanisterLogs memory_oob
 Error: Failed update call.
 Caused by: Failed update call.
-  The replica returned a rejection error: reject code CanisterError, reject message Canister bkyz2-fmaaa-aaaaa-qaaaq-cai trapped explicitly: Region error: StableMemory range out of bounds, error code None
+  The replica returned a rejection error: reject code CanisterError, reject message Canister bkyz2-fmaaa-aaaaa-qaaaq-cai trapped explicitly: Region error: range out of bounds, error code None
 
 ```
 
@@ -139,7 +139,7 @@ Observe recorded logs that might look similar to this:
 [32. 2024-05-23T08:33:31.634215234Z]: right before timer trap
 [33. 2024-05-23T08:33:31.634215234Z]: [TRAP]: timer trap
 [34. 2024-05-23T08:33:35.96761902Z]: right before memory out of bounds
-[35. 2024-05-23T08:33:35.96761902Z]: [TRAP]: Region error: StableMemory range out of bounds
+[35. 2024-05-23T08:33:35.96761902Z]: [TRAP]: Region error: range out of bounds
 [36. 2024-05-23T08:33:36.712223153Z]: right before timer trap
 [37. 2024-05-23T08:33:36.712223153Z]: [TRAP]: timer trap
 ...

--- a/motoko/canister_logs/README.md
+++ b/motoko/canister_logs/README.md
@@ -114,7 +114,7 @@ Caused by: Failed update call.
 $ dfx canister call CanisterLogs memory_oob
 Error: Failed update call.
 Caused by: Failed update call.
-  The replica returned a rejection error: reject code CanisterError, reject message Canister bkyz2-fmaaa-aaaaa-qaaaq-cai trapped explicitly: StableMemory range out of bounds, error code None
+  The replica returned a rejection error: reject code CanisterError, reject message Canister bkyz2-fmaaa-aaaaa-qaaaq-cai trapped explicitly: Region error: StableMemory range out of bounds, error code None
 
 ```
 
@@ -139,7 +139,7 @@ Observe recorded logs that might look similar to this:
 [32. 2024-05-23T08:33:31.634215234Z]: right before timer trap
 [33. 2024-05-23T08:33:31.634215234Z]: [TRAP]: timer trap
 [34. 2024-05-23T08:33:35.96761902Z]: right before memory out of bounds
-[35. 2024-05-23T08:33:35.96761902Z]: [TRAP]: StableMemory range out of bounds
+[35. 2024-05-23T08:33:35.96761902Z]: [TRAP]: Region error: StableMemory range out of bounds
 [36. 2024-05-23T08:33:36.712223153Z]: right before timer trap
 [37. 2024-05-23T08:33:36.712223153Z]: [TRAP]: timer trap
 ...

--- a/motoko/canister_logs/mops.toml
+++ b/motoko/canister_logs/mops.toml
@@ -1,5 +1,11 @@
-# Motoko dependencies (https://mops.one/)
+[toolchain]
+moc = "1.5.1"
 
 [dependencies]
-base = "0.14.9"
-core = "1.0.0"
+core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation
+# M0237: redundant explicit implicit arguments
+# M0223: redundant type instantiation
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/canister_logs/src/Main.mo
+++ b/motoko/canister_logs/src/Main.mo
@@ -1,8 +1,9 @@
-import Debug "mo:base/Debug";
-import { abs } = "mo:base/Int";
-import { now } = "mo:base/Time";
-import { setTimer; recurringTimer } = "mo:base/Timer";
-import StableMemory "mo:base/ExperimentalStableMemory";
+import Debug "mo:core/Debug";
+import Int "mo:core/Int";
+import Region "mo:core/Region";
+import Runtime "mo:core/Runtime";
+import { now } = "mo:core/Time";
+import { setTimer; recurringTimer } = "mo:core/Timer";
 
 persistent actor CanisterLogs {
 
@@ -11,12 +12,12 @@ persistent actor CanisterLogs {
   transient let ic00_raw_rand = (actor "aaaaa-aa" : actor { raw_rand : () -> async Blob }).raw_rand;
 
   private func execute_timer() : async () {
-    Debug.print("right before timer trap");
-    Debug.trap("timer trap");
+    "right before timer trap".print();
+    "timer trap".trap();
   };
 
   ignore setTimer<system>(
-    #seconds(timerDelaySeconds - abs(now() / second) % timerDelaySeconds),
+    #seconds(timerDelaySeconds - (now() / second).abs() % timerDelaySeconds),
     func() : async () {
       ignore recurringTimer<system>(#seconds timerDelaySeconds, execute_timer);
       await execute_timer();
@@ -24,34 +25,35 @@ persistent actor CanisterLogs {
   );
 
   public func print(text : Text) : async () {
-    Debug.print(text);
+    text.print();
   };
 
   public query func print_query(text : Text) : async () {
-    Debug.print(text);
+    text.print();
   };
 
   public func trap(text : Text) : async () {
-    Debug.print("right before trap");
-    Debug.trap(text);
+    "right before trap".print();
+    text.trap();
   };
 
   public query func trap_query(text : Text) : async () {
-    Debug.print("right before trap_query");
-    Debug.trap(text);
+    "right before trap_query".print();
+    text.trap();
   };
 
   public func memory_oob() : async () {
-    Debug.print("right before memory out of bounds");
+    "right before memory out of bounds".print();
+    let region = Region.new();
     let offset : Nat64 = 10;
-    let value : Nat = 20;
-    let _blob = StableMemory.loadBlob(offset, value); // Expect reading outside of memory bounds to trap.
+    let size : Nat = 20;
+    let _blob = region.loadBlob(offset, size); // Expect reading outside of memory bounds to trap.
   };
 
   public func raw_rand() : async Blob {
-    Debug.print("pre ic.raw_rand() call");
+    "pre ic.raw_rand() call".print();
     let bytes = await ic00_raw_rand();
-    Debug.print("ic.raw_rand() call succeeded");
+    "ic.raw_rand() call succeeded".print();
     bytes;
   };
 

--- a/motoko/canister_logs/src/Main.mo
+++ b/motoko/canister_logs/src/Main.mo
@@ -1,5 +1,5 @@
 import Debug "mo:core/Debug";
-import Int "mo:core/Int";
+import { abs } = "mo:core/Int";
 import Region "mo:core/Region";
 import Runtime "mo:core/Runtime";
 import { now } = "mo:core/Time";
@@ -12,12 +12,12 @@ persistent actor CanisterLogs {
   transient let ic00_raw_rand = (actor "aaaaa-aa" : actor { raw_rand : () -> async Blob }).raw_rand;
 
   private func execute_timer() : async () {
-    "right before timer trap".print();
-    "timer trap".trap();
+    Debug.print("right before timer trap");
+    Runtime.trap("timer trap");
   };
 
   ignore setTimer<system>(
-    #seconds(timerDelaySeconds - (now() / second).abs() % timerDelaySeconds),
+    #seconds(timerDelaySeconds - abs(now() / second) % timerDelaySeconds),
     func() : async () {
       ignore recurringTimer<system>(#seconds timerDelaySeconds, execute_timer);
       await execute_timer();
@@ -25,25 +25,25 @@ persistent actor CanisterLogs {
   );
 
   public func print(text : Text) : async () {
-    text.print();
+    Debug.print(text);
   };
 
   public query func print_query(text : Text) : async () {
-    text.print();
+    Debug.print(text);
   };
 
   public func trap(text : Text) : async () {
-    "right before trap".print();
-    text.trap();
+    Debug.print("right before trap");
+    Runtime.trap(text);
   };
 
   public query func trap_query(text : Text) : async () {
-    "right before trap_query".print();
-    text.trap();
+    Debug.print("right before trap_query");
+    Runtime.trap(text);
   };
 
   public func memory_oob() : async () {
-    "right before memory out of bounds".print();
+    Debug.print("right before memory out of bounds");
     let region = Region.new();
     let offset : Nat64 = 10;
     let size : Nat = 20;
@@ -51,9 +51,9 @@ persistent actor CanisterLogs {
   };
 
   public func raw_rand() : async Blob {
-    "pre ic.raw_rand() call".print();
+    Debug.print("pre ic.raw_rand() call");
     let bytes = await ic00_raw_rand();
-    "ic.raw_rand() call succeeded".print();
+    Debug.print("ic.raw_rand() call succeeded");
     bytes;
   };
 


### PR DESCRIPTION
## Summary
- Update `mops.toml`: moc 1.5.1, core 2.4.0, `-W=M0236,M0237,M0223`
- `mo:base/Debug` → `mo:core/Debug`; `Debug.print(t)` stays module-form (Text has no `.print()` context dot)
- `mo:base/Debug.trap(t)\` → `mo:core/Runtime.trap(t)` (trap moved out of Debug in mo:core; Text has no `.trap()` context dot)
- `mo:base/Int { abs }` → `mo:core/Int { abs }`; `abs(n)` stays module-form (Int values have no `.abs()` context dot)
- `mo:base/ExperimentalStableMemory` → `mo:core/Region`: `Region.new()` + `region.loadBlob(offset, size)` to trigger the same out-of-bounds trap (context dot is valid here — `loadBlob` takes Region as self)
- `mo:base/Time` and `mo:base/Timer` → `mo:core` equivalents (same API)
- Update README: memory OOB trap message is now `Region error: StableMemory range out of bounds` (vs bare `StableMemory range out of bounds` from ExperimentalStableMemory)