### PR TITLE
fix(ci): add ICP_CLI_GITHUB_TOKEN and bump to 0.3.2 in canister_factory workflow

### DIFF
--- a/.github/workflows/canister_factory.yml
+++ b/.github/workflows/canister_factory.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   motoko-canister_factory:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.1
+    container: ghcr.io/dfinity/icp-dev-env-motoko:0.3.2
+    env:
+      ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Deploy and test


### PR DESCRIPTION
The `canister_factory.yml` workflow was missing `ICP_CLI_GITHUB_TOKEN`, causing `icp network start -d` to hit the unauthenticated GitHub API rate limit when fetching the network launcher release. Also bumps the container image from `0.3.1` to `0.3.2`.