### PR TITLE
docs(unity_ii_deeplink): fix .well-known instructions for static-site

### DIFF
--- a/native-apps/unity_ii_deeplink/README.md
+++ b/native-apps/unity_ii_deeplink/README.md
@@ -184,13 +184,9 @@ dataNode.SetAttribute("pathPrefix", kAndroidNamespaceURI, "/authorize"); // add 
 
 Get the fingerprint with: `keytool -list -v -keystore <your-keystore>.jks`
 
-**4. Create `ii-bridge/public/.ic-assets.json5`** to allow the asset canister to serve the hidden directory:
+The static-site canister uploads `.well-known/` automatically and serves `assetlinks.json` as `application/json` (inferred from its `.json` extension), so no extra configuration is needed.
 
-```json5
-[{"match": ".well-known/**", "allow_raw_access": true}]
-```
-
-**5. Update the callback URL in `ii-bridge/src/main.js`:**
+**4. Update the callback URL in `ii-bridge/src/main.js`:**
 
 ```js
 const url = "https://<your-canister-id>.icp0.io/authorize#delegation=" + ...
@@ -265,13 +261,16 @@ public class iOSPostBuildProcessor
 
 Find your Team ID in the Apple Developer portal. Bundle ID is the one set in Unity Player Settings.
 
-**4. Create `ii-bridge/public/.ic-assets.json5`** (same file as the Android step — works for both):
+**4. Create `ii-bridge/public/_headers`** to serve the association file as JSON:
 
-```json5
-[{"match": ".well-known/**", "allow_raw_access": true}]
+`.well-known/` is uploaded automatically, but because `apple-app-site-association` has no file extension the static-site canister serves it as `application/octet-stream` by default, while iOS requires `application/json`. Override the content type with a `_headers` entry (this is the certified-assets replacement for the legacy asset canister's extension inference):
+
+```
+/.well-known/apple-app-site-association
+  Content-Type: application/json
 ```
 
-The asset canister must serve `apple-app-site-association` with `Content-Type: application/json`. The ICP asset canister infers this from the missing extension — verify with `curl -I https://<canister-id>.icp0.io/.well-known/apple-app-site-association`.
+After redeployment, verify with `curl -I https://<canister-id>.icp0.io/.well-known/apple-app-site-association` (expect `content-type: application/json`).
 
 **5. Update the callback URL in `ii-bridge/src/main.js`:**
 


### PR DESCRIPTION
Closes #1461 (last item of #1458). The Unity deep-link guide told users to create `ii-bridge/public/.ic-assets.json5` with `allow_raw_access` — a **legacy asset-canister** config the `ii-bridge` canister (now `@dfinity/static-site`/certified-assets) silently ignores. Rewritten to match how certified-assets actually serves `.well-known/`.

## Verified on a live local static-site deploy (both rounds)

| Path | No config | With `_headers` override |
|---|---|---|
| `/.well-known/assetlinks.json` (`.json`) | `200 application/json` ✅ | — (not needed) |
| `/.well-known/apple-app-site-association` (no ext) | `200 application/octet-stream` ❌ | `200 application/json` ✅ |

So: `.well-known/` is uploaded automatically (no `.ic-assets.json5`), `assetlinks.json` is served as JSON from its extension, and the extensionless AASA file needs a `_headers` `Content-Type` override.

## Doc changes
- **Android:** dropped the `.ic-assets.json5` step; noted `.well-known/` is auto-served and `assetlinks.json` gets `application/json` from its extension; renumbered the callback-URL step.
- **iOS:** replaced the `.ic-assets.json5` step with a `ii-bridge/public/_headers` step setting `Content-Type: application/json` for the extensionless AASA file (the certified-assets replacement for the legacy canister's extension inference), with a `curl -I` verification note.

Docs-only — no example files ship `.well-known/` or `_headers` (the HTTPS-deep-link setup is an opt-in production step the reader performs); throwaway test files used for verification were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)