### PR TITLE
chore: replace @dfinity/editorial with @dfinity/dx in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @dfinity/editorial
+* @dfinity/dx
 .github/workflows/ninja_pr_checks.yml @dfinity/ninja-devs
 
 /hosting/godot-html5-template/ @dfinity/sdk


### PR DESCRIPTION
## Summary

- Replaces `@dfinity/editorial` with `@dfinity/dx` as the default codeowner (`*`) in `.github/CODEOWNERS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)