### PR TITLE
chore: remove trust team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@
 /motoko/backend_only/ @dfinity/ninja-devs
 /motoko/canister_factory/ @dfinity/sdk
 /motoko/canister_logs/ @dfinity/core-protocol
-/motoko/cert-var/ @dfinity/trust
 /motoko/daily_planner/ @dfinity/ninja-devs
 /motoko/evm_block_explorer/ @dfinity/ninja-devs
 /motoko/filevault/ @dfinity/ninja-devs


### PR DESCRIPTION
Removes the `@dfinity/trust` team from `.github/CODEOWNERS`.

The only reference was `/motoko/cert-var/`, which now falls back to the default `* @dfinity/dx` owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)