### PR TITLE
chore: remove @dfinity/languages from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,24 +14,18 @@
 /motoko/canister_factory/ @dfinity/sdk
 /motoko/canister_logs/ @dfinity/core-protocol
 /motoko/cert-var/ @dfinity/trust
-/motoko/classes/ @dfinity/languages
-/motoko/composite_query/ @dfinity/languages
 /motoko/daily_planner/ @dfinity/ninja-devs
 /motoko/evm_block_explorer/ @dfinity/ninja-devs
 /motoko/filevault/ @dfinity/ninja-devs
 /motoko/flying_ninja/ @dfinity/ninja-devs
-/motoko/hello_cycles/ @dfinity/languages
 /motoko/hello_world/ @dfinity/ninja-devs
 /motoko/ic-pos/ @dfinity/sdk
 /motoko/icp_transfer/ @dfinity/defi
 /motoko/icrc2-swap/ @dfinity/sdk
 /motoko/llm_chatbot/ @dfinity/ninja-devs
-/motoko/low_wasm_memory/ @dfinity/languages
 /motoko/nft-creator/ @dfinity/ninja-devs
-/motoko/parallel_calls/ @dfinity/languages
 /motoko/pub-sub/ @dfinity/sdk
 /motoko/query_stats/ @dfinity/sdk
-/motoko/random_maze/ @dfinity/languages
 /motoko/send_http_get/ @dfinity/ninja-devs
 /motoko/send_http_post/ @dfinity/ninja-devs
 /motoko/superheroes/ @dfinity/ninja-devs
@@ -90,5 +84,3 @@
 
 /svelte/svelte-motoko-starter/ @dfinity/sdk
 /svelte/sveltekit-starter/ @dfinity/sdk
-
-/wasm/counter @dfinity/languages


### PR DESCRIPTION
The @dfinity/languages team is empty. Removes all 7 entries from CODEOWNERS. The `* @dfinity/dx` wildcard at the top of the file covers those paths as fallback.