### PR TITLE
chore(motoko): migrate cert-var to mo:core 2.4.0

### DIFF
--- a/motoko/cert-var/dfx.json
+++ b/motoko/cert-var/dfx.json
@@ -20,7 +20,7 @@
   },
   "defaults": {
     "build": {
-      "packtool": ""
+      "packtool": "mops sources"
     }
   },
   "version": 1

--- a/motoko/cert-var/mops.toml
+++ b/motoko/cert-var/mops.toml
@@ -1,0 +1,11 @@
+[toolchain]
+moc = "1.5.1"
+
+[dependencies]
+core = "2.4.0"
+
+[moc]
+# M0236: use context dot notation
+# M0237: redundant explicit implicit arguments
+# M0223: redundant type instantiation
+args = ["-W=M0236,M0237,M0223"]

--- a/motoko/cert-var/src/cert_var/main.mo
+++ b/motoko/cert-var/src/cert_var/main.mo
@@ -1,10 +1,8 @@
-/// Simple counter (see `Counter.mo`), but uses `mo:base/CertifiedData` to
+/// Simple counter (see `Counter.mo`), but uses `mo:core/CertifiedData` to
 /// implement the counter value as a certified variable.
-import CD "mo:base/CertifiedData";
-import Blob "mo:base/Blob";
-import Nat8 "mo:base/Nat8";
-import Nat32 "mo:base/Nat32";
-import Debug "mo:base/Debug";
+import CD "mo:core/CertifiedData";
+import Blob "mo:core/Blob";
+import Nat32 "mo:core/Nat32";
 
 persistent actor Variable {
 
@@ -14,14 +12,12 @@ persistent actor Variable {
   /// LE encoding matches Candid encoding of Nat32, for consistency and convenience.
   func blobOfNat32(n : Nat32) : Blob {
     let byteMask : Nat32 = 0xff;
-    func byte(x : Nat32) : Nat8 {
-      Nat8.fromNat(Nat32.toNat(x));
-    };
+    func byte(x : Nat32) : Nat8 = x.toNat8();
     Blob.fromArray([
-      byte(((byteMask << 0) & value) >> 0),
-      byte(((byteMask << 8) & value) >> 8),
-      byte(((byteMask << 16) & value) >> 16),
-      byte(((byteMask << 24) & value) >> 24),
+      byte(((byteMask << 0) & n) >> 0),
+      byte(((byteMask << 8) & n) >> 8),
+      byte(((byteMask << 16) & n) >> 16),
+      byte(((byteMask << 24) & n) >> 24),
     ]);
   };
 


### PR DESCRIPTION
## Summary
- Add `mops.toml`: moc 1.5.1, core 2.4.0, `-W=M0236,M0237,M0223`
- Update `dfx.json` packtool to `mops sources`
- Replace `mo:base` imports with `mo:core` equivalents
- Drop unused `Debug` import
- Use `x.toNat8()` context dot instead of `Nat8.fromNat(Nat32.toNat(x))`, dropping the `Nat8` import
- Fix M0194: `blobOfNat32` was using captured actor field `value` instead of its parameter `n` (functionally equivalent since it's always called with `value`, but causes an unused-parameter warning)