### PR TITLE
chore(rust/candid_type_generation): remove redundant .gitignore

### DIFF
--- a/rust/candid_type_generation/.gitignore
+++ b/rust/candid_type_generation/.gitignore
@@ -1,2 +1,0 @@
-# Rust build artifacts — generated code from ic-cdk-bindgen goes to Cargo's OUT_DIR
-# (inside target/), which is already covered by the root .gitignore.


### PR DESCRIPTION
## Summary

Removes `rust/candid_type_generation/.gitignore` which was added in #1408. The file contained only comments explaining that `ic-cdk-bindgen` writes generated code to Cargo's `OUT_DIR` (inside `target/`). Since `target/` is already covered by the root `.gitignore`, there are no actual rules to add — the file serves no purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)