### PR TITLE
Add ReadMe troubleshooting section for network start issues

### DIFF
--- a/motoko/hello_world/README.md
+++ b/motoko/hello_world/README.md
@@ -67,6 +67,42 @@ If you modify the backend's public API, regenerate the `.did` file using the Mot
 ```bash
 $(mops toolchain bin moc) --idl -o backend/backend.did backend/app.mo
 ```
+## Troubleshooting
+
+### `icp network start` exits with status 101
+
+The error message is:
+Error: network launcher ... exited prematurely with status exit status: 101
+
+The real cause is hidden in the log file at:
+.icp/cache/networks/local/network-launcher/stderr.log
+
+Always check that file first:
+```bash
+cat .icp/cache/networks/local/network-launcher/stderr.log
+```
+#### Cause: port 8000 already in use
+
+The most common cause is another process (e.g. a Docker container) already bound to port 8000:
+Failed to bind to address 127.0.0.1:8000: Address already in use (os error 98)
+
+**Fix:**
+```bash
+# Find what's using port 8000
+sudo lsof -i :8000
+# or
+sudo ss -tlnp | grep 8000
+
+Then kill it:
+bash# Replace <PID> with the number from the output above
+sudo kill -9 <PID>
+
+Or do it in one shot:
+bashsudo fuser -k 8000/tcp
+
+# Then retry
+icp network start -d
+```
 
 ## Security considerations and best practices
 


### PR DESCRIPTION
**Overview**
When `icp network start` exits with status 101, the terminal output gives no
actionable information. The actual error (e.g. port conflict) is silently written
to a log file that new users have no reason to know exists. This leaves developers
stuck with a cryptic error and no clear path to resolution.

**Requirements**
- Document where to find the real error log
- Cover the most common root cause (port 8000 already in use)
- Provide a concrete fix for the Docker port conflict case
- The fix must get `icp network start -d` running successfully

**Considered Solutions**
1. Improve the CLI output to surface the log file contents directly in the terminal
   instead of just reporting exit status 101 — this would be the ideal long-term fix
   but requires changes to the network launcher itself.
2. Document the issue in the troubleshooting guide so users can self-diagnose
   immediately — low effort, high impact, no code changes required.

**Recommended Solution**
Option 2 — documentation. It unblocks users today without touching any code.
The log file path and the port conflict error message are stable and reliable
signals, making them safe to document. Option 1 is worth a separate issue/PR
targeting the CLI itself.

**Considerations**
- **Security:** None. No code changes, no new behavior.
- **Performance:** None.
- **Users:** Purely additive. Existing workflows are unaffected; new users get
  a faster path to resolution instead of hitting a dead end.
- **Breaking changes:** None.
- **Maintenance:** Low. The log file path and pocket-ic port binding behavior
  are unlikely to change frequently. If the default port ever changes, this
  section will need a one-line update.