### PR TITLE
fix(hosting/photo-storage): restore asset-canister recipe and fix canister-ID discovery

### DIFF
--- a/hosting/photo-storage/README.md
+++ b/hosting/photo-storage/README.md
@@ -38,19 +38,19 @@ Deploy the canisters:
 icp deploy
 ```
 
-The URL for the frontend depends on the canister ID. When deployed, the URL will look like this:
+Open the frontend URL printed by `icp deploy`, e.g.:
 
 ```
-http://{canister_id}.localhost:8000
+http://frontend.local.localhost:8000
 ```
 
 To authorize an identity to upload files, it must be authorized first:
 
 ```bash
-icp canister call photo-storage authorize '(principal "535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe")'
+icp canister call frontend authorize '(principal "535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe")'
 ```
 
-> **Warning:** This example uses a hardcoded identity (defined in `src/App.js`). Before deploying to the IC mainnet, replace it with a proper authentication method such as [Internet Identity](https://docs.internetcomputer.org/building-apps/authentication/integrate-internet-identity).
+> **Warning:** This example uses a hardcoded identity (defined in `src/App.js`). Before deploying to the IC mainnet, replace it with a proper authentication method such as [Internet Identity](https://docs.internetcomputer.org/guides/authentication/internet-identity).
 
 Stop the local network when done:
 

--- a/hosting/photo-storage/README.md
+++ b/hosting/photo-storage/README.md
@@ -50,7 +50,7 @@ To authorize an identity to upload files, it must be authorized first:
 icp canister call frontend authorize '(principal "535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe")'
 ```
 
-> **Warning:** This example uses a hardcoded identity (defined in `src/App.js`). Before deploying to the IC mainnet, replace it with a proper authentication method such as [Internet Identity](https://docs.internetcomputer.org/guides/authentication/internet-identity).
+> **Warning:** This example uses a hardcoded identity (defined in `src/App.jsx`). Before deploying to the IC mainnet, replace it with a proper authentication method such as [Internet Identity](https://docs.internetcomputer.org/guides/authentication/internet-identity).
 
 Stop the local network when done:
 

--- a/hosting/photo-storage/icp.yaml
+++ b/hosting/photo-storage/icp.yaml
@@ -1,7 +1,11 @@
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/static-site@v0.3.1"
+      # Deliberately stays on the legacy asset-canister recipe: this example
+      # demonstrates programmatic uploads via AssetManager, which the
+      # static-site (certified-assets) canister does not support.
+      # See https://github.com/dfinity/examples/issues/1459
+      type: "@dfinity/asset-canister@v2.2.1"
       configuration:
         dir: dist
         build:

--- a/hosting/photo-storage/src/App.jsx
+++ b/hosting/photo-storage/src/App.jsx
@@ -15,10 +15,10 @@ const identity = Ed25519KeyIdentity.generate(new Uint8Array(Array.from({length: 
 // variables, so the app finds its own canister ID regardless of which URL the
 // gateway serves it under (canister-id-based or name-based).
 const canisterEnv = safeGetCanisterEnv();
-const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:frontend"] ?? new URLSearchParams(window.location.search).get('canisterId');
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:frontend"];
 
 if (!canisterId) {
-    throw new Error("Canister ID for 'frontend' not found. Run 'icp deploy' first.");
+    throw new Error("Canister ID for 'frontend' not found. Run 'icp deploy' and open the URL it prints.");
 }
 
 const agent = HttpAgent.createSync({

--- a/hosting/photo-storage/src/App.jsx
+++ b/hosting/photo-storage/src/App.jsx
@@ -1,5 +1,6 @@
 import {Ed25519KeyIdentity} from '@icp-sdk/core/identity';
 import {HttpAgent} from '@icp-sdk/core/agent';
+import {safeGetCanisterEnv} from '@icp-sdk/core/agent/canister-env';
 import {AssetManager} from '@icp-sdk/canisters/assets';
 import {useEffect, useState} from "react";
 import Masonry from "react-masonry-css";
@@ -8,16 +9,23 @@ import './App.css';
 // Hardcoded principal: 535yc-uxytb-gfk7h-tny7p-vjkoe-i4krp-3qmcl-uqfgr-cpgej-yqtjq-rqe
 // Should be replaced with authentication method e.g. Internet Identity when deployed on IC
 const identity = Ed25519KeyIdentity.generate(new Uint8Array(Array.from({length: 32}).fill(0)));
-const isLocal = !window.location.host.endsWith('ic0.app');
-const agent = HttpAgent.createSync({
-    host: isLocal ? `http://127.0.0.1:${window.location.port}` : 'https://ic0.app', identity,
-});
-if (isLocal) {
-    await agent.fetchRootKey();
+
+// The ic_env cookie is set by the asset canister on all HTML responses. It
+// contains the replica root key and the PUBLIC_* canister environment
+// variables, so the app finds its own canister ID regardless of which URL the
+// gateway serves it under (canister-id-based or name-based).
+const canisterEnv = safeGetCanisterEnv();
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:frontend"] ?? new URLSearchParams(window.location.search).get('canisterId');
+
+if (!canisterId) {
+    throw new Error("Canister ID for 'frontend' not found. Run 'icp deploy' first.");
 }
 
-// Canister id can be fetched from URL since frontend in this example is hosted in the same canister as file upload
-const canisterId = new URLSearchParams(window.location.search).get('canisterId') ?? /(.*?)(?:\.raw)?\.ic0.app/.exec(window.location.host)?.[1] ?? /(.*)\.localhost/.exec(window.location.host)?.[1];
+const agent = HttpAgent.createSync({
+    host: window.location.origin,
+    rootKey: canisterEnv?.IC_ROOT_KEY,
+    identity,
+});
 
 // Create asset manager instance for above asset canister
 const assetManager = new AssetManager({canisterId, agent});


### PR DESCRIPTION
## Problem

Two independent bugs, analyzed in #1458 / #1459:

1. **Missing API**: the certified-assets canister behind `@dfinity/static-site` exposes none of the legacy asset-canister API (`list`/`store`/`create_batch`/`commit_batch`) that `AssetManager` uses — programmatic uploads, the example's purpose, cannot work on it (confirmed against [certified-assets.did](https://github.com/dfinity/certified-assets/blob/main/certified-assets.did)).
2. **Broken canister-ID discovery**: the dfx-era hostname regex captured `"frontend.local"` from icp-cli's name-based URL (`frontend.local.localhost:8000`) and `Principal.fromText` threw `Invalid character: "."` at module load → white screen.

## Fix

- Revert the recipe to `@dfinity/asset-canister@v2.2.1` (interim per #1459; comment in `icp.yaml` explains the deliberate exception so the next recipe sweep doesn't re-migrate it).
- Replace the URL parsing with the `ic_env` cookie pattern from `hello_world`: `safeGetCanisterEnv()` provides `PUBLIC_CANISTER_ID:frontend` + `IC_ROOT_KEY`; agent uses `window.location.origin`. Works on both name-based and ID-based URLs, locally and on mainnet.
- README: authorize command targets `frontend` (the actual canister name), deploy section points at the URL `icp deploy` prints, II link → developer docs.

## Verification

Manual e2e (2026-07-30): gallery renders on `http://frontend.local.localhost:8000`, upload works after `authorize`, photos persist across reloads. See #1459 for the long-term decision (keep-legacy / repurpose / retire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)