### PR TITLE
docs: use name-based local canister URLs; link icp.yaml instead of inlining it

### DIFF
--- a/hosting/godot-html5-template/README.md
+++ b/hosting/godot-html5-template/README.md
@@ -35,10 +35,10 @@ Deploy the canisters:
 icp deploy
 ```
 
-The URL for the frontend depends on the canister ID. When deployed, the URL will look like this:
+`icp deploy` prints the frontend URL. On the local network it is derived from the canister name:
 
 ```
-http://{canister_id}.localhost:8000
+http://frontend.local.localhost:8000
 ```
 
 Stop the local network when done:

--- a/hosting/oisy-signer-demo/README.md
+++ b/hosting/oisy-signer-demo/README.md
@@ -44,10 +44,10 @@ Deploy the canister:
 icp deploy
 ```
 
-The URL for the frontend depends on the canister ID. When deployed, the URL will look like this:
+`icp deploy` prints the frontend URL. On the local network it is derived from the canister name:
 
 ```
-http://{canister_id}.localhost:8000
+http://frontend.local.localhost:8000
 ```
 
 Stop the local network when done:

--- a/hosting/react/README.md
+++ b/hosting/react/README.md
@@ -42,10 +42,10 @@ Deploy the canister:
 icp deploy
 ```
 
-The URL for the frontend depends on the canister ID. When deployed, the URL will look like this:
+`icp deploy` prints the frontend URL. On the local network it is derived from the canister name:
 
 ```
-http://{canister_id}.localhost:8000
+http://frontend.local.localhost:8000
 ```
 
 Stop the local network when done:

--- a/hosting/static-website/README.md
+++ b/hosting/static-website/README.md
@@ -21,20 +21,7 @@ static-website
         └── index.html
 ```
 
-The `icp.yaml` file is a configuration file that specifies the canister used for the dapp. In this case only one canister is needed.
-
-```yaml
-canisters:
-  - name: frontend
-    recipe:
-      type: "@dfinity/asset-canister@v2.1.0"
-      configuration:
-        dir: dist
-        build:
-          - mkdir -p dist
-          - cp -r frontend/assets/* dist/
-          - cp -r frontend/src/* dist/
-```
+[`icp.yaml`](icp.yaml) is the icp-cli project file. It defines the single canister this dapp needs — a `frontend` canister on the `@dfinity/static-site` recipe — together with the build steps that assemble the site into `dist/`.
 
 ## Prerequisites
 
@@ -63,10 +50,10 @@ Deploy the canisters:
 icp deploy
 ```
 
-The URL for the frontend depends on the canister ID. When deployed, the URL will look like this:
+`icp deploy` prints the frontend URL. On the local network it is derived from the canister name:
 
 ```
-http://{canister_id}.localhost:8000
+http://frontend.local.localhost:8000
 ```
 
 Stop the local network when done:

--- a/hosting/unity-webgl-template/README.md
+++ b/hosting/unity-webgl-template/README.md
@@ -35,10 +35,10 @@ Deploy the canisters:
 icp deploy
 ```
 
-The URL for the frontend depends on the canister ID. When deployed, the URL will look like this:
+`icp deploy` prints the frontend URL. On the local network it is derived from the canister name:
 
 ```
-http://{canister_id}.localhost:8000
+http://frontend.local.localhost:8000
 ```
 
 Stop the local network when done:

--- a/native-apps/unity_ii_deeplink/TESTING.md
+++ b/native-apps/unity_ii_deeplink/TESTING.md
@@ -25,8 +25,8 @@ Confirms the II login and double-delegation logic work. Does **not** test the Un
 ```bash
 icp network start -d
 icp deploy
-# Open the II bridge URL printed by icp deploy in a browser, e.g.:
-#   http://bkyz2-fmaaa-aaaaa-qaaaq-cai.localhost:8000
+# Open the II bridge URL printed by icp deploy in a browser:
+#   http://ii-bridge.local.localhost:8000
 ```
 
 **Steps and expected results:**


### PR DESCRIPTION
Doc-only fixes surfaced while auditing local URLs across the repo. No file overlap with the photo-storage removal PR — these two can merge in either order.

### 1. Name-based local canister URLs

`icp deploy` prints frontend URLs in **name-based** form, `http://<canister-name>.<network>.localhost:<port>`, but six docs still advertised the dfx-era canister-ID form.

Verified live by deploying `hosting/static-website`:

```
Frontends (serving http_request):
  frontend: http://frontend.local.localhost:8123/
```

(8123 only because port 8000 was busy locally; the gateway default is 8000 — `icp network start --help`: "The gateway binds to port 8000 by default".)

Both forms resolve — I curl'd each, 200 apiece — but only the name-based one is printed, and the ID form is the one that breaks host-regex canister-ID discovery in frontends: `/(.*)\.localhost/` captures `frontend.local`, so `Principal.fromText` throws. That was the second bug found in the photo-storage post-mortem (#1459).

- `hosting/{static-website,react,oisy-signer-demo,godot-html5-template,unity-webgl-template}`: `http://{canister_id}.localhost:8000` → `http://frontend.local.localhost:8000` (all five canisters are named `frontend`).
- `native-apps/unity_ii_deeplink/TESTING.md`: replaced the hardcoded `bkyz2-fmaaa-aaaaa-qaaaq-cai` with `ii-bridge.local.localhost:8000` — matching line 98 of the same file and `README.md:89`.

### 2. `static-website` README: link `icp.yaml`, don't inline it

The README embedded its whole `icp.yaml`, still showing `@dfinity/asset-canister@v2.1.0` while the actual file moved to `@dfinity/static-site` — the last stale legacy-recipe reference in the repo. Duplicated config drifts silently and nothing fails when the copy rots, so the block is replaced by a prose sentence linking the file. It was the only README in the repo embedding an `icp.yaml` body, so this also makes it consistent with every other example.

Resolves the remaining part of item 4 of #1458.

### Also audited, no change needed

- No Candid UI links anywhere in the repo.
- No README addresses a backend canister by URL — they all use `icp canister call <name>`, which is name-based and can't drift.
- `motoko/ic-pos`'s local II URL `http://id.ai.localhost:8000` is correct for `ii: true`.
- The `icp0.io` URLs in `unity_ii_deeplink` are all `<your-canister-id>` placeholders.
- The `127.0.0.1:4943` in `motoko/cert-var` and `rust/flying_ninja` `vite.config.js` is inside the **dfx fallback branch** only; the icp-cli branch correctly targets `:8000`. Not a bug — though those dfx fallback branches do sit oddly with AGENTS.md:49 "never `dfx`", which might be worth a separate look.
