### PR TITLE
chore: bump asset-canister recipe to v2.2.1 in hosting examples

### DIFF
--- a/hosting/oisy-signer-demo/icp.yaml
+++ b/hosting/oisy-signer-demo/icp.yaml
@@ -1,7 +1,7 @@
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: frontend/dist
         build:

--- a/hosting/react/icp.yaml
+++ b/hosting/react/icp.yaml
@@ -1,7 +1,7 @@
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: frontend/dist
         build:


### PR DESCRIPTION
## Summary

- Bump `@dfinity/asset-canister` from `v2.1.0` to `v2.2.1` in `hosting/oisy-signer-demo` and `hosting/react`

## Test plan

- [ ] CI workflows for `hosting-oisy-signer-demo` and `hosting-react` pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
