### PR TITLE
chore: add ICP_CLI_GITHUB_TOKEN env to CI workflows and template

### DIFF
--- a/.github/workflow-template.yml
+++ b/.github/workflow-template.yml
@@ -25,6 +25,8 @@ jobs:
   <language>-<example_name>:
     runs-on: ubuntu-24.04
     container: <image>
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test

--- a/.github/workflows/hello_world.yml
+++ b/.github/workflows/hello_world.yml
@@ -18,6 +18,8 @@ jobs:
   motoko-hello_world:
     runs-on: ubuntu-24.04
     container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test
@@ -30,6 +32,8 @@ jobs:
   rust-hello_world:
     runs-on: ubuntu-24.04
     container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test

--- a/.github/workflows/who_am_i.yml
+++ b/.github/workflows/who_am_i.yml
@@ -18,6 +18,8 @@ jobs:
   motoko-who_am_i:
     runs-on: ubuntu-24.04
     container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test
@@ -30,6 +32,8 @@ jobs:
   rust-who_am_i:
     runs-on: ubuntu-24.04
     container: ghcr.io/dfinity/icp-dev-env-rust:0.3.1
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,8 @@ jobs:
   motoko-<example_name>:
     runs-on: ubuntu-24.04
     container: ghcr.io/dfinity/icp-dev-env-motoko:<version>
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test
@@ -251,6 +253,8 @@ jobs:
   rust-<example_name>:
     runs-on: ubuntu-24.04
     container: ghcr.io/dfinity/icp-dev-env-rust:<version>
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test


### PR DESCRIPTION
## Summary

- Adds `ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to each job in `hello_world.yml` and `who_am_i.yml`, which were missing it
- Adds the same env block to `workflow-template.yml` so all future workflows are created with it
- Adds the same env block to the CI workflow template in `AGENTS.md`

## Test plan

- [ ] Verify `hello_world` and `who_am_i` CI jobs pass after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)