### PR TITLE
chore(motoko): bump dev-env to v2.0.0, moc to 1.14.1, mo:core to 2.6.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "ICP Examples (Motoko + Rust)",
-  "image": "ghcr.io/dfinity/icp-dev-env-all:v1.2.0",
+  "image": "ghcr.io/dfinity/icp-dev-env-all:v2.0.0",
   "forwardPorts": [8000, 5173],
   "portsAttributes": {
     "8000": {

--- a/.github/workflows/_run-example.yml
+++ b/.github/workflows/_run-example.yml
@@ -50,7 +50,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-24.04
-    container: ghcr.io/dfinity/icp-dev-env-${{ inputs.language }}:v1.2.0
+    container: ghcr.io/dfinity/icp-dev-env-${{ inputs.language }}:v2.0.0
     env:
       ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ mops check          # type-check all canister entry points
 mops check --fix    # auto-fix style warnings (M0236, M0237, M0223)
 ```
 
-`--default-persistent-actors` makes the **main actor** persistent by default, so the `persistent` keyword is omitted on the top-level `actor` declaration. `persistent actor class` declarations holding mutable state must still carry the keyword explicitly — the flag does not propagate into actor class sub-WASMs.
+`--default-persistent-actors` makes every actor persistent by default, including spawned `actor class` sub-WASMs — so the `persistent` keyword is omitted everywhere: on the top-level `actor` declaration and on `actor class` declarations alike (verified with `moc` 1.14.1: an `actor class` holding mutable `var` fields compiles and preserves state across `#upgrade` without the keyword, under this flag). If `moc` warns `M0217` ("the `persistent` keyword is redundant") on an `actor class`, remove it rather than keeping it "to be safe" — it is genuinely redundant.
 
 ### Naming
 

--- a/motoko/backend_only/mops.toml
+++ b/motoko/backend_only/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/basic_bitcoin/backend/BitcoinApi.mo
+++ b/motoko/basic_bitcoin/backend/BitcoinApi.mo
@@ -1,5 +1,5 @@
+import Array "mo:core/Array";
 import Types "Types";
-import Blob "mo:core/Blob";
 
 module {
   type Network = Types.Network;
@@ -116,7 +116,7 @@ module {
     let cost = 5_000_000_000 + transaction.size() * 20_000_000;
     await (with cycles = cost) bitcoinCanister(network).bitcoin_send_transaction({
       network;
-      transaction = Blob.fromArray(transaction);
+      transaction = transaction.toBlob();
     });
   };
 }

--- a/motoko/basic_bitcoin/backend/P2pkh.mo
+++ b/motoko/basic_bitcoin/backend/P2pkh.mo
@@ -11,7 +11,7 @@
 import Debug "mo:core/Debug";
 import Runtime "mo:core/Runtime";
 import Array "mo:core/Array";
-import Nat8 "mo:core/Nat8";
+import Nat "mo:core/Nat";
 import Nat32 "mo:core/Nat32";
 import Nat64 "mo:core/Nat64";
 import Blob "mo:core/Blob";
@@ -48,7 +48,7 @@ module {
     /// Returns the P2PKH address of this canister at the given derivation path.
     public func get_address(network : Network, key_name : Text, derivation_path : [[Nat8]]) : async BitcoinAddress {
         // Fetch the public key of the given derivation path.
-        let public_key = await EcdsaApi.ecdsa_public_key(key_name, derivation_path.map(Blob.fromArray));
+        let public_key = await EcdsaApi.ecdsa_public_key(key_name, derivation_path.map(Array.toBlob));
 
         // Compute the address.
         public_key_to_p2pkh_address(network, public_key.toArray());
@@ -72,7 +72,7 @@ module {
         };
 
         // Fetch our public key, P2PKH address, and UTXOs.
-        let own_public_key = (await EcdsaApi.ecdsa_public_key(key_name, derivation_path.map(Blob.fromArray))).toArray();
+        let own_public_key = (await EcdsaApi.ecdsa_public_key(key_name, derivation_path.map(Array.toBlob))).toArray();
         let own_address = public_key_to_p2pkh_address(network, own_public_key);
 
         // Note that pagination may have to be used to get all UTXOs for the given address.
@@ -82,11 +82,11 @@ module {
 
         // Build the transaction that sends `amount` to the destination address.
         let tx_bytes = await build_transaction(own_public_key, own_address, own_utxos, dst_address, amount, fee_per_vbyte);
-        let transaction = Utils.get_ok(Transaction.fromBytes(tx_bytes.vals()));
+        let transaction = Utils.get_ok(Transaction.fromBytes(tx_bytes.values()));
 
         // Sign the transaction.
-        let signed_transaction_bytes = await sign_transaction(own_public_key, own_address, transaction, key_name, derivation_path.map(Blob.fromArray), EcdsaApi.sign_with_ecdsa);
-        let signed_transaction = Utils.get_ok(Transaction.fromBytes(signed_transaction_bytes.vals()));
+        let signed_transaction_bytes = await sign_transaction(own_public_key, own_address, transaction, key_name, derivation_path.map(Array.toBlob), EcdsaApi.sign_with_ecdsa);
+        let signed_transaction = Utils.get_ok(Transaction.fromBytes(signed_transaction_bytes.values()));
 
         Debug.print("Sending transaction");
         await BitcoinApi.send_transaction(network, signed_transaction_bytes);
@@ -118,7 +118,7 @@ module {
         Debug.print("Building transaction...");
         var total_fee : Nat = 0;
         loop {
-            let transaction = Utils.get_ok_expect(Bitcoin.buildTransaction(2, own_utxos, [(dst_address_typed, amount)], #p2pkh own_address, Nat64.fromNat(total_fee)), "Error building transaction.");
+            let transaction = Utils.get_ok_expect(Bitcoin.buildTransaction(2, own_utxos, [(dst_address_typed, amount)], #p2pkh own_address, total_fee.toNat64()), "Error building transaction.");
 
             // Sign the transaction. We only care about the size of the signed
             // transaction for fee estimation, so we use a mock signer here for efficiency.
@@ -171,7 +171,7 @@ module {
                         SIGHASH_ALL,
                     );
 
-                    let signature_sec = await signer(key_name, derivation_path, Blob.fromArray(sighash));
+                    let signature_sec = await signer(key_name, derivation_path, sighash.toBlob());
                     let signature_der = Der.encodeSignature(signature_sec).toArray();
 
                     // Append the sighash type.
@@ -181,7 +181,7 @@ module {
                             if (n < signature_der.size()) {
                                 signature_der[n];
                             } else {
-                                Nat8.fromNat(SIGHASH_ALL.toNat());
+                                SIGHASH_ALL.toNat().toNat8();
                             };
                         },
                     );

--- a/motoko/basic_bitcoin/backend/P2tr.mo
+++ b/motoko/basic_bitcoin/backend/P2tr.mo
@@ -16,7 +16,7 @@
 import Debug "mo:core/Debug";
 import Runtime "mo:core/Runtime";
 import Array "mo:core/Array";
-import Nat8 "mo:core/Nat8";
+import Nat "mo:core/Nat";
 import Nat32 "mo:core/Nat32";
 import Nat64 "mo:core/Nat64";
 import Blob "mo:core/Blob";
@@ -103,7 +103,7 @@ module {
         var total_fee : Nat = 0;
 
         loop {
-            let transaction = Utils.get_ok_expect(Bitcoin.buildTransaction(2, own_utxos, [(dst_address_typed, amount)], #p2tr_key own_address, Nat64.fromNat(total_fee)), "Error building transaction.");
+            let transaction = Utils.get_ok_expect(Bitcoin.buildTransaction(2, own_utxos, [(dst_address_typed, amount)], #p2tr_key own_address, total_fee.toNat64()), "Error building transaction.");
             let tx_in_outpoints = transaction.txInputs.map(func(txin : TxInput.TxInput) : Types.OutPoint { txin.prevOutput });
 
             let amounts = own_utxos.filterMap(
@@ -169,7 +169,7 @@ module {
                         Nat32.fromIntWrap(i),
                     );
 
-                    let signature = (await signer(key_name, derivation_path, Blob.fromArray(sighash), aux)).toArray();
+                    let signature = (await signer(key_name, derivation_path, sighash.toBlob(), aux)).toArray();
                     transaction.witnesses[i] := [signature];
                 };
             };
@@ -226,7 +226,7 @@ module {
 
                     Debug.print("Signing sighash: " # debug_show (sighash));
 
-                    let signature = (await signer(key_name, derivation_path, Blob.fromArray(sighash), null)).toArray();
+                    let signature = (await signer(key_name, derivation_path, sighash.toBlob(), null)).toArray();
                     transaction.witnesses[i] := [signature, script_bytes, control_block_bytes];
                 };
             };
@@ -248,7 +248,7 @@ module {
         let leaf_script = Utils.get_ok(leafScript(script_bip340_public_key));
         let aux =
         #bip341({
-            merkle_root_hash = Blob.fromArray(leafHash(leaf_script));
+            merkle_root_hash = leafHash(leaf_script).toBlob();
         });
 
         await send_key_path_generic(own_tweaked_address, network, derivation_paths.key_path_derivation_path, key_name, ?aux, dst_address, amount);
@@ -293,7 +293,7 @@ module {
             },
         );
 
-        let signed_transaction_bytes = await sign_key_spend_transaction(own_address, transaction, amounts, key_name, signer_derivation_path.map(Blob.fromArray), aux, SchnorrApi.sign_with_schnorr);
+        let signed_transaction_bytes = await sign_key_spend_transaction(own_address, transaction, amounts, key_name, signer_derivation_path.map(Array.toBlob), aux, SchnorrApi.sign_with_schnorr);
 
         Debug.print("Sending transaction : " # debug_show (signed_transaction_bytes));
         let signed_transaction = Utils.get_ok(Transaction.fromBytes(signed_transaction_bytes.vals()));
@@ -359,7 +359,7 @@ module {
             transaction,
             amounts,
             key_name,
-            derivation_paths.script_path_derivation_path.map(Blob.fromArray),
+            derivation_paths.script_path_derivation_path.map(Array.toBlob),
             SchnorrApi.sign_with_schnorr,
         );
 
@@ -413,7 +413,7 @@ module {
     };
 
     public func fetch_bip340_public_key(key_name : Text, derivation_path : [[Nat8]]) : async [Nat8] {
-        let sec1_public_key = (await SchnorrApi.schnorr_public_key(key_name, derivation_path.map(Blob.fromArray))).toArray();
+        let sec1_public_key = (await SchnorrApi.schnorr_public_key(key_name, derivation_path.map(Array.toBlob))).toArray();
         sec1_public_key.sliceToArray(1, 33);
     };
 };

--- a/motoko/basic_bitcoin/backend/P2trKeyOnly.mo
+++ b/motoko/basic_bitcoin/backend/P2trKeyOnly.mo
@@ -10,8 +10,7 @@
 //! * Caching spent UTXOs so that they are not reused in future transactions.
 //! * Option to set the fee.
 
-import Nat8 "mo:core/Nat8";
-import Blob "mo:core/Blob";
+import Array "mo:core/Array";
 
 import Script "mo:bitcoin/bitcoin/Script";
 import Transaction "mo:bitcoin/bitcoin/Transaction";
@@ -38,7 +37,7 @@ module {
     let untweaked_bip340_public_key_bytes = await P2tr.fetch_bip340_public_key(key_name, derivation_path);
     let aux =
     #bip341({
-      merkle_root_hash = Blob.fromArray(P2tr.unspendableMerkleRoot(untweaked_bip340_public_key_bytes));
+      merkle_root_hash = P2tr.unspendableMerkleRoot(untweaked_bip340_public_key_bytes).toBlob();
     });
     await P2tr.send_key_path_generic(own_address, network, derivation_path, key_name, ?aux, dst_address, amount);
   };

--- a/motoko/basic_bitcoin/backend/Utils.mo
+++ b/motoko/basic_bitcoin/backend/Utils.mo
@@ -1,9 +1,9 @@
 import Result "mo:core/Result";
 import Nat8 "mo:core/Nat8";
 import Runtime "mo:core/Runtime";
+import Char "mo:core/Char";
 import Text "mo:core/Text";
 import Iter "mo:core/Iter";
-import Blob "mo:core/Blob";
 import Array "mo:core/Array";
 import IC "mo:ic/Types";
 
@@ -39,7 +39,7 @@ module {
 
     // Returns the hexadecimal representation of a `Nat8` considered as a `Nat4`.
     func nat4ToText(nat4 : Nat8) : Text {
-        Text.fromChar(
+        (
             switch nat4 {
                 case 0 '0';
                 case 1 '1';
@@ -59,7 +59,7 @@ module {
                 case 15 'f';
                 case _ Runtime.unreachable();
             }
-        );
+        ).toText();
     };
 
     /// Returns the hexadecimal representation of a `Nat8`.
@@ -71,20 +71,20 @@ module {
 
     /// Returns the hexadecimal representation of a byte array.
     public func bytesToText(bytes : [Nat8]) : Text {
-        bytes.vals().map(func(n : Nat8) : Text { nat8ToText(n) }).join("");
+        bytes.values().map(func(n : Nat8) : Text { nat8ToText(n) }).join("");
     };
 
     /// Mock ECDSA signer that returns a 64-byte placeholder signature.
     /// Used only during fee estimation to get the correct transaction size
     /// before invoking the real (expensive) threshold signing operation.
     public func mock_sign_with_ecdsa(_key_name : Text, _derivation_path : [Blob], _message_hash : Blob) : async Blob {
-        Blob.fromArray(Array.repeat(255 : Nat8, 64));
+        Array.repeat(255 : Nat8, 64).toBlob();
     };
 
     /// Mock Schnorr signer that returns a 64-byte placeholder signature.
     /// Used only during fee estimation to get the correct transaction size
     /// before invoking the real (expensive) threshold signing operation.
     public func mock_sign_with_schnorr(_key_name : Text, _derivation_path : [Blob], _message_hash : Blob, _aux : ?SchnorrAux) : async Blob {
-        Blob.fromArray(Array.repeat(255 : Nat8, 64));
+        Array.repeat(255 : Nat8, 64).toBlob();
     };
 };

--- a/motoko/basic_bitcoin/mops.toml
+++ b/motoko/basic_bitcoin/mops.toml
@@ -1,8 +1,8 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 bitcoin = "0.2.0"
 ic = "4.0.0"
 

--- a/motoko/canister_factory/backend/Counter.mo
+++ b/motoko/canister_factory/backend/Counter.mo
@@ -1,6 +1,6 @@
 /// Simple counter actor class with mutable state for demonstrating upgrade vs reinstall behavior.
 /// State is preserved during #upgrade but reset to 42 during #reinstall.
-persistent actor class Counter() {
+actor class Counter() {
   var value : Nat = 42;
   public func getValue() : async Nat { value };
   public func addToValue(x : Nat) : async Nat {

--- a/motoko/canister_factory/backend/CounterV2.mo
+++ b/motoko/canister_factory/backend/CounterV2.mo
@@ -1,7 +1,7 @@
 /// Extended counter actor class used for upgrade/reinstall demonstrations.
 /// Adds `substractFromValue` to show new functionality introduced after an upgrade.
 /// State is preserved during #upgrade but reset to 42 during #reinstall.
-persistent actor class CounterV2() {
+actor class CounterV2() {
   var value : Nat = 42;
   public func getValue() : async Nat { value };
   public func addToValue(x : Nat) : async Nat {

--- a/motoko/canister_factory/mops.toml
+++ b/motoko/canister_factory/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/canister_logs/backend/main.mo
+++ b/motoko/canister_logs/backend/main.mo
@@ -6,7 +6,7 @@ import { now } = "mo:core/Time";
 import { setTimer; recurringTimer } = "mo:core/Timer";
 import { ic } "mo:ic";
 
-persistent actor CanisterLogs {
+actor CanisterLogs {
 
   transient let timerDelaySeconds = 5;
   transient let second = 1_000_000_000;

--- a/motoko/canister_logs/mops.toml
+++ b/motoko/canister_logs/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/cert-var/backend/main.mo
+++ b/motoko/cert-var/backend/main.mo
@@ -4,7 +4,7 @@
 /// system-level certified-data hash so that query callers can cryptographically
 /// verify the returned value without waiting for a full consensus round.
 import CD "mo:core/CertifiedData";
-import Blob "mo:core/Blob";
+import Array "mo:core/Array";
 import Nat32 "mo:core/Nat32";
 
 actor CertVar {
@@ -17,12 +17,12 @@ actor CertVar {
   func blobOfNat32(n : Nat32) : Blob {
     let byteMask : Nat32 = 0xff;
     func byte(x : Nat32) : Nat8 = x.toNat8();
-    Blob.fromArray([
+    [
       byte(((byteMask << 0) & n) >> 0),
       byte(((byteMask << 8) & n) >> 8),
       byte(((byteMask << 16) & n) >> 16),
       byte(((byteMask << 24) & n) >> 24),
-    ]);
+    ].toBlob();
   };
 
   /// Increment the counter by one, update the certificate, and return the new value.

--- a/motoko/cert-var/mops.toml
+++ b/motoko/cert-var/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/composite_query/backend/Buckets.mo
+++ b/motoko/composite_query/backend/Buckets.mo
@@ -1,7 +1,7 @@
 import Map "mo:core/Map";
 import Nat "mo:core/Nat";
 
-persistent actor class Bucket(n : Nat, i : Nat) {
+actor class Bucket(n : Nat, i : Nat) {
 
   type Key = Nat;
   type Value = Text;

--- a/motoko/composite_query/mops.toml
+++ b/motoko/composite_query/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/daily_planner/backend/main.mo
+++ b/motoko/daily_planner/backend/main.mo
@@ -1,5 +1,4 @@
 import Array "mo:core/Array";
-import Blob "mo:core/Blob";
 import Iter "mo:core/Iter";
 import Option "mo:core/Option";
 import Text "mo:core/Text";
@@ -11,7 +10,7 @@ import { thash } "mo:map/Map";
 import { ic } "mo:ic";
 import IC "mo:ic/Types";
 
-persistent actor DailyPlanner {
+actor DailyPlanner {
   // General types used by the planner
   public type Note = {
     id : Nat;
@@ -131,7 +130,7 @@ persistent actor DailyPlanner {
         method = #get;
         transform = ?{
           function = transform;
-          context = Blob.fromArray([]);
+          context = ([] : [Nat8]).toBlob();
         };
         is_replicated = ?true;
       };
@@ -186,7 +185,7 @@ persistent actor DailyPlanner {
 
   // Transforms the raw HTTPS call response to an HttpResponsePayload on which the nodes can run consensus on.
   public query func transform({
-    context : Blob;
+    context = _context : Blob;
     response : IC.HttpRequestResult;
   }) : async IC.HttpRequestResult {
     {

--- a/motoko/daily_planner/mops.toml
+++ b/motoko/daily_planner/mops.toml
@@ -1,17 +1,14 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 json = "1.0.0"
 map = "9.0.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/evm_block_explorer/mops.toml
+++ b/motoko/evm_block_explorer/mops.toml
@@ -1,25 +1,13 @@
 [toolchain]
-moc = "1.11.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"
 candid = "backend/backend.did"
-# --actor-env-alias <alias> <envvar> <did-path>: resolve the `canister:evm_rpc`
-# import from the PUBLIC_CANISTER_ID:evm_rpc env var (injected by icp deploy),
-# typed against the EVM RPC canister's committed Candid interface — so no RPC
-# actor type is declared in the backend.
-# Per-canister args replace the global [moc].args, so repeat those flags here.
-args = [
-    "--default-persistent-actors",
-    "-W=M0236,M0237,M0223",
-    "--actor-env-alias", "evm_rpc", "PUBLIC_CANISTER_ID:evm_rpc", "candid/evm_rpc.did",
-]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223", "--actor-env-alias", "evm_rpc", "PUBLIC_CANISTER_ID:evm_rpc", "candid/evm_rpc.did" ]

--- a/motoko/filevault/mops.toml
+++ b/motoko/filevault/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 map = "9.0.1"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/flying_ninja/mops.toml
+++ b/motoko/flying_ninja/mops.toml
@@ -1,16 +1,11 @@
-# Motoko dependencies (https://mops.one/)
-
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation (e.g. map.get(k) instead of Map.get(map, compare, k))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/hello_cycles/backend/main.mo
+++ b/motoko/hello_cycles/backend/main.mo
@@ -1,5 +1,4 @@
 import Nat "mo:core/Nat";
-import Nat64 "mo:core/Nat64";
 import Cycles "mo:core/Cycles";
 
 actor HelloCycles {
@@ -20,7 +19,7 @@ actor HelloCycles {
   public func acceptCycles() : async { accepted : Nat64 } {
     let available = Cycles.available(); // total cycles the caller attached
     let accepted = Cycles.accept<system>(Nat.min(available, limit)); // claim up to limit
-    { accepted = Nat64.fromNat(accepted) };
+    { accepted = accepted.toNat64() };
   };
 
   /// Sends `amount` cycles from this canister's balance to `receiver`.

--- a/motoko/hello_cycles/mops.toml
+++ b/motoko/hello_cycles/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/hello_world/mops.toml
+++ b/motoko/hello_world/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.8.2"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/ic-pos/backend/main.mo
+++ b/motoko/ic-pos/backend/main.mo
@@ -93,7 +93,7 @@ actor class Main(_startBlock : Nat) {
     // Left-pad the fractional digits to `tokenDecimals`, then drop trailing zeros.
     var fracText = frac.toText();
     while (fracText.size() < tokenDecimals) { fracText := "0" # fracText };
-    whole # "." # Text.trimEnd(fracText, #char '0') # " " # tokenSymbol;
+    whole # "." # fracText.trimEnd(#char '0') # " " # tokenSymbol;
   };
 
   // Scan for new transactions and log a would-be notification for each payment

--- a/motoko/ic-pos/mops.toml
+++ b/motoko/ic-pos/mops.toml
@@ -1,27 +1,13 @@
-# Motoko dependencies (https://mops.one/)
-
 [toolchain]
-moc = "1.11.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"
 candid = "backend/backend.did"
-# --actor-env-alias <alias> <envvar> <did-path>: resolve the
-# `canister:icrc1_ledger` import from the PUBLIC_CANISTER_ID:icrc1_ledger env
-# var (injected by icp deploy), typed against the ledger's committed Candid
-# interface — so no ledger actor type is declared in the backend.
-# Per-canister args replace the global [moc].args, so repeat those flags here.
-args = [
-    "--default-persistent-actors",
-    "-W=M0236,M0237,M0223",
-    "--actor-env-alias", "icrc1_ledger", "PUBLIC_CANISTER_ID:icrc1_ledger", "candid/icrc1_ledger.did",
-]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223", "--actor-env-alias", "icrc1_ledger", "PUBLIC_CANISTER_ID:icrc1_ledger", "candid/icrc1_ledger.did" ]

--- a/motoko/icp_transfer/backend/main.mo
+++ b/motoko/icp_transfer/backend/main.mo
@@ -1,5 +1,5 @@
 import Array "mo:core/Array";
-import Blob "mo:core/Blob";
+import Iter "mo:core/Iter";
 import Debug "mo:core/Debug";
 import Hex "mo:hex";
 import Result "mo:core/Result";
@@ -47,7 +47,7 @@ actor IcpTransfer {
   // Convert a principal and optional subaccount to its AccountIdentifier as a
   // lowercase hex string — the format shown in block explorers and CEX deposit screens.
   public query func toAccountIdHex(p : Principal, subaccount : ?IcpLedger.SubAccount) : async Text {
-    let bytes = Array.fromIter(p.toLedgerAccount(subaccount).vals());
+    let bytes = p.toLedgerAccount(subaccount).vals().toArray();
     Hex.toText(bytes);
   };
 
@@ -74,7 +74,7 @@ actor IcpTransfer {
         if (bytes.size() != 32) {
           return #err("AccountIdentifier must be 32 bytes (64 hex chars), got " # debug_show(bytes.size()));
         };
-        await doTransfer(amount, Blob.fromArray(bytes));
+        await doTransfer(amount, bytes.toBlob());
       };
     };
   };

--- a/motoko/icp_transfer/mops.toml
+++ b/motoko/icp_transfer/mops.toml
@@ -1,20 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 hex = "1.0.3"
 
 [moc]
-args = [
-    "--default-persistent-actors",
-    "-W=M0236,M0237,M0223",
-    # --actor-id-alias <alias> <principal> <did-path>: bind the `canister:icp_ledger`
-    # import to the ICP ledger's fixed, well-known principal (same on mainnet and the
-    # local network), typed against candid/icp_ledger.did — so no ledger types are
-    # hand-written in the backend.
-    "--actor-id-alias", "icp_ledger", "ryjl3-tyaaa-aaaaa-aaaba-cai", "candid/icp_ledger.did",
-]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223", "--actor-id-alias", "icp_ledger", "ryjl3-tyaaa-aaaaa-aaaba-cai", "candid/icp_ledger.did" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/icrc2-swap/mops.toml
+++ b/motoko/icrc2-swap/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.13.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.6.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/llm_chatbot/mops.toml
+++ b/motoko/llm_chatbot/mops.toml
@@ -1,27 +1,13 @@
-# Motoko dependencies (https://mops.one/)
-
 [toolchain]
-moc = "1.11.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"
 candid = "backend/backend.did"
-# --actor-env-alias <alias> <envvar> <did-path>: resolve the `canister:llm`
-# import from the PUBLIC_CANISTER_ID:llm env var (injected by icp deploy), typed
-# against the LLM canister's committed Candid interface — so no LLM actor type
-# is declared in the backend.
-# Per-canister args replace the global [moc].args, so repeat those flags here.
-args = [
-    "--default-persistent-actors",
-    "-W=M0236,M0237,M0223",
-    "--actor-env-alias", "llm", "PUBLIC_CANISTER_ID:llm", "candid/llm.did",
-]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223", "--actor-env-alias", "llm", "PUBLIC_CANISTER_ID:llm", "candid/llm.did" ]

--- a/motoko/low_wasm_memory/mops.toml
+++ b/motoko/low_wasm_memory/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/parallel_calls/mops.toml
+++ b/motoko/parallel_calls/mops.toml
@@ -1,26 +1,15 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.caller]
 main = "caller/main.mo"
-# --actor-env-alias <alias> <envvar> <did-path>: resolve the `canister:callee`
-# import from the PUBLIC_CANISTER_ID:callee env var (injected by icp deploy),
-# typed against callee/callee.did — no actor type needed in caller/main.mo.
-# Per-canister args replace the global [moc].args, so repeat those flags here.
-args = [
-    "--default-persistent-actors",
-    "-W=M0236,M0237,M0223",
-    "--actor-env-alias", "callee", "PUBLIC_CANISTER_ID:callee", "callee/callee.did",
-]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223", "--actor-env-alias", "callee", "PUBLIC_CANISTER_ID:callee", "callee/callee.did" ]
 
 [canisters.callee]
 main = "callee/main.mo"

--- a/motoko/pub-sub/mops.toml
+++ b/motoko/pub-sub/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.publisher]
 main = "publisher/main.mo"
@@ -16,12 +13,4 @@ candid = "publisher/publisher.did"
 
 [canisters.subscriber]
 main = "subscriber/main.mo"
-# --actor-env-alias <alias> <envvar> <did-path>: resolve the `canister:publisher`
-# import from the PUBLIC_CANISTER_ID:publisher env var (injected by icp deploy),
-# typed against publisher/publisher.did — no actor type needed in subscriber/main.mo.
-# Per-canister args replace the global [moc].args, so repeat those flags here.
-args = [
-    "--default-persistent-actors",
-    "-W=M0236,M0237,M0223",
-    "--actor-env-alias", "publisher", "PUBLIC_CANISTER_ID:publisher", "publisher/publisher.did",
-]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223", "--actor-env-alias", "publisher", "PUBLIC_CANISTER_ID:publisher", "publisher/publisher.did" ]

--- a/motoko/query_stats/backend/main.mo
+++ b/motoko/query_stats/backend/main.mo
@@ -3,7 +3,7 @@ import Principal "mo:core/Principal";
 import Time "mo:core/Time";
 import { ic } "mo:ic";
 
-persistent actor QueryStats {
+actor QueryStats {
 
   public query func load() : async Int {
     Time.now();

--- a/motoko/query_stats/mops.toml
+++ b/motoko/query_stats/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/random_maze/backend/main.mo
+++ b/motoko/random_maze/backend/main.mo
@@ -33,11 +33,11 @@ actor {
     var cs = PureList.empty<(Nat, Nat)>();
     if (i > 1 and not visited(m[i - 2][j]))
       // The <(Nat,Nat)> type annotation is not required, but it can silence the underflow warning for i - 2
-      cs := cs.pushFront<(Nat, Nat)>((i - 2, j));
+      cs := cs.pushFront((i - 2, j));
     if (i + 1 < max and not visited(m[i + 2][j]))
       cs := cs.pushFront((i + 2, j));
     if (j > 1 and not visited(m[i][j - 2]))
-      cs := cs.pushFront<(Nat, Nat)>((i, j - 2));
+      cs := cs.pushFront((i, j - 2));
     if (j + 1 < max and not visited(m[i][j + 2]))
       cs := cs.pushFront((i, j + 2));
     cs;

--- a/motoko/random_maze/mops.toml
+++ b/motoko/random_maze/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/send_http_get/backend/main.mo
+++ b/motoko/send_http_get/backend/main.mo
@@ -1,16 +1,16 @@
-import Blob "mo:core/Blob";
+import Array "mo:core/Array";
 import Text "mo:core/Text";
 import { ic } "mo:ic";
 import IC "mo:ic/Types";
 
-persistent actor SendHttpGet {
+actor SendHttpGet {
 
   // #region transform
   // Strip HTTP response headers (date, cookies, tracking IDs) that vary across replicas.
   // In replicated mode, all replicas must see an identical response for consensus to
   // succeed — the transform ensures this by discarding non-deterministic fields.
   public query func transform({
-    context : Blob;
+    context = _context : Blob;
     response : IC.HttpRequestResult;
   }) : async IC.HttpRequestResult {
     { response with headers = [] };
@@ -29,7 +29,7 @@ persistent actor SendHttpGet {
       headers = [{ name = "User-Agent"; value = "ic-canister" }];
       body = null;
       method = #get;
-      transform = ?{ function = transform; context = Blob.fromArray([]) };
+      transform = ?{ function = transform; context = ([] : [Nat8]).toBlob() };
       // Replicated mode: all subnet nodes make the request independently,
       // providing strong integrity guarantees via consensus.
       is_replicated = ?true;

--- a/motoko/send_http_get/mops.toml
+++ b/motoko/send_http_get/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/send_http_post/backend/main.mo
+++ b/motoko/send_http_post/backend/main.mo
@@ -1,9 +1,9 @@
-import Blob "mo:core/Blob";
+import Array "mo:core/Array";
 import Text "mo:core/Text";
 import { ic } "mo:ic";
 import IC "mo:ic/Types";
 
-persistent actor SendHttpPost {
+actor SendHttpPost {
 
   // #region transform
   // Strip HTTP response headers (date, cookies, tracking IDs) that vary across requests.
@@ -11,7 +11,7 @@ persistent actor SendHttpPost {
   // always invokes it. In replicated mode, stripping non-deterministic fields is
   // essential for consensus to succeed.
   public query func transform({
-    context : Blob;
+    context = _context : Blob;
     response : IC.HttpRequestResult;
   }) : async IC.HttpRequestResult {
     { response with headers = [] };
@@ -34,7 +34,7 @@ persistent actor SendHttpPost {
       ];
       body = ?body;
       method = #post;
-      transform = ?{ function = transform; context = Blob.fromArray([]) };
+      transform = ?{ function = transform; context = ([] : [Nat8]).toBlob() };
       // Non-replicated: only one replica sends the request. For replicated
       // mode (true), add an Idempotency-Key header so the server can
       // deduplicate the requests sent by each replica independently.

--- a/motoko/send_http_post/mops.toml
+++ b/motoko/send_http_post/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/superheroes/mops.toml
+++ b/motoko/superheroes/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/threshold-ecdsa/backend/Hex.mo
+++ b/motoko/threshold-ecdsa/backend/Hex.mo
@@ -1,5 +1,7 @@
 import Array "mo:core/Array";
+import VarArray "mo:core/VarArray";
 import Option "mo:core/Option";
+import Nat "mo:core/Nat";
 import Nat8 "mo:core/Nat8";
 import Char "mo:core/Char";
 import Result "mo:core/Result";
@@ -63,13 +65,13 @@ module {
         };
       };
     };
-    #ok(Array.fromVarArray(array));
+    #ok(array.toArray());
   };
 
   private func decodeW4(char : Char) : Result<Nat8, DecodeError> {
     for (i in symbols.keys()) {
       if (symbols[i] == char) {
-        return #ok(Nat8.fromNat(i));
+        return #ok(i.toNat8());
       };
     };
     let str = "Unexpected character: " # char.toText();

--- a/motoko/threshold-ecdsa/backend/SHA256.mo
+++ b/motoko/threshold-ecdsa/backend/SHA256.mo
@@ -1,4 +1,5 @@
 import Array "mo:core/Array";
+import VarArray "mo:core/VarArray";
 import Nat "mo:core/Nat";
 import Nat8 "mo:core/Nat8";
 import Nat32 "mo:core/Nat32";
@@ -66,7 +67,7 @@ module {
         };
         nx += n;
         if (nx == 64) {
-          let buf = Array.fromVarArray(x);
+          let buf = x.toArray();
           block(buf);
           nx := 0;
         };
@@ -101,13 +102,13 @@ module {
       if (m > 0) {
         buf[0] := 0x80;
       };
-      write(Array.fromVarArray(buf));
+      write(buf.toArray());
       buf := Array.repeat(0 : Nat8, 8).toVarArray();
       for (i in buf.keys()) {
         let j : Nat64 = 56 -% 8 *% Nat64.fromIntWrap(i);
         buf[i] := Nat8.fromIntWrap((n >> j).toNat());
       };
-      write(Array.fromVarArray(buf));
+      write(buf.toArray());
       let hash = Array.repeat(0 : Nat8, 32).toVarArray();
       for (i in s.keys()) {
         var j = 0;
@@ -117,7 +118,7 @@ module {
           j += 1;
         };
       };
-      return Array.fromVarArray(hash);
+      return hash.toArray();
     };
 
     private func block(data : [Nat8]) {

--- a/motoko/threshold-ecdsa/backend/main.mo
+++ b/motoko/threshold-ecdsa/backend/main.mo
@@ -1,12 +1,13 @@
 import Error "mo:core/Error";
 import Principal "mo:core/Principal";
 import Text "mo:core/Text";
+import Array "mo:core/Array";
 import Blob "mo:core/Blob";
 import Hex "./Hex";
 import SHA256 "./SHA256";
 import { ic } "mo:ic";
 
-persistent actor ThresholdEcdsa {
+actor ThresholdEcdsa {
   transient let key_id : Text = "test_key_1"; // Use "key_1" for mainnet production
 
   public shared (msg) func public_key() : async {
@@ -32,7 +33,7 @@ persistent actor ThresholdEcdsa {
   } {
     let caller = msg.caller.toBlob();
     try {
-      let message_hash : Blob = Blob.fromArray(SHA256.sha256(message.encodeUtf8().toArray()));
+      let message_hash : Blob = SHA256.sha256(message.encodeUtf8().toArray()).toBlob();
       let { signature } = await (with cycles = 30_000_000_000) ic.sign_with_ecdsa({
         message_hash;
         derivation_path = [caller];

--- a/motoko/threshold-ecdsa/mops.toml
+++ b/motoko/threshold-ecdsa/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/threshold-schnorr/backend/Hex.mo
+++ b/motoko/threshold-schnorr/backend/Hex.mo
@@ -1,5 +1,7 @@
 import Array "mo:core/Array";
+import VarArray "mo:core/VarArray";
 import Option "mo:core/Option";
+import Nat "mo:core/Nat";
 import Nat8 "mo:core/Nat8";
 import Char "mo:core/Char";
 import Result "mo:core/Result";
@@ -63,13 +65,13 @@ module {
         };
       };
     };
-    #ok(Array.fromVarArray(array));
+    #ok(array.toArray());
   };
 
   private func decodeW4(char : Char) : Result<Nat8, DecodeError> {
     for (i in symbols.keys()) {
       if (symbols[i] == char) {
-        return #ok(Nat8.fromNat(i));
+        return #ok(i.toNat8());
       };
     };
     let str = "Unexpected character: " # char.toText();

--- a/motoko/threshold-schnorr/backend/main.mo
+++ b/motoko/threshold-schnorr/backend/main.mo
@@ -1,3 +1,4 @@
+import Array "mo:core/Array";
 import Blob "mo:core/Blob";
 import Error "mo:core/Error";
 import Option "mo:core/Option";
@@ -67,7 +68,7 @@ actor ThresholdSchnorr {
       case (#ok bytes) {
         #ok(
           #bip341({
-            merkle_root_hash = Blob.fromArray(bytes);
+            merkle_root_hash = bytes.toBlob();
           })
         );
       };

--- a/motoko/threshold-schnorr/mops.toml
+++ b/motoko/threshold-schnorr/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 ic = "4.0.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/vetkeys/basic_bls_signing/mops.toml
+++ b/motoko/vetkeys/basic_bls_signing/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.13.0"
+moc = "1.14.1"
 
 [dependencies]
 core = "2.6.1"
 ic-vetkeys = "0.6.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/vetkeys/basic_ibe/mops.toml
+++ b/motoko/vetkeys/basic_ibe/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.13.0"
+moc = "1.14.1"
 
 [dependencies]
 core = "2.6.1"
 ic-vetkeys = "0.6.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/vetkeys/basic_vetkd/mops.toml
+++ b/motoko/vetkeys/basic_vetkd/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.13.0"
+moc = "1.14.1"
 
 [dependencies]
 core = "2.6.1"
 ic-vetkeys = "0.6.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/backend/main.mo
@@ -69,11 +69,11 @@ actor {
     private var nextNoteId : Nat = 1;
 
     // Store notes by their ID, so that note-specific encryption keys can be derived.
-    private var notesById = Map.empty<NoteId, EncryptedNote>();
+    private let notesById = Map.empty<NoteId, EncryptedNote>();
     // Store which note IDs are owned by a particular principal
-    private var noteIdsByOwner = Map.empty<PrincipalName, PureList.List<NoteId>>();
+    private let noteIdsByOwner = Map.empty<PrincipalName, PureList.List<NoteId>>();
     // Store which notes are shared with a particular principal. Does not include the owner, as this is tracked by `noteIdsByOwner`.
-    private var noteIdsByUser = Map.empty<PrincipalName, PureList.List<NoteId>>();
+    private let noteIdsByUser = Map.empty<PrincipalName, PureList.List<NoteId>>();
 
     // Utility function that helps writing assertion-driven code more concisely.
     private func expect<T>(opt : ?T, violation_msg : Text) : T {
@@ -88,11 +88,11 @@ actor {
     };
 
     private func is_authorized(user : PrincipalName, note : EncryptedNote) : Bool {
-        user == note.owner or Option.isSome(Array.find(note.users, func(x : PrincipalName) : Bool { x == user }));
+        user == note.owner or Option.isSome(note.users.find(func(x : PrincipalName) : Bool { x == user }));
     };
 
     public shared ({ caller }) func whoami() : async Text {
-        return Principal.toText(caller);
+        return caller.toText();
     };
 
     // Shared functions, i.e., those specified with [shared], are
@@ -109,8 +109,8 @@ actor {
     //      [caller] already has [MAX_NOTES_PER_USER] notes
     //      This is the first note for [caller] and [MAX_USERS] is exceeded
     public shared ({ caller }) func createNote() : async NoteId {
-        assert not Principal.isAnonymous(caller);
-        let owner = Principal.toText(caller);
+        assert not caller.isAnonymous();
+        let owner = caller.toText();
 
         let newNote : EncryptedNote = {
             id = nextNoteId;
@@ -119,18 +119,18 @@ actor {
             users = [];
         };
 
-        switch (Map.get(noteIdsByOwner, Text.compare, owner)) {
+        switch (noteIdsByOwner.get(owner)) {
             case (?owner_nids) {
-                assert PureList.size(owner_nids) < MAX_NOTES_PER_USER;
-                ignore Map.insert(noteIdsByOwner, Text.compare, owner, PureList.pushFront(owner_nids, newNote.id));
+                assert owner_nids.size() < MAX_NOTES_PER_USER;
+                ignore noteIdsByOwner.insert(owner, owner_nids.pushFront(newNote.id));
             };
             case null {
-                assert Map.size(noteIdsByOwner) < MAX_USERS;
-                ignore Map.insert(noteIdsByOwner, Text.compare, owner, PureList.singleton(newNote.id));
+                assert noteIdsByOwner.size() < MAX_USERS;
+                ignore noteIdsByOwner.insert(owner, PureList.singleton(newNote.id));
             };
         };
 
-        ignore Map.insert(notesById, Nat.compare, newNote.id, newNote);
+        ignore notesById.insert(newNote.id, newNote);
         nextNoteId += 1;
         newNote.id;
     };
@@ -152,26 +152,26 @@ actor {
     // Traps:
     //      [caller] is the anonymous identity
     public shared ({ caller }) func getNotes() : async [EncryptedNote] {
-        assert not Principal.isAnonymous(caller);
-        let user = Principal.toText(caller);
+        assert not caller.isAnonymous();
+        let user = caller.toText();
 
         let owned_notes = PureList.map(
-            Option.get(Map.get(noteIdsByOwner, Text.compare, user), PureList.empty()),
+            noteIdsByOwner.get(user).get(PureList.empty()),
             func(nid : NoteId) : EncryptedNote {
-                expect(Map.get(notesById, Nat.compare, nid), "missing note with ID " # Nat.toText(nid));
+                expect(notesById.get(nid), "missing note with ID " # nid.toText());
             },
         );
         let shared_notes = PureList.map(
-            Option.get(Map.get(noteIdsByUser, Text.compare, user), PureList.empty()),
+            noteIdsByUser.get(user).get(PureList.empty()),
             func(nid : NoteId) : EncryptedNote {
-                expect(Map.get(notesById, Nat.compare, nid), "missing note with ID " # Nat.toText(nid));
+                expect(notesById.get(nid), "missing note with ID " # nid.toText());
             },
         );
 
         let buf = List.empty<EncryptedNote>();
-        List.append(buf, List.fromArray<EncryptedNote>(PureList.toArray(owned_notes)));
-        List.append(buf, List.fromArray<EncryptedNote>(PureList.toArray(shared_notes)));
-        List.toArray(buf);
+        buf.append(List.fromArray<EncryptedNote>(owned_notes.toArray()));
+        buf.append(List.fromArray<EncryptedNote>(shared_notes.toArray()));
+        buf.toArray();
     };
 
     // Replaces the encrypted text of note with ID [id] with [encryptedText].
@@ -184,14 +184,14 @@ actor {
     //     [caller] is not the note's owner and not a user with whom the note is shared
     //     [encryptedText] exceeds [MAX_NOTE_CHARS]
     public shared ({ caller }) func updateNote(id : NoteId, encryptedText : Text) : async () {
-        assert not Principal.isAnonymous(caller);
-        let caller_text = Principal.toText(caller);
-        let (?note_to_update) = Map.get(notesById, Nat.compare, id) else Runtime.trap("note with id " # Nat.toText(id) # "not found");
+        assert not caller.isAnonymous();
+        let caller_text = caller.toText();
+        let (?note_to_update) = notesById.get(id) else Runtime.trap("note with id " # id.toText() # "not found");
         if (not is_authorized(caller_text, note_to_update)) {
             Runtime.trap("unauthorized");
         };
         assert note_to_update.encryptedText.size() <= MAX_NOTE_CHARS;
-        ignore Map.insert(notesById, Nat.compare, id, { note_to_update with encryptedText });
+        ignore notesById.insert(id, { note_to_update with encryptedText });
     };
 
     // Shares the note with ID [note_id] with the [user].
@@ -204,27 +204,27 @@ actor {
     //     note with ID [id] does not exist
     //     [caller] is not the note's owner
     public shared ({ caller }) func addUser(note_id : NoteId, user : PrincipalName) : async () {
-        assert not Principal.isAnonymous(caller);
-        let caller_text = Principal.toText(caller);
-        let (?note) = Map.get(notesById, Nat.compare, note_id) else Runtime.trap("note with id " # Nat.toText(note_id) # "not found");
+        assert not caller.isAnonymous();
+        let caller_text = caller.toText();
+        let (?note) = notesById.get(note_id) else Runtime.trap("note with id " # note_id.toText() # "not found");
         if (caller_text != note.owner) {
             Runtime.trap("unauthorized");
         };
         assert note.users.size() < MAX_SHARES_PER_NOTE;
-        if (not Option.isSome(Array.find(note.users, func(u : PrincipalName) : Bool { u == user }))) {
-            let users_buf = List.fromArray<PrincipalName>(note.users);
-            List.add(users_buf, user);
-            let updated_note = { note with users = List.toArray(users_buf) };
-            ignore Map.insert(notesById, Nat.compare, note_id, updated_note);
+        if (not Option.isSome(note.users.find(func(u : PrincipalName) : Bool { u == user }))) {
+            let users_buf = List.fromArray(note.users);
+            users_buf.add(user);
+            let updated_note = { note with users = users_buf.toArray() };
+            ignore notesById.insert(note_id, updated_note);
         };
-        switch (Map.get(noteIdsByUser, Text.compare, user)) {
+        switch (noteIdsByUser.get(user)) {
             case (?user_nids) {
-                if (not PureList.any(user_nids, func(nid : NoteId) : Bool { nid == note_id })) {
-                    ignore Map.insert(noteIdsByUser, Text.compare, user, PureList.pushFront(user_nids, note_id));
+                if (not user_nids.any(func(nid : NoteId) : Bool { nid == note_id })) {
+                    ignore noteIdsByUser.insert(user, user_nids.pushFront(note_id));
                 };
             };
             case null {
-                ignore Map.insert(noteIdsByUser, Text.compare, user, PureList.singleton(note_id));
+                ignore noteIdsByUser.insert(user, PureList.singleton(note_id));
             };
         };
     };
@@ -239,22 +239,22 @@ actor {
     //     note with ID [id] does not exist
     //     [caller] is not the note's owner
     public shared ({ caller }) func removeUser(note_id : NoteId, user : PrincipalName) : async () {
-        assert not Principal.isAnonymous(caller);
-        let caller_text = Principal.toText(caller);
-        let (?note) = Map.get(notesById, Nat.compare, note_id) else Runtime.trap("note with id " # Nat.toText(note_id) # "not found");
+        assert not caller.isAnonymous();
+        let caller_text = caller.toText();
+        let (?note) = notesById.get(note_id) else Runtime.trap("note with id " # note_id.toText() # "not found");
         if (caller_text != note.owner) {
             Runtime.trap("unauthorized");
         };
-        let updated_note = { note with users = Array.filter(note.users, func(u : PrincipalName) : Bool { u != user }) };
-        ignore Map.insert(notesById, Nat.compare, note_id, updated_note);
+        let updated_note = { note with users = note.users.filter(func(u : PrincipalName) : Bool { u != user }) };
+        ignore notesById.insert(note_id, updated_note);
 
-        switch (Map.get(noteIdsByUser, Text.compare, user)) {
+        switch (noteIdsByUser.get(user)) {
             case (?user_nids) {
-                let updated_nids = PureList.filter(user_nids, func(nid : NoteId) : Bool { nid != note_id });
-                if (not PureList.isEmpty(updated_nids)) {
-                    ignore Map.insert(noteIdsByUser, Text.compare, user, updated_nids);
+                let updated_nids = user_nids.filter(func(nid : NoteId) : Bool { nid != note_id });
+                if (not updated_nids.isEmpty()) {
+                    ignore noteIdsByUser.insert(user, updated_nids);
                 } else {
-                    ignore Map.remove(noteIdsByUser, Text.compare, user);
+                    noteIdsByUser.remove(user);
                 };
             };
             case null {};
@@ -270,38 +270,38 @@ actor {
     //     note with ID [id] does not exist
     //     [caller] is not the note's owner
     public shared ({ caller }) func deleteNote(note_id : NoteId) : async () {
-        assert not Principal.isAnonymous(caller);
-        let caller_text = Principal.toText(caller);
-        let (?note_to_delete) = Map.get(notesById, Nat.compare, note_id) else Runtime.trap("note with id " # Nat.toText(note_id) # "not found");
+        assert not caller.isAnonymous();
+        let caller_text = caller.toText();
+        let (?note_to_delete) = notesById.get(note_id) else Runtime.trap("note with id " # note_id.toText() # "not found");
         let owner = note_to_delete.owner;
         if (owner != caller_text) {
             Runtime.trap("unauthorized");
         };
-        switch (Map.get(noteIdsByOwner, Text.compare, owner)) {
+        switch (noteIdsByOwner.get(owner)) {
             case (?owner_nids) {
-                let updated_nids = PureList.filter(owner_nids, func(nid : NoteId) : Bool { nid != note_id });
-                if (not PureList.isEmpty(updated_nids)) {
-                    ignore Map.insert(noteIdsByOwner, Text.compare, owner, updated_nids);
+                let updated_nids = owner_nids.filter(func(nid : NoteId) : Bool { nid != note_id });
+                if (not updated_nids.isEmpty()) {
+                    ignore noteIdsByOwner.insert(owner, updated_nids);
                 } else {
-                    ignore Map.remove(noteIdsByOwner, Text.compare, owner);
+                    noteIdsByOwner.remove(owner);
                 };
             };
             case null {};
         };
         for (user in note_to_delete.users.values()) {
-            switch (Map.get(noteIdsByUser, Text.compare, user)) {
+            switch (noteIdsByUser.get(user)) {
                 case (?user_nids) {
-                    let updated_nids = PureList.filter(user_nids, func(nid : NoteId) : Bool { nid != note_id });
-                    if (not PureList.isEmpty(updated_nids)) {
-                        ignore Map.insert(noteIdsByUser, Text.compare, user, updated_nids);
+                    let updated_nids = user_nids.filter(func(nid : NoteId) : Bool { nid != note_id });
+                    if (not updated_nids.isEmpty()) {
+                        ignore noteIdsByUser.insert(user, updated_nids);
                     } else {
-                        ignore Map.remove(noteIdsByUser, Text.compare, user);
+                        noteIdsByUser.remove(user);
                     };
                 };
                 case null {};
             };
         };
-        ignore Map.remove(notesById, Nat.compare, note_id);
+        notesById.remove(note_id);
     };
 
     // Only the vetKD methods in the IC management canister are required here.
@@ -327,20 +327,20 @@ actor {
             context = Text.encodeUtf8("note_symmetric_key");
             key_id = { curve = #bls12_381_g2; name = keyName };
         });
-        Hex.encode(Blob.toArray(public_key));
+        Hex.encode(public_key.toArray());
     };
 
     public shared ({ caller }) func encryptedSymmetricKeyForNote(note_id : NoteId, transport_public_key : Blob) : async Text {
-        let caller_text = Principal.toText(caller);
-        let (?note) = Map.get(notesById, Nat.compare, note_id) else Runtime.trap("note with id " # Nat.toText(note_id) # "not found");
+        let caller_text = caller.toText();
+        let (?note) = notesById.get(note_id) else Runtime.trap("note with id " # note_id.toText() # "not found");
         if (not is_authorized(caller_text, note)) {
             Runtime.trap("unauthorized");
         };
 
         let buf = List.empty<Nat8>();
-        List.append(buf, List.fromArray<Nat8>(natToBigEndianByteArray(16, note_id))); // fixed-size encoding
-        List.append(buf, List.fromArray<Nat8>(Blob.toArray(Text.encodeUtf8(note.owner))));
-        let input = Blob.fromArray(List.toArray(buf)); // prefix-free
+        buf.append(List.fromArray(natToBigEndianByteArray(16, note_id))); // fixed-size encoding
+        buf.append(List.fromArray(note.owner.encodeUtf8().toArray()));
+        let input = buf.toArray().toBlob(); // prefix-free
 
         let { encrypted_key } = await (with cycles = 26_153_846_153) management_canister.vetkd_derive_key({
             input;
@@ -348,7 +348,7 @@ actor {
             key_id = { curve = #bls12_381_g2; name = keyName };
             transport_public_key;
         });
-        Hex.encode(Blob.toArray(encrypted_key));
+        Hex.encode(encrypted_key.toArray());
     };
 
     // Converts a nat to a fixed-size big-endian byte (Nat8) array
@@ -358,6 +358,6 @@ actor {
             let shift : Nat = 8 * (len - 1 - i);
             Nat8.fromIntWrap(n / 2 ** shift);
         };
-        Array.tabulate<Nat8>(len, ith_byte);
+        Array.tabulate(len, ith_byte);
     };
 };

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/backend/utils/Hex.mo
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/backend/utils/Hex.mo
@@ -38,11 +38,11 @@ module {
    * Encode an array of unsigned 8-bit integers in hexadecimal format.
    */
   public func encode(array : [Nat8]) : Text {
-    let encoded = Array.foldLeft<Nat8, Text>(array, "", func (accum, w8) {
+    let encoded = array.foldLeft("", func (accum, w8) {
       accum # encodeW8(w8);
     });
     // encode as lowercase
-    return Text.map(encoded, Prim.charToLower);
+    return encoded.map(Prim.charToLower);
   };
 
   /**
@@ -51,7 +51,7 @@ module {
   private func encodeW8(w8 : Nat8) : Text {
     let c1 = symbols[Nat8.toNat(w8 / base)];
     let c2 = symbols[Nat8.toNat(w8 % base)];
-    Char.toText(c1) # Char.toText(c2);
+    c1.toText() # c2.toText();
   };
 
   /**
@@ -59,15 +59,15 @@ module {
    */
   public func decode(text : Text) : Result<[Nat8], DecodeError> {
     // Transform to uppercase for uniform decoding
-    let upper = Text.map(text, Prim.charToUpper);
+    let upper = text.map(Prim.charToUpper);
     let next = upper.chars().next;
     func parse() : Result<Nat8, DecodeError> {
-      Option.get<Result<Nat8, DecodeError>>(
+      Option.get(
         do ? {
           let c1 = next()!;
           let c2 = next()!;
-          Result.chain<Nat8, Nat8, DecodeError>(decodeW4(c1), func (x1) {
-            Result.chain<Nat8, Nat8, DecodeError>(decodeW4(c2), func (x2) {
+          decodeW4(c1).chain(func (x1) {
+            decodeW4(c2).chain(func (x2) {
                 #ok (x1 * base + x2);
             })
           })
@@ -89,7 +89,7 @@ module {
         };
       };
     };
-    #ok (Array.fromVarArray<Nat8>(array));
+    #ok (array.toArray());
   };
 
   /**
@@ -98,10 +98,10 @@ module {
   private func decodeW4(char : Char) : Result<Nat8, DecodeError> {
     for (i in Nat.range(0, 16)) {
       if (symbols[i] == char) {
-        return #ok (Nat8.fromNat(i));
+        return #ok (i.toNat8());
       };
     };
-    let str = "Unexpected character: " # Char.toText(char);
+    let str = "Unexpected character: " # char.toText();
     #err (#msg str);
   };
 };

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/mops.toml
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.11.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/vetkeys/password_manager/mops.toml
+++ b/motoko/vetkeys/password_manager/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.13.0"
+moc = "1.14.1"
 
 [dependencies]
 core = "2.6.1"
 ic-vetkeys = "0.6.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/vetkeys/password_manager_with_metadata/mops.toml
+++ b/motoko/vetkeys/password_manager_with_metadata/mops.toml
@@ -1,15 +1,12 @@
 [toolchain]
-moc = "1.13.0"
+moc = "1.14.1"
 
 [dependencies]
 core = "2.6.1"
 ic-vetkeys = "0.6.0"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"

--- a/motoko/who_am_i/mops.toml
+++ b/motoko/who_am_i/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.8.2"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation (e.g. x.toText() instead of Nat.toText(x))
-# M0237: redundant explicit implicit arguments (e.g. Nat.compare is inferred automatically)
-# M0223: redundant type instantiation (e.g. Array.tabulate instead of Array.tabulate<T>)
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "src/backend/main.mo"

--- a/native-apps/unity_ii_deeplink/backend/main.mo
+++ b/native-apps/unity_ii_deeplink/backend/main.mo
@@ -2,6 +2,6 @@ import Principal "mo:core/Principal";
 
 actor Greeter {
   public query (message) func greet() : async Text {
-    "Hello, " # Principal.toText(message.caller) # "!"
+    "Hello, " # message.caller.toText() # "!"
   };
 };

--- a/native-apps/unity_ii_deeplink/mops.toml
+++ b/native-apps/unity_ii_deeplink/mops.toml
@@ -1,14 +1,11 @@
 [toolchain]
-moc = "1.9.0"
+moc = "1.14.1"
 
 [dependencies]
-core = "2.5.0"
+core = "2.6.1"
 
 [moc]
-# M0236: use context dot notation
-# M0237: redundant explicit implicit arguments
-# M0223: redundant type instantiation
-args = ["--default-persistent-actors", "-W=M0236,M0237,M0223"]
+args = [ "--default-persistent-actors", "-W=M0236,M0237,M0223" ]
 
 [canisters.backend]
 main = "backend/main.mo"


### PR DESCRIPTION
## Summary

`dfinity/icp-dev-env` v2.0.0 bundles `mops-cli` 3.1.0 (and Rust 1.98.0). The `mops-cli` and `writing-motoko` ICP skills now state a compatibility floor of `mops >= 3.1.0`, `moc >= 1.11.2`, `core >= 2.5.0` — every motoko example here was below that (mostly `moc` 1.8.2–1.13.0).

- Bump the dev-env container image pin (`v1.2.0` → `v2.0.0`) in both guarded locations: `.devcontainer/devcontainer.json` and `_run-example.yml`.
- Bump `moc` to `1.14.1` and `mo:core` to `2.6.1` across all ~30 motoko `mops.toml` files, via `mops toolchain use` / `mops add` (never hand-edited).
- Fix the new compiler warnings the bump surfaced, per the `writing-motoko` skill: deprecated `Blob`/`Array`/`Nat` conversions replaced with dot-notation equivalents (`.toBlob()`, `.toArray()`, `.toNat64()`/`.toNat8()`, `.toText()`); redundant `persistent` removed from actor classes (verified empirically — see below); unused HTTP-outcall `context` params underscore-prefixed; `var` map bindings that are never reassigned changed to `let`; redundant `ignore` removed from `Map.remove` calls.
- Corrected an `AGENTS.md` caveat about actor-class persistence that turned out to be stale (see below).

**Actor-class persistence finding:** `AGENTS.md` used to say `--default-persistent-actors` does *not* propagate into spawned `actor class` sub-WASMs (e.g. `canister_factory`'s `Counter`), so those needed `persistent` kept explicit. Under `moc` 1.14.1, `moc` itself now flags that `persistent` as redundant (`M0217`). I verified empirically rather than trust the warning blindly: dropped the keyword and ran `canister_factory`'s full `test.sh`, including the test that adds to a spawned counter's value, upgrades it, and asserts the value survived — it passed. Same check on `composite_query`'s `Bucket`. So the flag now covers actor classes too, and `AGENTS.md` has been updated to match.

**Left as-is (not "fixed"):**
- A few `operator may trap for Nat` (`M0155`) warnings on subtractions that are already correctly guarded by an immediately-preceding bounds check (`icrc2-swap`, `random_maze`, `threshold-ecdsa/SHA256.mo`) — moc's flow analysis can't see across the branch, but the code is safe and in one case already has a comment saying so. Rewriting a hand-rolled SHA256 or a balance-debit path to silence an advisory warning felt like the wrong risk/reward trade.
- An `importing Candid service constructor as instantiated service` warning (`M0185`) on three vendored third-party `.did` files (`icp_ledger.did`, `icrc1_ledger.did`, `evm_rpc.did`) used via `--actor-id-alias`/`--actor-env-alias`. Editing a vendored candid interface to satisfy a new moc parsing nuance seemed out of scope for this PR.

## On ICP Ninja compatibility

None of this relies on any mops-v3-*specific* feature — `[toolchain]` pinning, `[dependencies]`, `[moc] args`, and `[canisters.<name>]` are all mops CLI ≥2.2.0 syntax, and the moc/core version bump is orthogonal to the mops CLI major version. So this isn't gated on Ninja's build backend supporting mops v3 in particular. The residual, ordinary question — whether Ninja's backend (which doesn't use this repo's devcontainer/CI image at all) resolves `moc` 1.14.1 / `core` 2.6.1 cleanly — is a normal toolchain-bump consideration, not a blocker specific to this change.

## Test plan

- [x] `mops check` passes clean (bar the two categories of accepted warnings noted above) on all 34 motoko canisters across ~30 examples
- [x] `mops build` succeeds on all 34 motoko canisters
- [x] `canister_factory`'s full `test.sh` passes locally, including the upgrade-preserves-state / reinstall-resets-state assertions
- [x] `composite_query`'s full `test.sh` passes locally (its `Bucket` actor class also lost its explicit `persistent`)
- [ ] CI green on this PR (dev-env v2.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)