### PR TITLE
fix(send_http_get,send_http_post): attach the computed cycle cost, not a hardcoded figure

### DIFF
--- a/motoko/send_http_get/backend/main.mo
+++ b/motoko/send_http_get/backend/main.mo
@@ -1,6 +1,6 @@
 import Blob "mo:core/Blob";
 import Text "mo:core/Text";
-import { ic } "mo:ic";
+import Call "mo:ic/Call";
 import IC "mo:ic/Types";
 
 persistent actor SendHttpGet {
@@ -35,9 +35,12 @@ persistent actor SendHttpGet {
       is_replicated = ?true;
     };
 
-    // Cycles must be explicitly attached to management canister calls.
-    // The amount is based on request size and max_response_bytes.
-    let response = await (with cycles = 230_949_972_000) ic.http_request(request);
+    // Cycles must be attached to management canister calls. Call.httpRequest
+    // computes the exact amount from the request size and max_response_bytes
+    // and attaches it. Prefer this over a hand-picked figure: attached cycles
+    // are held for the duration of the call, so an arbitrary margin caps how
+    // many outcalls the canister can have in flight.
+    let response = await Call.httpRequest(request);
 
     // postman-echo.com echoes back the request metadata as JSON, letting you
     // verify the query params and headers were sent correctly.

--- a/motoko/send_http_post/backend/main.mo
+++ b/motoko/send_http_post/backend/main.mo
@@ -1,6 +1,6 @@
 import Blob "mo:core/Blob";
 import Text "mo:core/Text";
-import { ic } "mo:ic";
+import Call "mo:ic/Call";
 import IC "mo:ic/Types";
 
 persistent actor SendHttpPost {
@@ -41,9 +41,12 @@ persistent actor SendHttpPost {
       is_replicated = ?false;
     };
 
-    // Cycles must be explicitly attached to management canister calls.
-    // The amount is based on request size and max_response_bytes.
-    let response = await (with cycles = 230_949_972_000) ic.http_request(request);
+    // Cycles must be attached to management canister calls. Call.httpRequest
+    // computes the exact amount from the request size and max_response_bytes
+    // and attaches it. Prefer this over a hand-picked figure: attached cycles
+    // are held for the duration of the call, so an arbitrary margin caps how
+    // many outcalls the canister can have in flight.
+    let response = await Call.httpRequest(request);
 
     // postman-echo.com echoes back the request data as JSON, letting you
     // verify the POST body and headers were sent correctly.


### PR DESCRIPTION
Both Motoko HTTPS outcall examples hardcoded the attached cycles:

```motoko
let response = await (with cycles = 230_949_972_000) ic.http_request(request);
```

The `ic` package (already a dependency here, `ic = "4.0.0"`) provides `Call.httpRequest`, which derives the exact cost from the request size and `max_response_bytes` via `ic0.cost_http_request` and attaches that:

```motoko
let response = await Call.httpRequest(request);
```

## Why this matters beyond precision

A hardcoded literal is not merely imprecise:

- **It caps outcall concurrency.** Attached cycles leave the canister's spendable balance for the duration of the call and are refunded only on reply. An arbitrary margin therefore limits how many outcalls can be in flight. The package documents exactly this: *"Only minimal amount of cycles are added to the call. This helps the canister to make more calls in parallel without running out of cycles."*
- **It is not cost-schedule aware.** The same literal is wrong on a subnet of a different size, and wrong on a cloud engine, where `ic0.cost_http_request` returns 0.
- **It is the pattern readers copy.** These examples are embedded in the developer-docs HTTPS outcalls guide, so the hardcoded number propagates into user code.

The Rust examples already use the auto-attaching `http_request` wrapper, so this brings the two languages to parity.

## Verification

- Both examples typecheck with the pinned toolchain (`moc 1.9.0`): `moc --check $(mops sources) --default-persistent-actors ... backend/main.mo`. The two remaining warnings (`M0217` redundant `persistent`, `M0194` unused `context`) are pre-existing and untouched.
- `#region` / `#endregion` markers are unchanged and still correctly paired, so the developer-docs `CodeExample` snippets extract exactly as before. The changed call site sits inside the `get_request` / `post_request` regions, which is the intent: the snippet readers see is now the correct pattern.
- CI deploys both examples to a local replica and runs `test.sh`, which exercises the changed call path.

Only the import line and the call site changed; imports sit outside the extracted regions.