### PR TITLE
fix(rust/receiving-icp): rename staging→ic, drop production environment

### DIFF
--- a/rust/receiving-icp/README.md
+++ b/rust/receiving-icp/README.md
@@ -11,10 +11,11 @@ The ICP ledger canister ID is configured via `icp.yaml` and read at runtime as a
 | Environment | Ledger | Canister ID |
 |---|---|---|
 | `local` | ICP ledger (pre-deployed by icp-cli) | `ryjl3-tyaaa-aaaaa-aaaba-cai` |
-| `staging` | TESTICP ledger | `xafvr-biaaa-aaaai-aql5q-cai` |
-| `production` | ICP ledger (mainnet) | `ryjl3-tyaaa-aaaaa-aaaba-cai` |
+| `ic` | TESTICP ledger | `xafvr-biaaa-aaaai-aql5q-cai` |
 
-The local environment uses the same principal as production because icp-cli's local network pre-deploys the ICP ledger at that well-known address. Staging uses the TESTICP ledger so you can test token flows without spending real ICP.
+The local environment uses the same canister ID as the mainnet ICP ledger because icp-cli's local network pre-deploys it at that well-known address. The `ic` environment uses the TESTICP ledger so you can test token flows on ICP mainnet without spending real ICP.
+
+For a production deployment using the real ICP ledger, update `ICP_LEDGER_CANISTER_ID` in `icp.yaml` to `ryjl3-tyaaa-aaaaa-aaaba-cai` — see the comment in `icp.yaml` for the exact change.
 
 ## Build and deploy from the command line
 
@@ -41,15 +42,13 @@ icp network stop
 
 `bash test.sh` runs 7 tests: account identifier format, subaccount uniqueness, funding the main account and a specific subaccount via account ID hex, balance queries, and subaccount independence. Tests are delta-based and idempotent across re-runs.
 
-### Deploy to staging or production
+### Deploy to ICP mainnet
 
 ```bash
-# Staging — targets the TESTICP ledger
-icp deploy --environment staging
-
-# Production — targets the mainnet ICP ledger
-icp deploy --environment production
+icp deploy -e ic
 ```
+
+This targets the TESTICP ledger by default. To use the real ICP ledger, update `ICP_LEDGER_CANISTER_ID` in `icp.yaml` first.
 
 ## Security considerations and best practices
 

--- a/rust/receiving-icp/icp.yaml
+++ b/rust/receiving-icp/icp.yaml
@@ -3,11 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/rust@v3.3.0"
 
-# ICP_LEDGER_CANISTER_ID is injected at deploy time by the recipe and baked
-# into the WASM. Deploy with `--environment staging` to target the TESTICP
-# ledger, or omit the flag to use the production ICP ledger (default for
-# both local and production).
+# ICP_LEDGER_CANISTER_ID is injected at deploy time and read at runtime via
+# ic_cdk::api::env_var_value("ICP_LEDGER_CANISTER_ID").
 environments:
+  # Local: icp-cli pre-deploys the ICP ledger at the well-known mainnet address.
   - name: local
     network: local
     settings:
@@ -15,16 +14,14 @@ environments:
         environment_variables:
           ICP_LEDGER_CANISTER_ID: "ryjl3-tyaaa-aaaaa-aaaba-cai"
 
-  - name: staging
+  # IC mainnet: uses the TESTICP ledger by default so you can test token flows
+  # without spending real ICP.
+  #
+  # For a production deployment using the real ICP ledger, change
+  # ICP_LEDGER_CANISTER_ID to "ryjl3-tyaaa-aaaaa-aaaba-cai".
+  - name: ic
     network: ic
     settings:
       backend:
         environment_variables:
           ICP_LEDGER_CANISTER_ID: "xafvr-biaaa-aaaai-aql5q-cai"
-
-  - name: production
-    network: ic
-    settings:
-      backend:
-        environment_variables:
-          ICP_LEDGER_CANISTER_ID: "ryjl3-tyaaa-aaaaa-aaaba-cai"


### PR DESCRIPTION
## Summary

Follow-up to #1394 — aligns the environment configuration with the pattern established in `rust/basic_ethereum`.

**Changed:**
- `staging` → `ic` (standard icp-cli environment name for ICP mainnet)
- `production` environment removed; a comment in `icp.yaml` explains how to adapt `ICP_LEDGER_CANISTER_ID` to the real ICP ledger for production use
- README updated: table and deploy command reflect `ic` instead of `staging`/`production`; production guidance points to the `icp.yaml` comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)