### PR TITLE
chore: bump icp-dev-env to 0.3.1, asset-canister to v2.2.1, and Motoko recipe to v5.0.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "ICP Examples (Motoko + Rust)",
-  "image": "ghcr.io/dfinity/icp-dev-env-all:0.1.0",
+  "image": "ghcr.io/dfinity/icp-dev-env-all:0.3.1",
   "forwardPorts": [8000, 5173],
   "portsAttributes": {
     "8000": {

--- a/.github/workflows/hello_world.yml
+++ b/.github/workflows/hello_world.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   motoko-hello_world:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test
@@ -29,7 +29,7 @@ jobs:
 
   rust-hello_world:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test

--- a/.github/workflows/vetkeys-basic-bls-signing.yml
+++ b/.github/workflows/vetkeys-basic-bls-signing.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +26,7 @@ jobs:
         run: icp network start -d && icp deploy
   motoko:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/vetkeys-basic-ibe.yml
+++ b/.github/workflows/vetkeys-basic-ibe.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +26,7 @@ jobs:
         run: icp network start -d && icp deploy
   motoko:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/vetkeys-basic-timelock-ibe.yml
+++ b/.github/workflows/vetkeys-basic-timelock-ibe.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/vetkeys-encrypted-notes-app-vetkd.yml
+++ b/.github/workflows/vetkeys-encrypted-notes-app-vetkd.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +26,7 @@ jobs:
         run: icp network start -d && icp deploy
   motoko:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/vetkeys-password-manager-with-metadata.yml
+++ b/.github/workflows/vetkeys-password-manager-with-metadata.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +26,7 @@ jobs:
         run: icp network start -d && icp deploy
   motoko:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/vetkeys-password-manager.yml
+++ b/.github/workflows/vetkeys-password-manager.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   rust:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -26,7 +26,7 @@ jobs:
         run: icp network start -d && icp deploy
   motoko:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/who_am_i.yml
+++ b/.github/workflows/who_am_i.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   motoko-who_am_i:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test
@@ -29,7 +29,7 @@ jobs:
 
   rust-who_am_i:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-rust:0.1.0
+    container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ canisters:
 
 ```toml
 [toolchain]
-moc = "1.8.2"
+moc = "1.9.0"
 
 [dependencies]
 core = "2.5.0"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ canisters:
 
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: frontend/dist
         build:
@@ -129,7 +129,7 @@ canisters:
 
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: frontend/dist
         build:
@@ -314,7 +314,7 @@ Rust: `icp build backend && candid-extractor target/wasm32-unknown-unknown/relea
 ## Pending items (do not resolve prematurely)
 
 ### Container images
-Images are published at `ghcr.io/dfinity/icp-dev-env-{motoko,rust,all}`. All devcontainer configs and CI workflows reference the pinned tag (e.g. `0.1.0`). When a new release is cut, update the tag in:
+Images are published at `ghcr.io/dfinity/icp-dev-env-{motoko,rust,all}`. All devcontainer configs and CI workflows reference the pinned tag (e.g. `0.3.1`). When a new release is cut, update the tag in:
 - `.devcontainer/devcontainer.json`
 - `.github/workflows/*.yml`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,10 +101,7 @@ networks:                          # omit if no Internet Identity needed
 canisters:
   - name: backend
     recipe:
-      type: https://raw.githubusercontent.com/dfinity/icp-cli-recipes/bc9581d9258d2d7feb15ab4ae8d04baf923b985f/recipes/motoko/recipe.hbs
-      # TODO: replace with @dfinity/motoko@vX.Y.Z once https://github.com/dfinity/icp-cli-recipes/pull/26 merges
-      configuration:
-        name: backend                  # must match [canisters.backend] key in mops.toml
+      type: "@dfinity/motoko@v5.0.0"
 
   - name: frontend
     recipe:
@@ -161,7 +158,7 @@ main = "backend/app.mo"
 candid = "backend/backend.did"
 ```
 
-`[canisters.<name>]` replaces the `main`, `candid`, and `args` fields that were previously in `icp.yaml`. The `name` key must match the `name` in the recipe configuration. `--default-persistent-actors` makes all actors persistent by default, so the `persistent` keyword is not needed in source files.
+`[canisters.<name>]` replaces the `main`, `candid`, and `args` fields that were previously in `icp.yaml`. The `@dfinity/motoko@v5.0.0` recipe reads this section directly, so the Motoko canister needs no `configuration:` block in `icp.yaml` — the `<name>` must match the canister `name` in `icp.yaml`. `--default-persistent-actors` makes all actors persistent by default, so the `persistent` keyword is not needed in source files.
 
 ---
 
@@ -319,17 +316,6 @@ Images are published at `ghcr.io/dfinity/icp-dev-env-{motoko,rust,all}`. All dev
 - `.github/workflows/*.yml`
 
 Source: https://github.com/dfinity/icp-dev-env
-
-### Motoko recipe version
-Both `motoko/who_am_i/icp.yaml` and `motoko/hello_world/icp.yaml` pin a specific commit SHA of the Motoko recipe to pick up `[moc] args` support from `mops.toml` before it ships in a stable release:
-
-```yaml
-type: https://raw.githubusercontent.com/dfinity/icp-cli-recipes/bc9581d9258d2d7feb15ab4ae8d04baf923b985f/recipes/motoko/recipe.hbs
-```
-
-Tracked in: https://github.com/dfinity/icp-cli-recipes/pull/26
-
-Once that PR merges and a new `@dfinity/motoko` version is released, replace the raw URL in both files with the versioned tag (e.g. `@dfinity/motoko@vX.Y.Z`).
 
 ---
 

--- a/motoko/hello_world/icp.yaml
+++ b/motoko/hello_world/icp.yaml
@@ -7,7 +7,7 @@ canisters:
 
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: frontend/dist
         build:

--- a/motoko/hello_world/icp.yaml
+++ b/motoko/hello_world/icp.yaml
@@ -1,9 +1,7 @@
 canisters:
   - name: backend
     recipe:
-      type: https://raw.githubusercontent.com/dfinity/icp-cli-recipes/bc9581d9258d2d7feb15ab4ae8d04baf923b985f/recipes/motoko/recipe.hbs
-      configuration:
-        name: backend
+      type: "@dfinity/motoko@v5.0.0"
 
   - name: frontend
     recipe:

--- a/motoko/who_am_i/icp.yaml
+++ b/motoko/who_am_i/icp.yaml
@@ -12,7 +12,7 @@ canisters:
 
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: src/frontend/dist
         build:

--- a/motoko/who_am_i/icp.yaml
+++ b/motoko/who_am_i/icp.yaml
@@ -6,9 +6,7 @@ networks:
 canisters:
   - name: backend
     recipe:
-      type: https://raw.githubusercontent.com/dfinity/icp-cli-recipes/bc9581d9258d2d7feb15ab4ae8d04baf923b985f/recipes/motoko/recipe.hbs
-      configuration:
-        name: backend
+      type: "@dfinity/motoko@v5.0.0"
 
   - name: frontend
     recipe:

--- a/rust/hello_world/icp.yaml
+++ b/rust/hello_world/icp.yaml
@@ -8,7 +8,7 @@ canisters:
 
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: frontend/dist
         build:

--- a/rust/vetkeys/basic_bls_signing/motoko/icp.yaml
+++ b/rust/vetkeys/basic_bls_signing/motoko/icp.yaml
@@ -1,9 +1,7 @@
 canisters:
   - name: basic_bls_signing
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: backend/src/Main.mo
+      type: "@dfinity/motoko@v5.0.0"
     init_args:
       type: text
       value: "(\"test_key_1\")"

--- a/rust/vetkeys/basic_bls_signing/motoko/icp.yaml
+++ b/rust/vetkeys/basic_bls_signing/motoko/icp.yaml
@@ -10,7 +10,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/basic_bls_signing/motoko/mops.toml
+++ b/rust/vetkeys/basic_bls_signing/motoko/mops.toml
@@ -5,3 +5,6 @@ moc = "1.9.0"
 core = "2.5.0"
 ic-vetkeys = "0.5.0"
 sha2 = "0.1.14"
+
+[canisters.basic_bls_signing]
+main = "backend/src/Main.mo"

--- a/rust/vetkeys/basic_bls_signing/rust/icp.yaml
+++ b/rust/vetkeys/basic_bls_signing/rust/icp.yaml
@@ -11,7 +11,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/basic_ibe/motoko/icp.yaml
+++ b/rust/vetkeys/basic_ibe/motoko/icp.yaml
@@ -10,7 +10,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/basic_ibe/motoko/icp.yaml
+++ b/rust/vetkeys/basic_ibe/motoko/icp.yaml
@@ -1,9 +1,7 @@
 canisters:
   - name: basic_ibe
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: backend/src/Main.mo
+      type: "@dfinity/motoko@v5.0.0"
     init_args:
       type: text
       value: "(\"test_key_1\")"

--- a/rust/vetkeys/basic_ibe/motoko/mops.toml
+++ b/rust/vetkeys/basic_ibe/motoko/mops.toml
@@ -5,3 +5,6 @@ moc = "1.9.0"
 core = "2.5.0"
 ic-vetkeys = "0.5.0"
 sha2 = "0.1.14"
+
+[canisters.basic_ibe]
+main = "backend/src/Main.mo"

--- a/rust/vetkeys/basic_ibe/rust/icp.yaml
+++ b/rust/vetkeys/basic_ibe/rust/icp.yaml
@@ -11,7 +11,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/basic_timelock_ibe/icp.yaml
+++ b/rust/vetkeys/basic_timelock_ibe/icp.yaml
@@ -11,7 +11,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/encrypted_notes_app_vetkd/motoko/icp.yaml
+++ b/rust/vetkeys/encrypted_notes_app_vetkd/motoko/icp.yaml
@@ -1,9 +1,7 @@
 canisters:
   - name: encrypted_notes
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: backend/main.mo
+      type: "@dfinity/motoko@v5.0.0"
     init_args:
       type: text
       value: "(\"test_key_1\")"

--- a/rust/vetkeys/encrypted_notes_app_vetkd/motoko/icp.yaml
+++ b/rust/vetkeys/encrypted_notes_app_vetkd/motoko/icp.yaml
@@ -10,7 +10,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/encrypted_notes_app_vetkd/motoko/mops.toml
+++ b/rust/vetkeys/encrypted_notes_app_vetkd/motoko/mops.toml
@@ -3,3 +3,6 @@ moc = "1.9.0"
 
 [dependencies]
 core = "2.5.0"
+
+[canisters.encrypted_notes]
+main = "backend/main.mo"

--- a/rust/vetkeys/encrypted_notes_app_vetkd/rust/icp.yaml
+++ b/rust/vetkeys/encrypted_notes_app_vetkd/rust/icp.yaml
@@ -11,7 +11,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/password_manager/motoko/icp.yaml
+++ b/rust/vetkeys/password_manager/motoko/icp.yaml
@@ -10,7 +10,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/password_manager/motoko/icp.yaml
+++ b/rust/vetkeys/password_manager/motoko/icp.yaml
@@ -1,9 +1,7 @@
 canisters:
   - name: ic_vetkeys_encrypted_maps_canister
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: backend/src/Main.mo
+      type: "@dfinity/motoko@v5.0.0"
     init_args:
       type: text
       value: "(\"test_key_1\")"

--- a/rust/vetkeys/password_manager/motoko/mops.toml
+++ b/rust/vetkeys/password_manager/motoko/mops.toml
@@ -4,3 +4,6 @@ moc = "1.9.0"
 [dependencies]
 core = "2.5.0"
 ic-vetkeys = "0.5.0"
+
+[canisters.ic_vetkeys_encrypted_maps_canister]
+main = "backend/src/Main.mo"

--- a/rust/vetkeys/password_manager/rust/icp.yaml
+++ b/rust/vetkeys/password_manager/rust/icp.yaml
@@ -11,7 +11,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/password_manager_with_metadata/motoko/icp.yaml
+++ b/rust/vetkeys/password_manager_with_metadata/motoko/icp.yaml
@@ -1,9 +1,7 @@
 canisters:
   - name: password_manager_with_metadata
     recipe:
-      type: "@dfinity/motoko@v4.1.0"
-      configuration:
-        main: backend/src/Main.mo
+      type: "@dfinity/motoko@v5.0.0"
     init_args:
       type: text
       value: "(\"test_key_1\")"

--- a/rust/vetkeys/password_manager_with_metadata/motoko/icp.yaml
+++ b/rust/vetkeys/password_manager_with_metadata/motoko/icp.yaml
@@ -10,7 +10,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/vetkeys/password_manager_with_metadata/motoko/mops.toml
+++ b/rust/vetkeys/password_manager_with_metadata/motoko/mops.toml
@@ -4,3 +4,5 @@ moc = "1.9.0"
 [dependencies]
 core = "2.5.0"
 ic-vetkeys = "0.5.0"
+[canisters.password_manager_with_metadata]
+main = "backend/src/Main.mo"

--- a/rust/vetkeys/password_manager_with_metadata/rust/icp.yaml
+++ b/rust/vetkeys/password_manager_with_metadata/rust/icp.yaml
@@ -11,7 +11,7 @@ canisters:
 
   - name: www
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/rust/who_am_i/icp.yaml
+++ b/rust/who_am_i/icp.yaml
@@ -13,7 +13,7 @@ canisters:
 
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: src/frontend/dist
         build:


### PR DESCRIPTION
## Summary

- Bumps CI workflow container images from `icp-dev-env-{motoko,rust}:0.1.0` to `0.3.1` for all examples that already use the new images (`hello_world`, `who_am_i`, all vetkeys variants)
- Updates asset-canister recipe from `@dfinity/asset-canister@v2.1.0` to `v2.2.1` in the corresponding `icp.yaml` files — v2.2.1 uses a `type: plugin` sync step internally, replacing the `type: assets` built-in that was removed in icp-cli v0.3.0
- Updates Motoko recipe from the pinned SHA URL / `@dfinity/motoko@v4.1.0` to `@dfinity/motoko@v5.0.0` — the new recipe reads the entry point from `mops.toml`'s `[canisters.<name>]` section, so the `configuration:` block in `icp.yaml` is no longer needed and has been removed
- Updates AGENTS.md canonical snippets and pinned tag example to reflect the new versions

## Test plan

- [ ] CI passes on the affected workflows (hello_world, who_am_i, vetkeys-*)
- [ ] No other examples were modified

🤖 Generated with [Claude Code](https://claude.ai/claude-code)