### PR TITLE
feat(vetkeys): adopt EncryptedMaps mixins in the Motoko examples (ic-vetkeys 0.6.0)

### DIFF
--- a/motoko/vetkeys/basic_bls_signing/README.md
+++ b/motoko/vetkeys/basic_bls_signing/README.md
@@ -23,7 +23,7 @@ To confirm the canister can only produce signatures in the intended way, users n
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
+The key name is read once at the first install and captured in stable state: it feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted — and since the canister only ever sees ciphertext, it cannot re-encrypt either. Changing the variable on a later upgrade is therefore silently ignored; only `icp deploy --mode reinstall`, which drops all data, switches keys. Re-keying live data would need application-level key rotation, which these examples do not implement.
 
 ### Install
 

--- a/motoko/vetkeys/basic_bls_signing/README.md
+++ b/motoko/vetkeys/basic_bls_signing/README.md
@@ -21,7 +21,9 @@ To confirm the canister can only produce signatures in the intended way, users n
 
 ### (Optionally) choose a different master key
 
-This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `init_args` value in `icp.yaml` before deploying.
+This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
+
+Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
 
 ### Install
 

--- a/motoko/vetkeys/basic_bls_signing/README.md
+++ b/motoko/vetkeys/basic_bls_signing/README.md
@@ -23,7 +23,7 @@ To confirm the canister can only produce signatures in the intended way, users n
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
+Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
 
 ### Install
 

--- a/motoko/vetkeys/basic_bls_signing/backend/backend.did
+++ b/motoko/vetkeys/basic_bls_signing/backend/backend.did
@@ -1,13 +1,11 @@
-type _anon_class_13_1 = 
- service {
-   getMySignatures: () -> (vec Signature) query;
-   getMyVerificationKey: () -> (blob);
-   signMessage: (message: text) -> (blob);
- };
 type Signature = 
  record {
    message: text;
    signature: blob;
    timestamp: nat64;
  };
-service : (keyName: text) -> _anon_class_13_1
+service : {
+  getMySignatures: () -> (vec Signature) query;
+  getMyVerificationKey: () -> (blob);
+  signMessage: (message: text) -> (blob);
+}

--- a/motoko/vetkeys/basic_bls_signing/backend/main.mo
+++ b/motoko/vetkeys/basic_bls_signing/backend/main.mo
@@ -15,10 +15,16 @@ actor {
     // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
     // canister environment variable (see `icp.yaml`) to pick a different key; it
     // defaults to `test_key_1` so a deploy can never leave the canister
-    // half-initialized. It is re-read on every upgrade, so changing the variable
-    // does take effect — and orphans everything encrypted under the old key, which
-    // no other key can decrypt. Treat it as fixed once the canister holds data.
-    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+    // half-initialized.
+    //
+    // This is a stable variable on purpose, so it is captured at the first install
+    // and never re-read: changing the environment variable later is silently
+    // ignored, and only a reinstall — which drops all data — switches keys. The key
+    // feeds vetKD derivation, so a different key cannot decrypt what the old one
+    // encrypted, and this canister only ever sees ciphertext and so cannot
+    // re-encrypt. Were it `transient` instead, a changed variable would take effect
+    // on the next upgrade and silently orphan the stored data.
+    let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     // Types
     type Signature = {

--- a/motoko/vetkeys/basic_bls_signing/backend/main.mo
+++ b/motoko/vetkeys/basic_bls_signing/backend/main.mo
@@ -9,8 +9,17 @@ import List "mo:core/List";
 import Nat "mo:core/Nat";
 import VetKeys "mo:ic-vetkeys";
 import Order "mo:core/Order";
+import Runtime "mo:core/Runtime";
 
-actor class (keyName : Text) = {
+actor {
+    // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
+    // canister environment variable (see `icp.yaml`) to pick a different key; it
+    // defaults to `test_key_1` so a deploy can never leave the canister
+    // half-initialized. Do not change it once the canister holds data: the key
+    // feeds vetKD derivation, so a different key cannot decrypt what the old one
+    // encrypted.
+    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+
     // Types
     type Signature = {
         message : Text;

--- a/motoko/vetkeys/basic_bls_signing/backend/main.mo
+++ b/motoko/vetkeys/basic_bls_signing/backend/main.mo
@@ -15,9 +15,9 @@ actor {
     // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
     // canister environment variable (see `icp.yaml`) to pick a different key; it
     // defaults to `test_key_1` so a deploy can never leave the canister
-    // half-initialized. Do not change it once the canister holds data: the key
-    // feeds vetKD derivation, so a different key cannot decrypt what the old one
-    // encrypted.
+    // half-initialized. It is re-read on every upgrade, so changing the variable
+    // does take effect — and orphans everything encrypted under the old key, which
+    // no other key can decrypt. Treat it as fixed once the canister holds data.
     transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     // Types

--- a/motoko/vetkeys/basic_bls_signing/backend/main.mo
+++ b/motoko/vetkeys/basic_bls_signing/backend/main.mo
@@ -6,7 +6,7 @@ import Time "mo:core/Time";
 import Map "mo:core/Map";
 import Array "mo:core/Array";
 import List "mo:core/List";
-import Nat8 "mo:core/Nat8";
+import Nat "mo:core/Nat";
 import VetKeys "mo:ic-vetkeys";
 import Order "mo:core/Order";
 
@@ -37,7 +37,7 @@ actor class (keyName : Text) = {
     };
 
     // Signatures are retained across upgrades: this actor field is not declared `transient`.
-    private var signatures = Map.empty<SignatureKey, Signature>();
+    private let signatures = Map.empty<SignatureKey, Signature>();
 
     // Helper function to get current timestamp
     private func getTimestamp() : Nat64 {
@@ -47,19 +47,18 @@ actor class (keyName : Text) = {
     // Helper function to create context for vetKD
     private func context(signer : Principal) : Blob {
         // Domain separator for this app
-        let domainSeparator : [Nat8] = Blob.toArray(Text.encodeUtf8("basic_bls_signing_app"));
-        let domainSeparatorLength : [Nat8] = [Nat8.fromNat(domainSeparator.size())]; // Length of domain separator
+        let domainSeparator : [Nat8] = Text.encodeUtf8("basic_bls_signing_app").toArray();
+        let domainSeparatorLength : [Nat8] = [domainSeparator.size().toNat8()]; // Length of domain separator
 
         // Combine domain separator length, domain separator, and signer principal
-        let signerBytes = Principal.toBlob(signer);
-        let signerArray = Blob.toArray(signerBytes);
+        let signerBytes = signer.toBlob();
+        let signerArray = signerBytes.toArray();
 
-        let contextArray = Array.concat<Nat8>(
-            Array.concat<Nat8>(domainSeparatorLength, domainSeparator),
+        let contextArray = domainSeparatorLength.concat(domainSeparator).concat(
             signerArray,
         );
 
-        Blob.fromArray(contextArray);
+        contextArray.toBlob();
     };
 
     // Helper function to get key ID
@@ -73,7 +72,7 @@ actor class (keyName : Text) = {
     // Sign a message using BLS
     public shared ({ caller }) func signMessage(message : Text) : async Blob {
         let signatureBytes = await VetKeys.ManagementCanister.signWithBls(
-            Text.encodeUtf8(message),
+            message.encodeUtf8(),
             context(caller),
             keyId(),
         );
@@ -87,26 +86,26 @@ actor class (keyName : Text) = {
 
         // Handle potential timestamp collisions by incrementing until we find a free slot
         var timestampForMapKey = timestamp;
-        while (Map.get(signatures, signatureKeyCompare, { signer = caller; timestamp = timestampForMapKey }) != null) {
+        while (signatures.get(signatureKeyCompare, { signer = caller; timestamp = timestampForMapKey }) != null) {
             timestampForMapKey += 1;
         };
 
-        ignore Map.insert(signatures, signatureKeyCompare, { signer = caller; timestamp = timestampForMapKey }, signature);
+        ignore signatures.insert(signatureKeyCompare, { signer = caller; timestamp = timestampForMapKey }, signature);
 
         signatureBytes;
     };
 
     // Get all signatures for the current caller
     public shared query ({ caller }) func getMySignatures() : async [Signature] {
-        var callerSignatures = List.empty<Signature>();
+        let callerSignatures = List.empty<Signature>();
 
-        for ((key, value) in Map.entries(signatures)) {
+        for ((key, value) in signatures.entries()) {
             if (Principal.equal(key.signer, caller)) {
-                List.add(callerSignatures, value);
+                callerSignatures.add(value);
             };
         };
 
-        List.toArray(callerSignatures);
+        callerSignatures.toArray();
     };
 
     // Get verification key for the current caller

--- a/motoko/vetkeys/basic_bls_signing/icp.yaml
+++ b/motoko/vetkeys/basic_bls_signing/icp.yaml
@@ -4,9 +4,9 @@ canisters:
       type: "@dfinity/motoko@v5.0.0"
     settings:
       # The vetKD master key this canister derives from, read by the canister via
-      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
-      # canister that already holds data — a different key cannot decrypt what the
-      # old one encrypted.
+      # `Runtime.envVar("VETKD_KEY_NAME")` and captured in stable state at the first
+      # install. Set it before deploying: a later change is silently ignored, and
+      # only a reinstall — which drops all data — switches keys.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/basic_bls_signing/icp.yaml
+++ b/motoko/vetkeys/basic_bls_signing/icp.yaml
@@ -3,9 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/motoko@v5.0.0"
     settings:
-      # The vetKD master key this canister derives from. Read at install time via
-      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
-      # changing it on a canister that already holds data.
+      # The vetKD master key this canister derives from, read by the canister via
+      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
+      # canister that already holds data — a different key cannot decrypt what the
+      # old one encrypted.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/basic_bls_signing/icp.yaml
+++ b/motoko/vetkeys/basic_bls_signing/icp.yaml
@@ -2,9 +2,12 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/motoko@v5.0.0"
-    init_args:
-      type: text
-      value: "(\"test_key_1\")"
+    settings:
+      # The vetKD master key this canister derives from. Read at install time via
+      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
+      # changing it on a canister that already holds data.
+      environment_variables:
+        VETKD_KEY_NAME: "test_key_1"
 
   - name: frontend
     recipe:

--- a/motoko/vetkeys/basic_bls_signing/mops.toml
+++ b/motoko/vetkeys/basic_bls_signing/mops.toml
@@ -1,9 +1,9 @@
 [toolchain]
-moc = "1.11.0"
+moc = "1.13.0"
 
 [dependencies]
-core = "2.5.0"
-ic-vetkeys = "0.5.0"
+core = "2.6.1"
+ic-vetkeys = "0.6.0"
 
 [moc]
 # M0236: use context dot notation

--- a/motoko/vetkeys/basic_ibe/README.md
+++ b/motoko/vetkeys/basic_ibe/README.md
@@ -24,7 +24,7 @@ Note that generally it is possible for a canister to request a decryption key to
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
+The key name is read once at the first install and captured in stable state: it feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted — and since the canister only ever sees ciphertext, it cannot re-encrypt either. Changing the variable on a later upgrade is therefore silently ignored; only `icp deploy --mode reinstall`, which drops all data, switches keys. Re-keying live data would need application-level key rotation, which these examples do not implement.
 
 ### Install
 

--- a/motoko/vetkeys/basic_ibe/README.md
+++ b/motoko/vetkeys/basic_ibe/README.md
@@ -22,7 +22,9 @@ Note that generally it is possible for a canister to request a decryption key to
 
 ### (Optionally) choose a different master key
 
-This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `init_args` value in `icp.yaml` before deploying.
+This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
+
+Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
 
 ### Install
 

--- a/motoko/vetkeys/basic_ibe/README.md
+++ b/motoko/vetkeys/basic_ibe/README.md
@@ -24,7 +24,7 @@ Note that generally it is possible for a canister to request a decryption key to
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
+Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
 
 ### Install
 

--- a/motoko/vetkeys/basic_ibe/backend/backend.did
+++ b/motoko/vetkeys/basic_ibe/backend/backend.did
@@ -1,11 +1,3 @@
-type _anon_class_13_1 = 
- service {
-   getIbePublicKey: () -> (blob);
-   getMyEncryptedIbeKey: (transportKey: blob) -> (blob);
-   getMyMessages: () -> (Inbox) query;
-   removeMyMessageByIndex: (messageIndex: nat64) -> (Result);
-   sendMessage: (request: SendMessageRequest) -> (Result);
- };
 type SendMessageRequest = 
  record {
    encryptedMessage: blob;
@@ -23,4 +15,10 @@ type Message =
    timestamp: nat64;
  };
 type Inbox = record {messages: vec Message;};
-service : (keyNameString: text) -> _anon_class_13_1
+service : {
+  getIbePublicKey: () -> (blob);
+  getMyEncryptedIbeKey: (transportKey: blob) -> (blob);
+  getMyMessages: () -> (Inbox) query;
+  removeMyMessageByIndex: (messageIndex: nat64) -> (Result);
+  sendMessage: (request: SendMessageRequest) -> (Result);
+}

--- a/motoko/vetkeys/basic_ibe/backend/main.mo
+++ b/motoko/vetkeys/basic_ibe/backend/main.mo
@@ -9,8 +9,17 @@ import Nat64 "mo:core/Nat64";
 import Nat "mo:core/Nat";
 import Result "mo:core/Result";
 import Int "mo:core/Int";
+import Runtime "mo:core/Runtime";
 
-actor class (keyNameString : Text) {
+actor {
+  // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
+  // canister environment variable (see `icp.yaml`) to pick a different key; it
+  // defaults to `test_key_1` so a deploy can never leave the canister
+  // half-initialized. Do not change it once the canister holds data: the key
+  // feeds vetKD derivation, so a different key cannot decrypt what the old one
+  // encrypted.
+  transient let keyNameString = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+
   // Types
   type Message = {
     sender : Principal;

--- a/motoko/vetkeys/basic_ibe/backend/main.mo
+++ b/motoko/vetkeys/basic_ibe/backend/main.mo
@@ -64,7 +64,7 @@ actor class (keyNameString : Text) {
   let DOMAIN_SEPARATOR : Text = "basic_ibe_example_dapp";
 
   // State
-  var inboxes = Map.empty<Principal, Inbox>();
+  let inboxes = Map.empty<Principal, Inbox>();
 
   // Management canister actor
   let vetKdSystemApi : VetKdSystemApi = actor ("aaaaa-aa");
@@ -74,22 +74,22 @@ actor class (keyNameString : Text) {
     let message : Message = {
       sender = caller;
       encryptedMessage = request.encryptedMessage;
-      timestamp = Nat64.fromNat(Int.abs(Time.now()));
+      timestamp = Int.abs(Time.now()).toNat64();
     };
 
     let receiver = request.receiver;
-    let currentInbox = switch (Map.get(inboxes, Principal.compare, receiver)) {
+    let currentInbox = switch (inboxes.get(receiver)) {
       case (?inbox) { inbox };
       case null { { messages = [] } };
     };
 
     if (currentInbox.messages.size() >= MAX_MESSAGES_PER_INBOX) {
-      return #Err("Inbox for " # Principal.toText(receiver) # " is full");
+      return #Err("Inbox for " # receiver.toText() # " is full");
     };
 
-    let newMessages = Array.concat(currentInbox.messages, [message]);
+    let newMessages = currentInbox.messages.concat([message]);
     let newInbox : Inbox = { messages = newMessages };
-    ignore Map.insert(inboxes, Principal.compare, receiver, newInbox);
+    ignore inboxes.insert(receiver, newInbox);
 
     #Ok();
   };
@@ -101,7 +101,7 @@ actor class (keyNameString : Text) {
       name = keyNameString;
     };
 
-    let context = Text.encodeUtf8(DOMAIN_SEPARATOR);
+    let context = DOMAIN_SEPARATOR.encodeUtf8();
     let request : VetKdPublicKeyArgs = {
       canister_id = null;
       context = context;
@@ -119,8 +119,8 @@ actor class (keyNameString : Text) {
       name = keyNameString;
     };
 
-    let context = Text.encodeUtf8(DOMAIN_SEPARATOR);
-    let input = Principal.toBlob(caller);
+    let context = DOMAIN_SEPARATOR.encodeUtf8();
+    let input = caller.toBlob();
     let request : VetKdDeriveKeyArgs = {
       context = context;
       input = input;
@@ -134,7 +134,7 @@ actor class (keyNameString : Text) {
 
   // Get the caller's messages
   public shared query ({ caller }) func getMyMessages() : async Inbox {
-    switch (Map.get(inboxes, Principal.compare, caller)) {
+    switch (inboxes.get(caller)) {
       case (?inbox) { inbox };
       case null { { messages = [] } };
     };
@@ -142,12 +142,12 @@ actor class (keyNameString : Text) {
 
   // Remove a message by index
   public shared ({ caller }) func removeMyMessageByIndex(messageIndex : Nat64) : async Result<(), Text> {
-    let currentInbox = switch (Map.get(inboxes, Principal.compare, caller)) {
+    let currentInbox = switch (inboxes.get(caller)) {
       case (?inbox) { inbox };
       case null { { messages = [] } };
     };
 
-    let index = Nat64.toNat(messageIndex);
+    let index = messageIndex.toNat();
     if (index >= currentInbox.messages.size()) {
       return #Err("Message index out of bounds");
     };
@@ -158,13 +158,13 @@ actor class (keyNameString : Text) {
 
     for (i in messages.keys()) {
       if (i != index) {
-        List.add(newMessagesList, messages[i]);
+        newMessagesList.add(messages[i]);
       };
     };
 
-    let newMessages = List.toArray(newMessagesList);
+    let newMessages = newMessagesList.toArray();
     let newInbox : Inbox = { messages = newMessages };
-    ignore Map.insert(inboxes, Principal.compare, caller, newInbox);
+    ignore inboxes.insert(caller, newInbox);
 
     #Ok();
   };

--- a/motoko/vetkeys/basic_ibe/backend/main.mo
+++ b/motoko/vetkeys/basic_ibe/backend/main.mo
@@ -15,9 +15,9 @@ actor {
   // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
   // canister environment variable (see `icp.yaml`) to pick a different key; it
   // defaults to `test_key_1` so a deploy can never leave the canister
-  // half-initialized. Do not change it once the canister holds data: the key
-  // feeds vetKD derivation, so a different key cannot decrypt what the old one
-  // encrypted.
+  // half-initialized. It is re-read on every upgrade, so changing the variable
+  // does take effect — and orphans everything encrypted under the old key, which
+  // no other key can decrypt. Treat it as fixed once the canister holds data.
   transient let keyNameString = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
   // Types

--- a/motoko/vetkeys/basic_ibe/backend/main.mo
+++ b/motoko/vetkeys/basic_ibe/backend/main.mo
@@ -15,10 +15,16 @@ actor {
   // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
   // canister environment variable (see `icp.yaml`) to pick a different key; it
   // defaults to `test_key_1` so a deploy can never leave the canister
-  // half-initialized. It is re-read on every upgrade, so changing the variable
-  // does take effect — and orphans everything encrypted under the old key, which
-  // no other key can decrypt. Treat it as fixed once the canister holds data.
-  transient let keyNameString = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+  // half-initialized.
+  //
+  // This is a stable variable on purpose, so it is captured at the first install
+  // and never re-read: changing the environment variable later is silently
+  // ignored, and only a reinstall — which drops all data — switches keys. The key
+  // feeds vetKD derivation, so a different key cannot decrypt what the old one
+  // encrypted, and this canister only ever sees ciphertext and so cannot
+  // re-encrypt. Were it `transient` instead, a changed variable would take effect
+  // on the next upgrade and silently orphan the stored data.
+  let keyNameString = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
   // Types
   type Message = {

--- a/motoko/vetkeys/basic_ibe/icp.yaml
+++ b/motoko/vetkeys/basic_ibe/icp.yaml
@@ -4,9 +4,9 @@ canisters:
       type: "@dfinity/motoko@v5.0.0"
     settings:
       # The vetKD master key this canister derives from, read by the canister via
-      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
-      # canister that already holds data — a different key cannot decrypt what the
-      # old one encrypted.
+      # `Runtime.envVar("VETKD_KEY_NAME")` and captured in stable state at the first
+      # install. Set it before deploying: a later change is silently ignored, and
+      # only a reinstall — which drops all data — switches keys.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/basic_ibe/icp.yaml
+++ b/motoko/vetkeys/basic_ibe/icp.yaml
@@ -3,9 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/motoko@v5.0.0"
     settings:
-      # The vetKD master key this canister derives from. Read at install time via
-      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
-      # changing it on a canister that already holds data.
+      # The vetKD master key this canister derives from, read by the canister via
+      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
+      # canister that already holds data — a different key cannot decrypt what the
+      # old one encrypted.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/basic_ibe/icp.yaml
+++ b/motoko/vetkeys/basic_ibe/icp.yaml
@@ -2,9 +2,12 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/motoko@v5.0.0"
-    init_args:
-      type: text
-      value: "(\"test_key_1\")"
+    settings:
+      # The vetKD master key this canister derives from. Read at install time via
+      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
+      # changing it on a canister that already holds data.
+      environment_variables:
+        VETKD_KEY_NAME: "test_key_1"
 
   - name: frontend
     recipe:

--- a/motoko/vetkeys/basic_ibe/mops.toml
+++ b/motoko/vetkeys/basic_ibe/mops.toml
@@ -1,9 +1,9 @@
 [toolchain]
-moc = "1.11.0"
+moc = "1.13.0"
 
 [dependencies]
-core = "2.5.0"
-ic-vetkeys = "0.5.0"
+core = "2.6.1"
+ic-vetkeys = "0.6.0"
 
 [moc]
 # M0236: use context dot notation

--- a/motoko/vetkeys/basic_vetkd/README.md
+++ b/motoko/vetkeys/basic_vetkd/README.md
@@ -18,7 +18,7 @@ For a higher-level approach using the `@icp-sdk/vetkeys` SDK, see the other exam
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
+Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
 
 ### Install
 

--- a/motoko/vetkeys/basic_vetkd/README.md
+++ b/motoko/vetkeys/basic_vetkd/README.md
@@ -18,7 +18,7 @@ For a higher-level approach using the `@icp-sdk/vetkeys` SDK, see the other exam
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
+The key name is read once at the first install and captured in stable state: it feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted — and since the canister only ever sees ciphertext, it cannot re-encrypt either. Changing the variable on a later upgrade is therefore silently ignored; only `icp deploy --mode reinstall`, which drops all data, switches keys. Re-keying live data would need application-level key rotation, which these examples do not implement.
 
 ### Install
 

--- a/motoko/vetkeys/basic_vetkd/README.md
+++ b/motoko/vetkeys/basic_vetkd/README.md
@@ -14,6 +14,12 @@ For a higher-level approach using the `@icp-sdk/vetkeys` SDK, see the other exam
 - [ ] Install icp-cli: `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`
 - [ ] Install mops: `npm install -g ic-mops`
 
+### (Optionally) choose a different master key
+
+This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
+
+Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
+
 ### Install
 
 ```bash

--- a/motoko/vetkeys/basic_vetkd/backend/backend.did
+++ b/motoko/vetkeys/basic_vetkd/backend/backend.did
@@ -1,6 +1,7 @@
 service : {
-  "symmetric_key_verification_key" : () -> (blob);
-  "encrypted_symmetric_key_for_caller" : (blob) -> (blob);
-  "ibe_encryption_key" : () -> (blob);
-  "encrypted_ibe_decryption_key_for_caller" : (blob) -> (blob);
-};
+  encrypted_ibe_decryption_key_for_caller: (transport_public_key: blob) ->
+   (blob);
+  encrypted_symmetric_key_for_caller: (transport_public_key: blob) -> (blob);
+  ibe_encryption_key: () -> (blob);
+  symmetric_key_verification_key: () -> (blob);
+}

--- a/motoko/vetkeys/basic_vetkd/backend/main.mo
+++ b/motoko/vetkeys/basic_vetkd/backend/main.mo
@@ -14,7 +14,7 @@ actor {
     };
 
     public shared ({ caller }) func encrypted_symmetric_key_for_caller(transport_public_key : Blob) : async Blob {
-        await ManagementCanister.vetKdDeriveKey(Principal.toBlob(caller), Text.encodeUtf8("symmetric_key"), TEST_KEY, transport_public_key);
+        await ManagementCanister.vetKdDeriveKey(caller.toBlob(), Text.encodeUtf8("symmetric_key"), TEST_KEY, transport_public_key);
     };
 
     public shared func ibe_encryption_key() : async Blob {
@@ -22,6 +22,6 @@ actor {
     };
 
     public shared ({ caller }) func encrypted_ibe_decryption_key_for_caller(transport_public_key : Blob) : async Blob {
-        await ManagementCanister.vetKdDeriveKey(Principal.toBlob(caller), Text.encodeUtf8("ibe_encryption"), TEST_KEY, transport_public_key);
+        await ManagementCanister.vetKdDeriveKey(caller.toBlob(), Text.encodeUtf8("ibe_encryption"), TEST_KEY, transport_public_key);
     };
 };

--- a/motoko/vetkeys/basic_vetkd/backend/main.mo
+++ b/motoko/vetkeys/basic_vetkd/backend/main.mo
@@ -1,12 +1,21 @@
 import ManagementCanister "mo:ic-vetkeys/ManagementCanister";
 import Principal "mo:core/Principal";
 import Text "mo:core/Text";
+import Runtime "mo:core/Runtime";
 
 actor {
 
+    // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
+    // canister environment variable (see `icp.yaml`) to pick a different key; it
+    // defaults to `test_key_1` so a deploy can never leave the canister
+    // half-initialized. Do not change it once the canister holds data: the key
+    // feeds vetKD derivation, so a different key cannot decrypt what the old one
+    // encrypted.
+    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+
     let TEST_KEY : ManagementCanister.VetKdKeyid = {
         curve = #bls12_381_g2;
-        name = "test_key_1";
+        name = keyName;
     };
 
     public shared func symmetric_key_verification_key() : async Blob {

--- a/motoko/vetkeys/basic_vetkd/backend/main.mo
+++ b/motoko/vetkeys/basic_vetkd/backend/main.mo
@@ -8,9 +8,9 @@ actor {
     // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
     // canister environment variable (see `icp.yaml`) to pick a different key; it
     // defaults to `test_key_1` so a deploy can never leave the canister
-    // half-initialized. Do not change it once the canister holds data: the key
-    // feeds vetKD derivation, so a different key cannot decrypt what the old one
-    // encrypted.
+    // half-initialized. It is re-read on every upgrade, so changing the variable
+    // does take effect — and orphans everything encrypted under the old key, which
+    // no other key can decrypt. Treat it as fixed once the canister holds data.
     transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     let TEST_KEY : ManagementCanister.VetKdKeyid = {

--- a/motoko/vetkeys/basic_vetkd/backend/main.mo
+++ b/motoko/vetkeys/basic_vetkd/backend/main.mo
@@ -8,10 +8,16 @@ actor {
     // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
     // canister environment variable (see `icp.yaml`) to pick a different key; it
     // defaults to `test_key_1` so a deploy can never leave the canister
-    // half-initialized. It is re-read on every upgrade, so changing the variable
-    // does take effect — and orphans everything encrypted under the old key, which
-    // no other key can decrypt. Treat it as fixed once the canister holds data.
-    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+    // half-initialized.
+    //
+    // This is a stable variable on purpose, so it is captured at the first install
+    // and never re-read: changing the environment variable later is silently
+    // ignored, and only a reinstall — which drops all data — switches keys. The key
+    // feeds vetKD derivation, so a different key cannot decrypt what the old one
+    // encrypted, and this canister only ever sees ciphertext and so cannot
+    // re-encrypt. Were it `transient` instead, a changed variable would take effect
+    // on the next upgrade and silently orphan the stored data.
+    let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     let TEST_KEY : ManagementCanister.VetKdKeyid = {
         curve = #bls12_381_g2;

--- a/motoko/vetkeys/basic_vetkd/icp.yaml
+++ b/motoko/vetkeys/basic_vetkd/icp.yaml
@@ -4,9 +4,9 @@ canisters:
       type: "@dfinity/motoko@v5.0.0"
     settings:
       # The vetKD master key this canister derives from, read by the canister via
-      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
-      # canister that already holds data — a different key cannot decrypt what the
-      # old one encrypted.
+      # `Runtime.envVar("VETKD_KEY_NAME")` and captured in stable state at the first
+      # install. Set it before deploying: a later change is silently ignored, and
+      # only a reinstall — which drops all data — switches keys.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/basic_vetkd/icp.yaml
+++ b/motoko/vetkeys/basic_vetkd/icp.yaml
@@ -3,9 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/motoko@v5.0.0"
     settings:
-      # The vetKD master key this canister derives from. Read at install time via
-      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
-      # changing it on a canister that already holds data.
+      # The vetKD master key this canister derives from, read by the canister via
+      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
+      # canister that already holds data — a different key cannot decrypt what the
+      # old one encrypted.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/basic_vetkd/icp.yaml
+++ b/motoko/vetkeys/basic_vetkd/icp.yaml
@@ -2,6 +2,12 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/motoko@v5.0.0"
+    settings:
+      # The vetKD master key this canister derives from. Read at install time via
+      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
+      # changing it on a canister that already holds data.
+      environment_variables:
+        VETKD_KEY_NAME: "test_key_1"
 
   - name: frontend
     recipe:

--- a/motoko/vetkeys/basic_vetkd/mops.toml
+++ b/motoko/vetkeys/basic_vetkd/mops.toml
@@ -1,9 +1,9 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.13.0"
 
 [dependencies]
-core = "2.5.0"
-ic-vetkeys = "0.5.0"
+core = "2.6.1"
+ic-vetkeys = "0.6.0"
 
 [moc]
 # M0236: use context dot notation

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/README.md
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/README.md
@@ -18,7 +18,7 @@ The vetKey used to encrypt and decrypt a note is note-ID-specific (and not, for 
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
+Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
 
 ### Install
 

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/README.md
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/README.md
@@ -14,6 +14,12 @@ The vetKey used to encrypt and decrypt a note is note-ID-specific (and not, for 
 - Install [icp-cli](https://cli.internetcomputer.org): `npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm`
 - Install [ic-mops](https://mops.one): `npm install -g ic-mops`
 
+### (Optionally) choose a different master key
+
+This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
+
+Do not change it once the canister holds data: the key name feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted.
+
 ### Install
 
 ```bash

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/README.md
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/README.md
@@ -18,7 +18,7 @@ The vetKey used to encrypt and decrypt a note is note-ID-specific (and not, for 
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-Treat it as fixed once the canister holds data. The key name feeds vetKD key derivation, and this canister re-reads the variable on every upgrade, so a changed value takes effect immediately and orphans everything encrypted under the old key.
+The key name is read once at the first install and captured in stable state: it feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted — and since the canister only ever sees ciphertext, it cannot re-encrypt either. Changing the variable on a later upgrade is therefore silently ignored; only `icp deploy --mode reinstall`, which drops all data, switches keys. Re-keying live data would need application-level key rotation, which these examples do not implement.
 
 ### Install
 

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/backend/backend.did
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/backend/backend.did
@@ -1,16 +1,3 @@
-type _anon_class_17_1 = 
- service {
-   addUser: (note_id: NoteId, user: PrincipalName) -> ();
-   createNote: () -> (NoteId);
-   deleteNote: (note_id: NoteId) -> ();
-   encryptedSymmetricKeyForNote: (note_id: NoteId, transport_public_key:
-    blob) -> (text);
-   getNotes: () -> (vec EncryptedNote);
-   removeUser: (note_id: NoteId, user: PrincipalName) -> ();
-   symmetricKeyVerificationKeyForNote: () -> (text);
-   updateNote: (id: NoteId, encryptedText: text) -> ();
-   whoami: () -> (text);
- };
 type PrincipalName = text;
 type NoteId = nat;
 type EncryptedNote = 
@@ -20,4 +7,15 @@ type EncryptedNote =
    owner: PrincipalName;
    users: vec PrincipalName;
  };
-service : (keyName: text) -> _anon_class_17_1
+service : {
+  addUser: (note_id: NoteId, user: PrincipalName) -> ();
+  createNote: () -> (NoteId);
+  deleteNote: (note_id: NoteId) -> ();
+  encryptedSymmetricKeyForNote: (note_id: NoteId, transport_public_key:
+   blob) -> (text);
+  getNotes: () -> (vec EncryptedNote);
+  removeUser: (note_id: NoteId, user: PrincipalName) -> ();
+  symmetricKeyVerificationKeyForNote: () -> (text);
+  updateNote: (id: NoteId, encryptedText: text) -> ();
+  whoami: () -> (text);
+}

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
@@ -16,10 +16,16 @@ actor {
     // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
     // canister environment variable (see `icp.yaml`) to pick a different key; it
     // defaults to `test_key_1` so a deploy can never leave the canister
-    // half-initialized. It is re-read on every upgrade, so changing the variable
-    // does take effect — and orphans everything encrypted under the old key, which
-    // no other key can decrypt. Treat it as fixed once the canister holds data.
-    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
+    // half-initialized.
+    //
+    // This is a stable variable on purpose, so it is captured at the first install
+    // and never re-read: changing the environment variable later is silently
+    // ignored, and only a reinstall — which drops all data — switches keys. The key
+    // feeds vetKD derivation, so a different key cannot decrypt what the old one
+    // encrypted, and this canister only ever sees ciphertext and so cannot
+    // re-encrypt. Were it `transient` instead, a changed variable would take effect
+    // on the next upgrade and silently orphan the stored data.
+    let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     // Currently, a single canister is limited to 4 GB of heap size.
     // For the current limits see https://docs.internetcomputer.org/references/resource-limits.

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
@@ -16,9 +16,9 @@ actor {
     // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
     // canister environment variable (see `icp.yaml`) to pick a different key; it
     // defaults to `test_key_1` so a deploy can never leave the canister
-    // half-initialized. Do not change it once the canister holds data: the key
-    // feeds vetKD derivation, so a different key cannot decrypt what the old one
-    // encrypted.
+    // half-initialized. It is re-read on every upgrade, so changing the variable
+    // does take effect — and orphans everything encrypted under the old key, which
+    // no other key can decrypt. Treat it as fixed once the canister holds data.
     transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     // Currently, a single canister is limited to 4 GB of heap size.

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
@@ -12,9 +12,14 @@ import Runtime "mo:core/Runtime";
 import Blob "mo:core/Blob";
 import Hex "./utils/Hex";
 
-// Declare a shared actor class
-// Bind the caller and the initializer
-shared ({ caller = initializer }) actor class (keyName: Text) {
+actor {
+    // The vetKD key name this canister derives from. Set the `VETKD_KEY_NAME`
+    // canister environment variable (see `icp.yaml`) to pick a different key; it
+    // defaults to `test_key_1` so a deploy can never leave the canister
+    // half-initialized. Do not change it once the canister holds data: the key
+    // feeds vetKD derivation, so a different key cannot decrypt what the old one
+    // encrypted.
+    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     // Currently, a single canister is limited to 4 GB of heap size.
     // For the current limits see https://docs.internetcomputer.org/references/resource-limits.

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/icp.yaml
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/icp.yaml
@@ -4,9 +4,9 @@ canisters:
       type: "@dfinity/motoko@v5.0.0"
     settings:
       # The vetKD master key this canister derives from, read by the canister via
-      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
-      # canister that already holds data — a different key cannot decrypt what the
-      # old one encrypted.
+      # `Runtime.envVar("VETKD_KEY_NAME")` and captured in stable state at the first
+      # install. Set it before deploying: a later change is silently ignored, and
+      # only a reinstall — which drops all data — switches keys.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/icp.yaml
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/icp.yaml
@@ -3,9 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/motoko@v5.0.0"
     settings:
-      # The vetKD master key this canister derives from. Read at install time via
-      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
-      # changing it on a canister that already holds data.
+      # The vetKD master key this canister derives from, read by the canister via
+      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
+      # canister that already holds data — a different key cannot decrypt what the
+      # old one encrypted.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/icp.yaml
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/icp.yaml
@@ -2,9 +2,12 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/motoko@v5.0.0"
-    init_args:
-      type: text
-      value: "(\"test_key_1\")"
+    settings:
+      # The vetKD master key this canister derives from. Read at install time via
+      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
+      # changing it on a canister that already holds data.
+      environment_variables:
+        VETKD_KEY_NAME: "test_key_1"
 
   - name: frontend
     recipe:

--- a/motoko/vetkeys/password_manager/README.md
+++ b/motoko/vetkeys/password_manager/README.md
@@ -20,7 +20,7 @@ The **VetKey Password Manager** is an example application demonstrating how to u
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-The key name is read once at install time and baked into the canister's stable state, because it feeds vetKD key derivation: changing it later would make every already-encrypted value undecryptable. Changing the variable on a later upgrade is therefore silently ignored — only `icp deploy --mode reinstall`, which drops all data, switches keys.
+The key name is read once at the first install and captured in stable state: it feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted — and since the canister only ever sees ciphertext, it cannot re-encrypt either. Changing the variable on a later upgrade is therefore silently ignored; only `icp deploy --mode reinstall`, which drops all data, switches keys. Re-keying live data would need application-level key rotation, which these examples do not implement.
 
 ### Install
 

--- a/motoko/vetkeys/password_manager/README.md
+++ b/motoko/vetkeys/password_manager/README.md
@@ -18,7 +18,9 @@ The **VetKey Password Manager** is an example application demonstrating how to u
 
 ### (Optionally) choose a different master key
 
-This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `init_args` value in `icp.yaml` before deploying.
+This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
+
+The key name is read once at install time and baked into the canister's stable state, because it feeds vetKD key derivation: changing it later would make every already-encrypted value undecryptable. Changing the variable on a later upgrade is therefore silently ignored — only `icp deploy --mode reinstall`, which drops all data, switches keys.
 
 ### Install
 
@@ -54,7 +56,7 @@ icp network stop
 
 An **Encrypted Maps**-enabled Motoko canister that securely stores passwords.
 
-> **Note on naming.** The backend methods are snake_case (rather than the usual Motoko camelCase) because the `@icp-sdk/vetkeys` Encrypted Maps client calls the canister by these exact names — renaming them would break the frontend. The delegation methods are hand-written for now; an upstream Motoko actor mixin that generates this endpoint set automatically is in progress ([dfinity/vetkeys#405](https://github.com/dfinity/vetkeys/pull/405)).
+> **Note.** The whole Encrypted Maps endpoint set comes from the `EncryptedMapsCanister` mixin (`mo:ic-vetkeys/encrypted_maps/Canister`), so the backend is a few lines instead of ~200 lines of hand-written delegation, and the exposed Candid matches what the `@icp-sdk/vetkeys` client expects by construction. Those methods are snake_case (rather than the usual Motoko camelCase) because the client calls the canister by these exact names. The mixin holds no stable state of its own: this actor declares the `EncryptedMapsState` and passes it in, so the persistent state stays a plain, visible stable variable the canister owns and can migrate. If you need to keep state linked to each value, use the `EncryptedMapsControlPlaneCanister` mixin instead — see the [`password_manager_with_metadata`](../password_manager_with_metadata/) example.
 
 ### Frontend (`frontend/`)
 

--- a/motoko/vetkeys/password_manager/backend/main.mo
+++ b/motoko/vetkeys/password_manager/backend/main.mo
@@ -1,228 +1,39 @@
-import IcVetkeys "mo:ic-vetkeys";
+import EncryptedMapsCanister "mo:ic-vetkeys/encrypted_maps/Canister";
+import EncryptedMaps "mo:ic-vetkeys/encrypted_maps/EncryptedMaps";
 import Types "mo:ic-vetkeys/Types";
-import Principal "mo:core/Principal";
-import Text "mo:core/Text";
-import Blob "mo:core/Blob";
-import Result "mo:core/Result";
-import Array "mo:core/Array";
+import Runtime "mo:core/Runtime";
 
-// This canister exposes the Encrypted Maps interface. Its public methods are
-// intentionally snake_case (not the usual Motoko camelCase) because the
-// `@icp-sdk/vetkeys` Encrypted Maps client calls the canister by these exact
-// names — renaming them to camelCase would break the frontend. The delegation
-// methods below are hand-written today; an upstream Motoko actor mixin that
-// generates this endpoint set automatically is in progress
-// (https://github.com/dfinity/vetkeys/pull/405).
-actor class (keyName : Text) {
-    let encryptedMapsState = IcVetkeys.EncryptedMaps.newEncryptedMapsState<Types.AccessRights>({ curve = #bls12_381_g2; name = keyName }, "password_manager_example_app");
-    transient let encryptedMaps = IcVetkeys.EncryptedMaps.EncryptedMaps<Types.AccessRights>(encryptedMapsState, Types.accessRightsOperations());
+// This canister is a thin wrapper around the `ic-vetkeys` Encrypted Maps
+// library. The `EncryptedMapsCanister` mixin contributes the whole endpoint set
+// — the vetKD key, access-control, map-name and value endpoints — so the Candid
+// this canister exposes is exactly what the `@icp-sdk/vetkeys` Encrypted Maps
+// client expects. Those endpoints are snake_case (not the usual Motoko
+// camelCase) because the client calls them by these exact names.
+//
+// The mixin holds no stable state of its own: this actor declares the
+// `EncryptedMapsState` and passes it in, so the persistent state stays a plain,
+// visible stable variable this canister owns and can migrate.
+actor PasswordManager {
+    // The vetKD key name is only an install-time input — it is baked into the
+    // stable state below and never read again, hence `transient`. Set the
+    // `VETKD_KEY_NAME` canister environment variable (see `icp.yaml`) to pick a
+    // different key; it defaults to `test_key_1` so a deploy can never leave the
+    // canister half-initialized.
+    //
+    // The key name is immutable for the life of the canister's data: it feeds
+    // vetKD key derivation, so changing it would make every already-encrypted
+    // value undecryptable. Changing the environment variable on a later upgrade
+    // is silently ignored (the stable state is not rebuilt); only a `reinstall`,
+    // which drops all data, switches keys.
+    transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
-    /// In this canister, we use the `ByteBuf` type to represent blobs. The reason is that we want to be consistent with the Rust canister implementation.
-    /// Unfortunately, the `Blob` type cannot be serialized/deserialized in the current Rust implementation efficiently without nesting it in another type.
-    public type ByteBuf = { inner : Blob };
+    // The second argument is the domain separator that isolates this
+    // application's derived keys from other vetKeys deployments; like the key
+    // name it must stay stable for the life of the canister.
+    let encryptedMapsState = EncryptedMaps.newEncryptedMapsState<Types.AccessRights>(
+        { curve = #bls12_381_g2; name = keyName },
+        "password_manager_app",
+    );
 
-    public type EncryptedMapData = {
-        map_owner : Principal;
-        map_name : ByteBuf;
-        keyvals : [(ByteBuf, ByteBuf)];
-        access_control : [(Principal, Types.AccessRights)];
-    };
-
-    /// The result type compatible with Rust's `Result`.
-    public type Result<Ok, Err> = {
-        #Ok : Ok;
-        #Err : Err;
-    };
-
-    public query (msg) func get_accessible_shared_map_names() : async [(Principal, ByteBuf)] {
-        Array.map<(Principal, Blob), (Principal, ByteBuf)>(
-            encryptedMaps.getAccessibleSharedMapNames(msg.caller),
-
-            func((principal, blob) : (Principal, Blob)) {
-                (principal, { inner = blob });
-            },
-        );
-    };
-
-    public query (msg) func get_shared_user_access_for_map(
-        map_owner : Principal,
-        map_name : ByteBuf,
-    ) : async Result<[(Principal, Types.AccessRights)], Text> {
-        convertResult(encryptedMaps.getSharedUserAccessForMap(msg.caller, (map_owner, map_name.inner)));
-    };
-
-    public query (msg) func get_encrypted_values_for_map(
-        map_owner : Principal,
-        map_name : ByteBuf,
-    ) : async Result<[(ByteBuf, ByteBuf)], Text> {
-        let result = encryptedMaps.getEncryptedValuesForMap(msg.caller, (map_owner, map_name.inner));
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(values)) {
-                #Ok(
-                    Array.map<(Blob, Blob), (ByteBuf, ByteBuf)>(
-                        values,
-                        func((blob1, blob2) : (Blob, Blob)) {
-                            ({ inner = blob1 }, { inner = blob2 });
-                        },
-                    )
-                );
-            };
-        };
-    };
-
-    public query (msg) func get_all_accessible_encrypted_values() : async [((Principal, ByteBuf), [(ByteBuf, ByteBuf)])] {
-        Array.map<((Principal, Blob), [(Blob, Blob)]), ((Principal, ByteBuf), [(ByteBuf, ByteBuf)])>(
-            encryptedMaps.getAllAccessibleEncryptedValues(msg.caller),
-            func(((owner, map_name), values) : ((Principal, Blob), [(Blob, Blob)])) {
-                (
-                    (owner, { inner = map_name }),
-                    Array.map<(Blob, Blob), (ByteBuf, ByteBuf)>(
-                        values,
-                        func((blob1, blob2) : (Blob, Blob)) {
-                            ({ inner = blob1 }, { inner = blob2 });
-                        },
-                    ),
-                );
-            },
-        );
-    };
-
-    public query (msg) func get_all_accessible_encrypted_maps() : async [EncryptedMapData] {
-        Array.map<IcVetkeys.EncryptedMaps.EncryptedMapData<Types.AccessRights>, EncryptedMapData>(
-            encryptedMaps.getAllAccessibleEncryptedMaps(msg.caller),
-            func(map : IcVetkeys.EncryptedMaps.EncryptedMapData<Types.AccessRights>) : EncryptedMapData {
-                {
-                    map_owner = map.map_owner;
-                    map_name = { inner = map.map_name };
-                    keyvals = Array.map<(Blob, Blob), (ByteBuf, ByteBuf)>(
-                        map.keyvals,
-                        func((blob1, blob2) : (Blob, Blob)) {
-                            ({ inner = blob1 }, { inner = blob2 });
-                        },
-                    );
-                    access_control = map.access_control;
-                };
-            },
-        );
-    };
-
-    public query (msg) func get_encrypted_value(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        map_key : ByteBuf,
-    ) : async Result<?ByteBuf, Text> {
-        let result = encryptedMaps.getEncryptedValue(msg.caller, (map_owner, map_name.inner), map_key.inner);
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(null)) { #Ok(null) };
-            case (#ok(?blob)) { #Ok(?{ inner = blob }) };
-        };
-    };
-
-    public shared (msg) func remove_map_values(
-        map_owner : Principal,
-        map_name : ByteBuf,
-    ) : async Result<[ByteBuf], Text> {
-        let result = encryptedMaps.removeMapValues(msg.caller, (map_owner, map_name.inner));
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(values)) {
-                #Ok(
-                    Array.map<Blob, ByteBuf>(
-                        values,
-                        func(blob : Blob) : ByteBuf {
-                            { inner = blob };
-                        },
-                    )
-                );
-            };
-        };
-    };
-
-    public query (msg) func get_owned_non_empty_map_names() : async [ByteBuf] {
-        Array.map<Blob, ByteBuf>(
-            encryptedMaps.getOwnedNonEmptyMapNames(msg.caller),
-            func(blob : Blob) : ByteBuf {
-                { inner = blob };
-            },
-        );
-    };
-
-    public shared (msg) func insert_encrypted_value(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        map_key : ByteBuf,
-        value : ByteBuf,
-    ) : async Result<?ByteBuf, Text> {
-        let result = encryptedMaps.insertEncryptedValue(msg.caller, (map_owner, map_name.inner), map_key.inner, value.inner);
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(null)) { #Ok(null) };
-            case (#ok(?blob)) { #Ok(?{ inner = blob }) };
-        };
-    };
-
-    public shared (msg) func remove_encrypted_value(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        map_key : ByteBuf,
-    ) : async Result<?ByteBuf, Text> {
-        let result = encryptedMaps.removeEncryptedValue(msg.caller, (map_owner, map_name.inner), map_key.inner);
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(null)) { #Ok(null) };
-            case (#ok(?blob)) { #Ok(?{ inner = blob }) };
-        };
-    };
-
-    public shared func get_vetkey_verification_key() : async ByteBuf {
-        let inner = await encryptedMaps.getVetkeyVerificationKey();
-        { inner };
-    };
-
-    public shared (msg) func get_encrypted_vetkey(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        transport_key : ByteBuf,
-    ) : async Result<ByteBuf, Text> {
-        let result = await encryptedMaps.getEncryptedVetkey(msg.caller, (map_owner, map_name.inner), transport_key.inner);
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(vetkey)) { #Ok({ inner = vetkey }) };
-        };
-    };
-
-    public query (msg) func get_user_rights(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        user : Principal,
-    ) : async Result<?Types.AccessRights, Text> {
-        convertResult(encryptedMaps.getUserRights(msg.caller, (map_owner, map_name.inner), user));
-    };
-
-    public shared (msg) func set_user_rights(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        user : Principal,
-        access_rights : Types.AccessRights,
-    ) : async Result<?Types.AccessRights, Text> {
-        convertResult(encryptedMaps.setUserRights(msg.caller, (map_owner, map_name.inner), user, access_rights));
-    };
-
-    public shared (msg) func remove_user(
-        map_owner : Principal,
-        map_name : ByteBuf,
-        user : Principal,
-    ) : async Result<?Types.AccessRights, Text> {
-        convertResult(encryptedMaps.removeUser(msg.caller, (map_owner, map_name.inner), user));
-    };
-
-    /// Convert to the result type compatible with Rust's `Result`
-    private func convertResult<Ok, Err>(result : Result.Result<Ok, Err>) : Result<Ok, Err> {
-        switch (result) {
-            case (#err(e)) { #Err(e) };
-            case (#ok(o)) { #Ok(o) };
-        };
-    };
+    include EncryptedMapsCanister(encryptedMapsState);
 };

--- a/motoko/vetkeys/password_manager/backend/main.mo
+++ b/motoko/vetkeys/password_manager/backend/main.mo
@@ -22,9 +22,10 @@ actor PasswordManager {
     //
     // The key name is immutable for the life of the canister's data: it feeds
     // vetKD key derivation, so changing it would make every already-encrypted
-    // value undecryptable. Changing the environment variable on a later upgrade
-    // is silently ignored (the stable state is not rebuilt); only a `reinstall`,
-    // which drops all data, switches keys.
+    // value undecryptable — and this canister only ever sees ciphertext, so it
+    // cannot re-encrypt them either. Changing the environment variable on a later
+    // upgrade is silently ignored (the stable state is not rebuilt); only a
+    // `reinstall`, which drops all data, switches keys.
     transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
     // The second argument is the domain separator that isolates this

--- a/motoko/vetkeys/password_manager/backend/main.mo
+++ b/motoko/vetkeys/password_manager/backend/main.mo
@@ -11,8 +11,8 @@ import Runtime "mo:core/Runtime";
 /// camelCase) because the client calls them by these exact names.
 ///
 /// The mixin holds no stable state of its own: this actor declares the
-// `EncryptedMapsState` and passes it in, so the persistent state stays a plain,
-// visible stable variable this canister owns and can migrate.
+/// `EncryptedMapsState` and passes it in, so the persistent state stays a plain,
+/// visible stable variable this canister owns and can migrate.
 actor PasswordManager {
     // The vetKD key name is only an install-time input — it is baked into the
     // stable state below and never read again, hence `transient`. Set the

--- a/motoko/vetkeys/password_manager/backend/main.mo
+++ b/motoko/vetkeys/password_manager/backend/main.mo
@@ -3,14 +3,14 @@ import EncryptedMaps "mo:ic-vetkeys/encrypted_maps/EncryptedMaps";
 import Types "mo:ic-vetkeys/Types";
 import Runtime "mo:core/Runtime";
 
-// This canister is a thin wrapper around the `ic-vetkeys` Encrypted Maps
-// library. The `EncryptedMapsCanister` mixin contributes the whole endpoint set
-// — the vetKD key, access-control, map-name and value endpoints — so the Candid
-// this canister exposes is exactly what the `@icp-sdk/vetkeys` Encrypted Maps
-// client expects. Those endpoints are snake_case (not the usual Motoko
-// camelCase) because the client calls them by these exact names.
-//
-// The mixin holds no stable state of its own: this actor declares the
+/// This canister is a thin wrapper around the `ic-vetkeys` Encrypted Maps
+/// library. The `EncryptedMapsCanister` mixin contributes the whole endpoint set
+/// — the vetKD key, access-control, map-name and value endpoints — so the Candid
+/// this canister exposes is exactly what the `@icp-sdk/vetkeys` Encrypted Maps
+/// client expects. Those endpoints are snake_case (not the usual Motoko
+/// camelCase) because the client calls them by these exact names.
+///
+/// The mixin holds no stable state of its own: this actor declares the
 // `EncryptedMapsState` and passes it in, so the persistent state stays a plain,
 // visible stable variable this canister owns and can migrate.
 actor PasswordManager {

--- a/motoko/vetkeys/password_manager/icp.yaml
+++ b/motoko/vetkeys/password_manager/icp.yaml
@@ -4,9 +4,9 @@ canisters:
       type: "@dfinity/motoko@v5.0.0"
     settings:
       # The vetKD master key this canister derives from, read by the canister via
-      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
-      # canister that already holds data — a different key cannot decrypt what the
-      # old one encrypted.
+      # `Runtime.envVar("VETKD_KEY_NAME")` and captured in stable state at the first
+      # install. Set it before deploying: a later change is silently ignored, and
+      # only a reinstall — which drops all data — switches keys.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/password_manager/icp.yaml
+++ b/motoko/vetkeys/password_manager/icp.yaml
@@ -3,9 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/motoko@v5.0.0"
     settings:
-      # The vetKD master key this canister derives from. Read at install time via
-      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
-      # changing it on a canister that already holds data.
+      # The vetKD master key this canister derives from, read by the canister via
+      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
+      # canister that already holds data — a different key cannot decrypt what the
+      # old one encrypted.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/password_manager/icp.yaml
+++ b/motoko/vetkeys/password_manager/icp.yaml
@@ -2,9 +2,12 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/motoko@v5.0.0"
-    init_args:
-      type: text
-      value: "(\"test_key_1\")"
+    settings:
+      # The vetKD master key this canister derives from. Read at install time via
+      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
+      # changing it on a canister that already holds data.
+      environment_variables:
+        VETKD_KEY_NAME: "test_key_1"
 
   - name: frontend
     recipe:

--- a/motoko/vetkeys/password_manager/mops.toml
+++ b/motoko/vetkeys/password_manager/mops.toml
@@ -1,9 +1,9 @@
 [toolchain]
-moc = "1.11.0"
+moc = "1.13.0"
 
 [dependencies]
-core = "2.5.0"
-ic-vetkeys = "0.5.0"
+core = "2.6.1"
+ic-vetkeys = "0.6.0"
 
 [moc]
 # M0236: use context dot notation

--- a/motoko/vetkeys/password_manager_with_metadata/README.md
+++ b/motoko/vetkeys/password_manager_with_metadata/README.md
@@ -21,7 +21,9 @@ This version extends the basic password manager by supporting unencrypted metada
 
 ### (Optionally) choose a different master key
 
-This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `init_args` value in `icp.yaml` before deploying.
+This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
+
+The key name is read once at install time and baked into the canister's stable state, because it feeds vetKD key derivation: changing it later would make every already-encrypted value undecryptable. Changing the variable on a later upgrade is therefore silently ignored — only `icp deploy --mode reinstall`, which drops all data, switches keys.
 
 ### Install
 
@@ -57,7 +59,7 @@ icp network stop
 
 An **Encrypted Maps**-enabled Motoko canister that stores encrypted passwords together with unencrypted metadata (URLs, tags) in atomic update calls.
 
-> **Note on naming.** The backend methods are snake_case (rather than the usual Motoko camelCase). The standard Encrypted Maps methods are called by these exact names by the `@icp-sdk/vetkeys` Encrypted Maps client, and the custom metadata methods follow the same convention — renaming them would break the frontend. An upstream Motoko actor mixin that generates the Encrypted Maps endpoint set automatically is in progress ([dfinity/vetkeys#405](https://github.com/dfinity/vetkeys/pull/405)).
+> **Note.** This example includes the `EncryptedMapsControlPlaneCanister` mixin (`mo:ic-vetkeys/encrypted_maps/ControlPlaneCanister`) rather than the full `EncryptedMapsCanister` used by the [`password_manager`](../password_manager/) example. The control-plane mixin contributes the vetKD key, access-control and map-name endpoints plus the in-scope `encryptedMaps` object, but **none** of the endpoints that read or write encrypted values — so the plain `insert_encrypted_value`/`remove_encrypted_value` mutators, which would write a value with no metadata row and desync the two stores, are never exposed. The canister writes its own `*_with_metadata` endpoints against `encryptedMaps` instead, updating both stores in a single call. All methods are snake_case (rather than the usual Motoko camelCase) because the `@icp-sdk/vetkeys` client calls the standard ones by these exact names, and the metadata methods follow the same convention.
 
 ### Frontend (`frontend/`)
 

--- a/motoko/vetkeys/password_manager_with_metadata/README.md
+++ b/motoko/vetkeys/password_manager_with_metadata/README.md
@@ -23,7 +23,7 @@ This version extends the basic password manager by supporting unencrypted metada
 
 This example uses `test_key_1` by default. To use a different [available master key](https://docs.internetcomputer.org/concepts/vetkeys/#api-overview), change the `VETKD_KEY_NAME` environment variable in `icp.yaml` before the first deploy.
 
-The key name is read once at install time and baked into the canister's stable state, because it feeds vetKD key derivation: changing it later would make every already-encrypted value undecryptable. Changing the variable on a later upgrade is therefore silently ignored — only `icp deploy --mode reinstall`, which drops all data, switches keys.
+The key name is read once at the first install and captured in stable state: it feeds vetKD key derivation, so a different key cannot decrypt what the old one encrypted — and since the canister only ever sees ciphertext, it cannot re-encrypt either. Changing the variable on a later upgrade is therefore silently ignored; only `icp deploy --mode reinstall`, which drops all data, switches keys. Re-keying live data would need application-level key rotation, which these examples do not implement.
 
 ### Install
 

--- a/motoko/vetkeys/password_manager_with_metadata/backend/backend.did
+++ b/motoko/vetkeys/password_manager_with_metadata/backend/backend.did
@@ -1,30 +1,3 @@
-type _anon_class_15_1 = 
- service {
-   get_accessible_shared_map_names: () ->
-    (vec record {
-           principal;
-           ByteBuf;
-         }) query;
-   get_encrypted_values_for_map_with_metadata: (map_owner: principal,
-    map_name: ByteBuf) -> (Result_4) query;
-   get_encrypted_vetkey: (map_owner: principal, map_name: ByteBuf,
-    transport_key: ByteBuf) -> (Result_3);
-   get_owned_non_empty_map_names: () -> (vec ByteBuf) query;
-   get_shared_user_access_for_map: (map_owner: principal, map_name:
-    ByteBuf) -> (Result_2) query;
-   get_user_rights: (map_owner: principal, map_name: ByteBuf, user:
-    principal) -> (Result) query;
-   get_vetkey_verification_key: () -> (ByteBuf);
-   insert_encrypted_value_with_metadata: (map_owner: principal, map_name:
-    ByteBuf, map_key: ByteBuf, value: ByteBuf, tags: vec text, url: text) ->
-    (Result_1);
-   remove_encrypted_value_with_metadata: (map_owner: principal, map_name:
-    ByteBuf, map_key: ByteBuf) -> (Result_1);
-   remove_user: (map_owner: principal, map_name: ByteBuf, user: principal) ->
-    (Result);
-   set_user_rights: (map_owner: principal, map_name: ByteBuf, user:
-    principal, access_rights: AccessRights) -> (Result);
- };
 type Result_4 = 
  variant {
    Err: text;
@@ -76,4 +49,29 @@ type AccessRights =
    ReadWrite;
    ReadWriteManage;
  };
-service : (keyName: text) -> _anon_class_15_1
+service : {
+  get_accessible_shared_map_names: () ->
+   (vec record {
+          principal;
+          ByteBuf;
+        }) query;
+  get_encrypted_values_for_map_with_metadata: (map_owner: principal,
+   map_name: ByteBuf) -> (Result_4) query;
+  get_encrypted_vetkey: (map_owner: principal, map_name: ByteBuf,
+   transport_key: ByteBuf) -> (Result_3);
+  get_owned_non_empty_map_names: () -> (vec ByteBuf) query;
+  get_shared_user_access_for_map: (map_owner: principal, map_name:
+   ByteBuf) -> (Result_2) query;
+  get_user_rights: (map_owner: principal, map_name: ByteBuf, user:
+   principal) -> (Result) query;
+  get_vetkey_verification_key: () -> (ByteBuf);
+  insert_encrypted_value_with_metadata: (map_owner: principal, map_name:
+   ByteBuf, map_key: ByteBuf, value: ByteBuf, tags: vec text, url: text) ->
+   (Result_1);
+  remove_encrypted_value_with_metadata: (map_owner: principal, map_name:
+   ByteBuf, map_key: ByteBuf) -> (Result_1);
+  remove_user: (map_owner: principal, map_name: ByteBuf, user: principal) ->
+   (Result);
+  set_user_rights: (map_owner: principal, map_name: ByteBuf, user: principal,
+   access_rights: AccessRights) -> (Result);
+}

--- a/motoko/vetkeys/password_manager_with_metadata/backend/main.mo
+++ b/motoko/vetkeys/password_manager_with_metadata/backend/main.mo
@@ -1,30 +1,73 @@
 import Principal "mo:core/Principal";
 import Blob "mo:core/Blob";
 import List "mo:core/List";
-import Array "mo:core/Array";
 import OrderedMap "mo:core/pure/Map";
-import MotokoResult "mo:core/Result";
-import Text "mo:core/Text";
 import Time "mo:core/Time";
-import Nat64 "mo:core/Nat64";
+import Nat "mo:core/Nat";
 import Int "mo:core/Int";
-import Debug "mo:core/Debug";
 import Runtime "mo:core/Runtime";
-import VetKeys "mo:ic-vetkeys";
+import EncryptedMapsControlPlaneCanister "mo:ic-vetkeys/encrypted_maps/ControlPlaneCanister";
+import EncryptedMaps "mo:ic-vetkeys/encrypted_maps/EncryptedMaps";
+import Types "mo:ic-vetkeys/Types";
 
-// This canister combines the Encrypted Maps interface with extra metadata-aware
-// methods. Its public methods are intentionally snake_case (not the usual Motoko
-// camelCase): the standard Encrypted Maps methods are called by these exact names
-// by the `@icp-sdk/vetkeys` Encrypted Maps client, and the custom metadata
-// methods follow the same convention for a consistent interface — renaming to
-// camelCase would break the frontend. An upstream Motoko actor mixin that
-// generates the Encrypted Maps endpoint set automatically is in progress
-// (https://github.com/dfinity/vetkeys/pull/405).
-actor class (keyName : Text) {
+// This canister layers a second, backend-authoritative store on top of the
+// `ic-vetkeys` Encrypted Maps library: every encrypted password has a matching
+// metadata row (creation date, modification counter, tags, url) that the
+// canister — not the client — maintains.
+//
+// It includes the `EncryptedMapsControlPlaneCanister` mixin rather than the full
+// `EncryptedMapsCanister`: the control-plane mixin contributes the vetKD key,
+// access-control and map-name endpoints plus the in-scope `encryptedMaps`
+// object, but none of the endpoints that read or write encrypted values. That is
+// what this canister needs — the plain `insert_encrypted_value` /
+// `remove_encrypted_value` mutators are never exposed, so nothing can write a
+// value without its metadata row, and the `*_with_metadata` endpoints below
+// update both stores in a single call.
+//
+// The public methods are snake_case (not the usual Motoko camelCase): the
+// standard Encrypted Maps methods are called by these exact names by the
+// `@icp-sdk/vetkeys` client, and the custom metadata methods follow the same
+// convention for a consistent interface.
+actor PasswordManagerWithMetadata {
+  // The vetKD key name is only an install-time input — it is baked into the
+  // stable state below and never read again, hence `transient`. Set the
+  // `VETKD_KEY_NAME` canister environment variable (see `icp.yaml`) to pick a
+  // different key; it defaults to `test_key_1` so a deploy can never leave the
+  // canister half-initialized.
+  //
+  // The key name is immutable for the life of the canister's data: it feeds
+  // vetKD key derivation, so changing it would make every already-encrypted
+  // value undecryptable. Changing the environment variable on a later upgrade is
+  // silently ignored (the stable state is not rebuilt); only a `reinstall`,
+  // which drops all data, switches keys.
+  transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
-  // Global state
-  let encryptedMapsState = VetKeys.EncryptedMaps.newEncryptedMapsState<VetKeys.AccessRights>({ curve = #bls12_381_g2; name = keyName }, "password_manager_example_app");
-  transient let encryptedMaps = VetKeys.EncryptedMaps.EncryptedMaps<VetKeys.AccessRights>(encryptedMapsState, VetKeys.accessRightsOperations());
+  // The second argument is the domain separator that isolates this
+  // application's derived keys from other vetKeys deployments; like the key name
+  // it must stay stable for the life of the canister. This actor — not the mixin
+  // — owns the state, so it stays a plain, visible stable variable.
+  let encryptedMapsState = EncryptedMaps.newEncryptedMapsState<Types.AccessRights>(
+    { curve = #bls12_381_g2; name = keyName },
+    "password_manager_with_metadata_app",
+  );
+
+  // Brings the control-plane endpoints and the `encryptedMaps`, `ByteBuf` and
+  // `Result` names into scope, over the state declared above.
+  include EncryptedMapsControlPlaneCanister(encryptedMapsState);
+
+  public type PasswordMetadata = {
+    creation_date : Nat64;
+    last_modification_date : Nat64;
+    number_of_modifications : Nat64;
+    last_modified_principal : Principal;
+    tags : [Text];
+    url : Text;
+  };
+
+  type MapOwner = Principal;
+  type MapName = Blob;
+  type MapKey = Blob;
+  type MetadataKey = (MapOwner, MapName, MapKey);
 
   func compareMetadataKeys(a : MetadataKey, b : MetadataKey) : {
     #less;
@@ -43,32 +86,12 @@ actor class (keyName : Text) {
       ownerCompare;
     };
   };
+
+  // The metadata store kept in lockstep with the encrypted values above.
   var metadata : OrderedMap.Map<MetadataKey, PasswordMetadata> = OrderedMap.empty<MetadataKey, PasswordMetadata>();
 
-  // Types
-  public type PasswordMetadata = {
-    creation_date : Nat64;
-    last_modification_date : Nat64;
-    number_of_modifications : Nat64;
-    last_modified_principal : Principal;
-    tags : [Text];
-    url : Text;
-  };
-
-  type MapOwner = Principal;
-  type MapName = Blob;
-  type MapKey = Blob;
-  type MapId = (MapOwner, MapName);
-  type MetadataKey = (MapOwner, MapName, MapKey);
-  type ByteBuf = { inner : Blob };
-  type Result<T, E> = {
-    #Ok : T;
-    #Err : E;
-  };
-
-  // Helper function to create new PasswordMetadata
   func newPasswordMetadata(caller : Principal, tags : [Text], url : Text) : PasswordMetadata {
-    let timeNow = Nat64.fromNat(Int.abs(Time.now()));
+    let timeNow = Int.abs(Time.now()).toNat64();
     {
       creation_date = timeNow;
       last_modification_date = timeNow;
@@ -79,9 +102,8 @@ actor class (keyName : Text) {
     };
   };
 
-  // Helper function to update PasswordMetadata
   func updatePasswordMetadata(metadata : PasswordMetadata, caller : Principal, tags : [Text], url : Text) : PasswordMetadata {
-    let timeNow = Nat64.fromNat(Int.abs(Time.now()));
+    let timeNow = Int.abs(Time.now()).toNat64();
     {
       creation_date = metadata.creation_date;
       last_modification_date = timeNow;
@@ -92,65 +114,33 @@ actor class (keyName : Text) {
     };
   };
 
-  func convertResult<T, E>(result : MotokoResult.Result<T, E>) : Result<T, E> {
-    switch (result) {
-      case (#err(msg)) { #Err(msg) };
-      case (#ok(value)) { #Ok(value) };
-    };
-  };
-
-  public query ({ caller }) func get_accessible_shared_map_names() : async [(Principal, ByteBuf)] {
-    let mapIds = encryptedMaps.getAccessibleSharedMapNames(caller);
-    Array.map<MapId, (Principal, ByteBuf)>(
-      mapIds,
-      func(mapId) = (mapId.0, { inner = mapId.1 }),
-    );
-  };
-
-  public query ({ caller }) func get_shared_user_access_for_map(
-    map_owner : Principal,
-    map_name : ByteBuf,
-  ) : async Result<[(Principal, VetKeys.AccessRights)], Text> {
-    let mapId = (map_owner, map_name.inner);
-    convertResult(encryptedMaps.getSharedUserAccessForMap(caller, mapId));
-  };
-
-  public query ({ caller }) func get_encrypted_values_for_map_with_metadata(
+  public query (msg) func get_encrypted_values_for_map_with_metadata(
     map_owner : Principal,
     map_name : ByteBuf,
   ) : async Result<[(ByteBuf, ByteBuf, PasswordMetadata)], Text> {
-    let mapId = (map_owner, map_name.inner);
-
-    switch (encryptedMaps.getEncryptedValuesForMap(caller, mapId)) {
+    switch (encryptedMaps.getEncryptedValuesForMap(msg.caller, (map_owner, map_name.inner))) {
       case (#err(msg)) { #Err(msg) };
       case (#ok(mapValues)) {
         let results = List.empty<(ByteBuf, ByteBuf, PasswordMetadata)>();
 
         for ((key, encryptedValue) in mapValues.values()) {
           let metadataKey = (map_owner, map_name.inner, key);
-          switch (OrderedMap.get(metadata, compareMetadataKeys,metadataKey)) {
+          switch (metadata.get(compareMetadataKeys, metadataKey)) {
             case (null) {
               Runtime.trap("bug: inconsistent state: no metadata for key");
             };
             case (?metadataValue) {
-              List.add(results, ({ inner = key }, { inner = encryptedValue }, metadataValue));
+              results.add(({ inner = key }, { inner = encryptedValue }, metadataValue));
             };
           };
         };
 
-        #Ok(List.toArray(results));
+        #Ok(results.toArray());
       };
     };
   };
 
-  public query ({ caller }) func get_owned_non_empty_map_names() : async [ByteBuf] {
-    Array.map<MapName, ByteBuf>(
-      encryptedMaps.getOwnedNonEmptyMapNames(caller),
-      func(mapName) = { inner = mapName },
-    );
-  };
-
-  public shared ({ caller }) func insert_encrypted_value_with_metadata(
+  public shared (msg) func insert_encrypted_value_with_metadata(
     map_owner : Principal,
     map_name : ByteBuf,
     map_key : ByteBuf,
@@ -158,24 +148,24 @@ actor class (keyName : Text) {
     tags : [Text],
     url : Text,
   ) : async Result<?(ByteBuf, PasswordMetadata), Text> {
-    let mapId = (map_owner, map_name.inner);
-
-    switch (encryptedMaps.insertEncryptedValue(caller, mapId, map_key.inner, value.inner)) {
+    // The library call performs the access-control check, so it comes first: if
+    // the caller may not write, the metadata store is left untouched.
+    switch (encryptedMaps.insertEncryptedValue(msg.caller, (map_owner, map_name.inner), map_key.inner, value.inner)) {
       case (#err(msg)) { #Err(msg) };
       case (#ok(optPrevValue)) {
         let metadataKey = (map_owner, map_name.inner, map_key.inner);
-        let prevMetadata = OrderedMap.get(metadata, compareMetadataKeys,metadataKey);
+        let prevMetadata = metadata.get(compareMetadataKeys, metadataKey);
 
         let metadataValue = switch (prevMetadata) {
           case (null) {
-            newPasswordMetadata(caller, tags, url);
+            newPasswordMetadata(msg.caller, tags, url);
           };
           case (?existingMetadata) {
-            updatePasswordMetadata(existingMetadata, caller, tags, url);
+            updatePasswordMetadata(existingMetadata, msg.caller, tags, url);
           };
         };
 
-        metadata := OrderedMap.add(metadata, compareMetadataKeys,metadataKey, metadataValue);
+        metadata := metadata.add(compareMetadataKeys, metadataKey, metadataValue);
 
         switch (optPrevValue, prevMetadata) {
           case (null, null) { #Ok(null) };
@@ -191,20 +181,18 @@ actor class (keyName : Text) {
     };
   };
 
-  public shared ({ caller }) func remove_encrypted_value_with_metadata(
+  public shared (msg) func remove_encrypted_value_with_metadata(
     map_owner : Principal,
     map_name : ByteBuf,
     map_key : ByteBuf,
   ) : async Result<?(ByteBuf, PasswordMetadata), Text> {
-    let mapId = (map_owner, map_name.inner);
-
-    switch (encryptedMaps.removeEncryptedValue(caller, mapId, map_key.inner)) {
+    switch (encryptedMaps.removeEncryptedValue(msg.caller, (map_owner, map_name.inner), map_key.inner)) {
       case (#err(msg)) { #Err(msg) };
       case (#ok(optPrevValue)) {
         let metadataKey = (map_owner, map_name.inner, map_key.inner);
-        let prevMetadata = OrderedMap.get(metadata, compareMetadataKeys,metadataKey);
+        let prevMetadata = metadata.get(compareMetadataKeys, metadataKey);
 
-        metadata := OrderedMap.remove(metadata, compareMetadataKeys,metadataKey);
+        metadata := metadata.remove(compareMetadataKeys, metadataKey);
 
         switch (optPrevValue, prevMetadata) {
           case (null, null) { #Ok(null) };
@@ -218,49 +206,5 @@ actor class (keyName : Text) {
         };
       };
     };
-  };
-
-  public shared func get_vetkey_verification_key() : async ByteBuf {
-    { inner = await encryptedMaps.getVetkeyVerificationKey() };
-  };
-
-  public shared ({ caller }) func get_encrypted_vetkey(
-    map_owner : Principal,
-    map_name : ByteBuf,
-    transport_key : ByteBuf,
-  ) : async Result<ByteBuf, Text> {
-    let mapId = (map_owner, map_name.inner);
-    switch (await encryptedMaps.getEncryptedVetkey(caller, mapId, transport_key.inner)) {
-      case (#err(msg)) { #Err(msg) };
-      case (#ok(vetkey)) { #Ok({ inner = vetkey }) };
-    };
-  };
-
-  public query ({ caller }) func get_user_rights(
-    map_owner : Principal,
-    map_name : ByteBuf,
-    user : Principal,
-  ) : async Result<?VetKeys.AccessRights, Text> {
-    let mapId = (map_owner, map_name.inner);
-    convertResult(encryptedMaps.getUserRights(caller, mapId, user));
-  };
-
-  public shared ({ caller }) func set_user_rights(
-    map_owner : Principal,
-    map_name : ByteBuf,
-    user : Principal,
-    access_rights : VetKeys.AccessRights,
-  ) : async Result<?VetKeys.AccessRights, Text> {
-    let mapId = (map_owner, map_name.inner);
-    convertResult(encryptedMaps.setUserRights(caller, mapId, user, access_rights));
-  };
-
-  public shared ({ caller }) func remove_user(
-    map_owner : Principal,
-    map_name : ByteBuf,
-    user : Principal,
-  ) : async Result<?VetKeys.AccessRights, Text> {
-    let mapId = (map_owner, map_name.inner);
-    convertResult(encryptedMaps.removeUser(caller, mapId, user));
   };
 };

--- a/motoko/vetkeys/password_manager_with_metadata/backend/main.mo
+++ b/motoko/vetkeys/password_manager_with_metadata/backend/main.mo
@@ -10,24 +10,24 @@ import EncryptedMapsControlPlaneCanister "mo:ic-vetkeys/encrypted_maps/ControlPl
 import EncryptedMaps "mo:ic-vetkeys/encrypted_maps/EncryptedMaps";
 import Types "mo:ic-vetkeys/Types";
 
-// This canister layers a second, backend-authoritative store on top of the
-// `ic-vetkeys` Encrypted Maps library: every encrypted password has a matching
-// metadata row (creation date, modification counter, tags, url) that the
-// canister — not the client — maintains.
-//
-// It includes the `EncryptedMapsControlPlaneCanister` mixin rather than the full
-// `EncryptedMapsCanister`: the control-plane mixin contributes the vetKD key,
-// access-control and map-name endpoints plus the in-scope `encryptedMaps`
-// object, but none of the endpoints that read or write encrypted values. That is
-// what this canister needs — the plain `insert_encrypted_value` /
-// `remove_encrypted_value` mutators are never exposed, so nothing can write a
-// value without its metadata row, and the `*_with_metadata` endpoints below
-// update both stores in a single call.
-//
-// The public methods are snake_case (not the usual Motoko camelCase): the
-// standard Encrypted Maps methods are called by these exact names by the
-// `@icp-sdk/vetkeys` client, and the custom metadata methods follow the same
-// convention for a consistent interface.
+/// This canister layers a second, backend-authoritative store on top of the
+/// `ic-vetkeys` Encrypted Maps library: every encrypted password has a matching
+/// metadata row (creation date, modification counter, tags, url) that the
+/// canister — not the client — maintains.
+///
+/// It includes the `EncryptedMapsControlPlaneCanister` mixin rather than the full
+/// `EncryptedMapsCanister`: the control-plane mixin contributes the vetKD key,
+/// access-control and map-name endpoints plus the in-scope `encryptedMaps`
+/// object, but none of the endpoints that read or write encrypted values. That is
+/// what this canister needs — the plain `insert_encrypted_value` /
+/// `remove_encrypted_value` mutators are never exposed, so nothing can write a
+/// value without its metadata row, and the `*_with_metadata` endpoints below
+/// update both stores in a single call.
+///
+/// The public methods are snake_case (not the usual Motoko camelCase): the
+/// standard Encrypted Maps methods are called by these exact names by the
+/// `@icp-sdk/vetkeys` client, and the custom metadata methods follow the same
+/// convention for a consistent interface.
 actor PasswordManagerWithMetadata {
   // The vetKD key name is only an install-time input — it is baked into the
   // stable state below and never read again, hence `transient`. Set the

--- a/motoko/vetkeys/password_manager_with_metadata/backend/main.mo
+++ b/motoko/vetkeys/password_manager_with_metadata/backend/main.mo
@@ -37,9 +37,10 @@ actor PasswordManagerWithMetadata {
   //
   // The key name is immutable for the life of the canister's data: it feeds
   // vetKD key derivation, so changing it would make every already-encrypted
-  // value undecryptable. Changing the environment variable on a later upgrade is
-  // silently ignored (the stable state is not rebuilt); only a `reinstall`,
-  // which drops all data, switches keys.
+  // value undecryptable — and this canister only ever sees ciphertext, so it
+  // cannot re-encrypt them either. Changing the environment variable on a later
+  // upgrade is silently ignored (the stable state is not rebuilt); only a
+  // `reinstall`, which drops all data, switches keys.
   transient let keyName = Runtime.envVar<system>("VETKD_KEY_NAME") ?? "test_key_1";
 
   // The second argument is the domain separator that isolates this

--- a/motoko/vetkeys/password_manager_with_metadata/icp.yaml
+++ b/motoko/vetkeys/password_manager_with_metadata/icp.yaml
@@ -4,9 +4,9 @@ canisters:
       type: "@dfinity/motoko@v5.0.0"
     settings:
       # The vetKD master key this canister derives from, read by the canister via
-      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
-      # canister that already holds data — a different key cannot decrypt what the
-      # old one encrypted.
+      # `Runtime.envVar("VETKD_KEY_NAME")` and captured in stable state at the first
+      # install. Set it before deploying: a later change is silently ignored, and
+      # only a reinstall — which drops all data — switches keys.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/password_manager_with_metadata/icp.yaml
+++ b/motoko/vetkeys/password_manager_with_metadata/icp.yaml
@@ -3,9 +3,10 @@ canisters:
     recipe:
       type: "@dfinity/motoko@v5.0.0"
     settings:
-      # The vetKD master key this canister derives from. Read at install time via
-      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
-      # changing it on a canister that already holds data.
+      # The vetKD master key this canister derives from, read by the canister via
+      # `Runtime.envVar("VETKD_KEY_NAME")`. See the README before changing it on a
+      # canister that already holds data — a different key cannot decrypt what the
+      # old one encrypted.
       environment_variables:
         VETKD_KEY_NAME: "test_key_1"
 

--- a/motoko/vetkeys/password_manager_with_metadata/icp.yaml
+++ b/motoko/vetkeys/password_manager_with_metadata/icp.yaml
@@ -2,9 +2,12 @@ canisters:
   - name: backend
     recipe:
       type: "@dfinity/motoko@v5.0.0"
-    init_args:
-      type: text
-      value: "(\"test_key_1\")"
+    settings:
+      # The vetKD master key this canister derives from. Read at install time via
+      # `Runtime.envVar("VETKD_KEY_NAME")`; see the note in the README before
+      # changing it on a canister that already holds data.
+      environment_variables:
+        VETKD_KEY_NAME: "test_key_1"
 
   - name: frontend
     recipe:

--- a/motoko/vetkeys/password_manager_with_metadata/mops.toml
+++ b/motoko/vetkeys/password_manager_with_metadata/mops.toml
@@ -1,9 +1,9 @@
 [toolchain]
-moc = "1.11.0"
+moc = "1.13.0"
 
 [dependencies]
-core = "2.5.0"
-ic-vetkeys = "0.5.0"
+core = "2.6.1"
+ic-vetkeys = "0.6.0"
 
 [moc]
 # M0236: use context dot notation


### PR DESCRIPTION
Motoko counterpart to #1474, using the mixins shipped in mops [`ic-vetkeys` 0.6.0](https://mops.one/ic-vetkeys) — the Motoko half of [dfinity/vetkeys#423](https://github.com/dfinity/vetkeys/issues/423) (PR dfinity/vetkeys#425).

## Mixins

- **`password_manager`** includes `EncryptedMapsCanister`, which contributes the complete Encrypted Maps endpoint set: **228 → 38 lines**.
- **`password_manager_with_metadata`** includes `EncryptedMapsControlPlaneCanister`, which contributes the control-plane endpoints and the in-scope `encryptedMaps` object but **none** of the value read/write endpoints: **266 → 197 lines**. The plain `insert_encrypted_value`/`remove_encrypted_value` mutators would write a value with no metadata row and desync the two stores, so they are never exposed; the canister keeps its own `*_with_metadata` endpoints.

Neither mixin declares stable state — the actor declares the `EncryptedMapsState` and passes it in, so the persistent state stays a plain, visible stable variable the canister owns and can migrate.

## Key configuration

All six Motoko vetKeys examples now resolve the vetKD key name from the `VETKD_KEY_NAME` canister environment variable (defaulting to `test_key_1` so init stays total), replacing `actor class (keyName : Text)` + `init_args`. This follows the upstream reference canisters and removes the actor class from every main canister — `encrypted_notes_app_vetkd` also loses a `shared ({ caller = initializer })` binding that was never used. `basic_vetkd`'s key name was hardcoded and is now configurable like the rest.

The key is **captured in stable state at the first install**, so a later change to the variable is silently ignored and only a reinstall switches keys. This is deliberate: the key feeds vetKD derivation, and since a canister only ever sees ciphertext it can never re-encrypt what the old key protected. Holding it in a `transient` instead would re-read it on every upgrade, turning an edited variable into silent data loss behind a green deploy.

## Other changes

- Domain separators: both password managers shared `password_manager_example_app`; they are now `password_manager_app` and `password_manager_with_metadata_app`, matching the Rust examples.
- 0.6.0 requires **moc 1.13.0** and **`mo:core` 2.6.1** (raised from 1.11.0 / 2.5.0), so all five examples pinning `ic-vetkeys` move together. The new toolchain surfaces dot-notation warnings (auto-fixed), deprecated `Nat64.fromNat` / `Nat8.fromNat` / `Blob.fromArray`, and never-reassigned `var`s — changing those to `let` needs no migration, since matching stable fields may differ in mutability.
- Regenerated the committed Candid: each service loses its `(text)` init argument with **method sets unchanged**, so the frontends are untouched. `basic_vetkd`'s file was hand-formatted, so it also picks up the generator's parameter names and ordering.

## Verification

`mops check` clean and `icp project show` valid for all six; every backend builds.

Local `icp deploy` end-to-end: both password managers (insert/update/read with metadata, vault sharing, values and metadata surviving an upgrade, `insert_encrypted_value` correctly absent from the metadata canister), plus IBE public key, BLS sign + list, symmetric key verification and a note round trip for the other four. Browser-tested by @marc0olo: both password managers (share a vault, modify a password, redeploy — state survived) and the two IBE apps.

Two things a green deploy would not have caught, checked separately:

- **The variable is really delivered** — the `?? "test_key_1"` default yields identical results if it never arrives, so `basic_ibe` was deployed with `VETKD_KEY_NAME=no_such_key` and vetKD rejected the name.
- **The key is really frozen** — `basic_ibe` was then upgraded with `VETKD_KEY_NAME=no_such_key` and returned an unchanged IBE public key.

## Follow-up

The Rust examples still take the key name as an init argument; moving them to `ic_cdk::api::env_var_value` would make the two languages consistent, but #1474 is already tested and open, so that belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)