### PR TITLE
chore: drop dfx fallbacks and dfx_test_key; unify dev-server preflight across all vite configs

### DIFF
--- a/motoko/cert-var/frontend/src/actor.js
+++ b/motoko/cert-var/frontend/src/actor.js
@@ -7,14 +7,11 @@ import { createActor } from "./bindings/backend";
 // via Set-Cookie header (see vite.config.js).
 const canisterEnv = safeGetCanisterEnv();
 
-// Resolve canister ID: cookie (icp-cli + dev server) → env var (dfx build-time)
-const canisterId =
-  canisterEnv?.["PUBLIC_CANISTER_ID:backend"] ??
-  process.env.CANISTER_ID_BACKEND;
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
 
 if (!canisterId) {
   throw new Error(
-    "Canister ID for 'backend' not found. Run 'icp deploy' or 'dfx deploy' first."
+    "Canister ID for 'backend' not found. Run 'icp deploy' first."
   );
 }
 

--- a/motoko/cert-var/frontend/vite.config.js
+++ b/motoko/cert-var/frontend/vite.config.js
@@ -2,18 +2,21 @@ import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -21,14 +24,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -36,7 +39,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/cert-var/frontend/vite.config.js
+++ b/motoko/cert-var/frontend/vite.config.js
@@ -1,9 +1,8 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
-  // Try icp-cli first
   try {
     const canisterId = execSync("icp canister status backend -e local -i", {
       encoding: "utf-8",
@@ -27,44 +26,13 @@ function getDevServerConfig() {
     };
   } catch {}
 
-  // Try dfx
-  try {
-    const pingResult = JSON.parse(
-      execSync("dfx ping", { encoding: "utf-8", stdio: "pipe" })
-    );
-    const rootKeyHex = Buffer.from(pingResult.root_key).toString("hex");
-    const canisterId = execSync("dfx canister id backend", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${rootKeyHex}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": {
-          target: "http://127.0.0.1:4943",
-          changeOrigin: true,
-        },
-      },
-      host: "127.0.0.1",
-    };
-  } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy\nor:\n  dfx start --background && dfx deploy"
+    "No local network running. Start with:\n  icp network start -d && icp deploy"
   );
 }
 
-export default defineConfig(({ command, mode }) => {
-  // dfx generates ../.env with CANISTER_ID_* vars on deploy. Bake them into the
-  // bundle so actor.js can fall back to them when the ic_env cookie does not
-  // contain canister IDs (dfx does not inject PUBLIC_CANISTER_ID:* env vars
-  // into the asset canister, unlike icp-cli).
-  const env = loadEnv(mode, "..", ["CANISTER_"]);
-
+export default defineConfig(({ command }) => {
   return {
     base: "./",
     plugins: [
@@ -73,11 +41,6 @@ export default defineConfig(({ command, mode }) => {
         outDir: "./src/bindings",
       }),
     ],
-    define: {
-      "process.env.CANISTER_ID_BACKEND": JSON.stringify(
-        env.CANISTER_ID_BACKEND
-      ),
-    },
     optimizeDeps: {
       esbuildOptions: { define: { global: "globalThis" } },
     },

--- a/motoko/cert-var/frontend/vite.config.js
+++ b/motoko/cert-var/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/cert-var/frontend/vite.config.js
+++ b/motoko/cert-var/frontend/vite.config.js
@@ -3,32 +3,46 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/cert-var/frontend/vite.config.js
+++ b/motoko/cert-var/frontend/vite.config.js
@@ -26,9 +26,8 @@ function getDevServerConfig() {
     };
   } catch {}
 
-
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/daily_planner/frontend/vite.config.js
+++ b/motoko/daily_planner/frontend/vite.config.js
@@ -4,32 +4,46 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/daily_planner/frontend/vite.config.js
+++ b/motoko/daily_planner/frontend/vite.config.js
@@ -28,7 +28,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/daily_planner/frontend/vite.config.js
+++ b/motoko/daily_planner/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -37,7 +40,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/daily_planner/frontend/vite.config.js
+++ b/motoko/daily_planner/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/evm_block_explorer/frontend/vite.config.js
+++ b/motoko/evm_block_explorer/frontend/vite.config.js
@@ -3,6 +3,52 @@ import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import react from "@vitejs/plugin-react";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     react(),
@@ -16,52 +62,8 @@ export default defineConfig(({ command }) => {
     return { plugins };
   }
 
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
   return {
     plugins,
-    server: {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: proxyTarget, changeOrigin: true },
-      },
-    },
+    server: getDevServerConfig(),
   };
 });

--- a/motoko/evm_block_explorer/frontend/vite.config.js
+++ b/motoko/evm_block_explorer/frontend/vite.config.js
@@ -19,9 +19,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, { encoding: "utf-8" })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -29,16 +41,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/motoko/evm_block_explorer/frontend/vite.config.js
+++ b/motoko/evm_block_explorer/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/filevault/frontend/src/actor.js
+++ b/motoko/filevault/frontend/src/actor.js
@@ -3,9 +3,7 @@ import { createActor } from "./bindings/backend";
 
 const canisterEnv = safeGetCanisterEnv();
 
-const canisterId =
-  canisterEnv?.["PUBLIC_CANISTER_ID:backend"] ??
-  process.env.CANISTER_ID_BACKEND;
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
 
 if (!canisterId) {
   throw new Error(

--- a/motoko/filevault/frontend/vite.config.js
+++ b/motoko/filevault/frontend/vite.config.js
@@ -4,33 +4,47 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      replicaPort: "8000",
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    replicaPort: new URL(networkStatus.api_url).port,
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/filevault/frontend/vite.config.js
+++ b/motoko/filevault/frontend/vite.config.js
@@ -29,7 +29,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/filevault/frontend/vite.config.js
+++ b/motoko/filevault/frontend/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
@@ -33,8 +33,7 @@ function getDevServerConfig() {
   );
 }
 
-export default defineConfig(({ command, mode }) => {
-  const env = loadEnv(mode, "..", ["CANISTER_"]);
+export default defineConfig(({ command }) => {
   const devConfig = command === "serve" ? getDevServerConfig() : undefined;
 
   return {
@@ -47,9 +46,6 @@ export default defineConfig(({ command, mode }) => {
       }),
     ],
     define: {
-      "process.env.CANISTER_ID_BACKEND": JSON.stringify(
-        env.CANISTER_ID_BACKEND
-      ),
       "process.env.REPLICA_PORT": JSON.stringify(devConfig?.replicaPort ?? ""),
     },
     optimizeDeps: {

--- a/motoko/filevault/frontend/vite.config.js
+++ b/motoko/filevault/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -38,7 +41,7 @@ function getDevServerConfig() {
     replicaPort: new URL(networkStatus.api_url).port,
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/filevault/frontend/vite.config.js
+++ b/motoko/filevault/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/flying_ninja/frontend/vite.config.js
+++ b/motoko/flying_ninja/frontend/vite.config.js
@@ -3,18 +3,21 @@ import react from "@vitejs/plugin-react";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -37,7 +40,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/flying_ninja/frontend/vite.config.js
+++ b/motoko/flying_ninja/frontend/vite.config.js
@@ -29,7 +29,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/flying_ninja/frontend/vite.config.js
+++ b/motoko/flying_ninja/frontend/vite.config.js
@@ -4,33 +4,46 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
-  // Try icp-cli first
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/flying_ninja/frontend/vite.config.js
+++ b/motoko/flying_ninja/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/hello_world/frontend/vite.config.js
+++ b/motoko/hello_world/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/hello_world/frontend/vite.config.js
+++ b/motoko/hello_world/frontend/vite.config.js
@@ -20,11 +20,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, {
-      encoding: "utf-8",
-    })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -33,16 +43,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/motoko/hello_world/frontend/vite.config.js
+++ b/motoko/hello_world/frontend/vite.config.js
@@ -2,6 +2,52 @@ import { defineConfig } from "vite";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     icpBindgen({
@@ -15,60 +61,8 @@ export default defineConfig(({ command }) => {
     return { plugins };
   }
 
-  // If we're running the local npm dev server, we're going to look up the
-  // local network's root key and the relevant canister ids.
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  // Backend must be deployed before starting dev server
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
-  const server = {
-    headers: {
-      "Set-Cookie": `ic_env=${encodeURIComponent(
-        `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-      )}; SameSite=Lax;`,
-    },
-    proxy: {
-      "/api": {
-        target: proxyTarget,
-        changeOrigin: true,
-      },
-    },
-  };
-
   return {
     plugins,
-    server,
+    server: getDevServerConfig(),
   };
 });

--- a/motoko/llm_chatbot/frontend/vite.config.js
+++ b/motoko/llm_chatbot/frontend/vite.config.js
@@ -21,11 +21,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, {
-      encoding: "utf-8",
-    })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -33,16 +43,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/motoko/llm_chatbot/frontend/vite.config.js
+++ b/motoko/llm_chatbot/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/llm_chatbot/frontend/vite.config.js
+++ b/motoko/llm_chatbot/frontend/vite.config.js
@@ -3,6 +3,52 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     react(),
@@ -18,57 +64,8 @@ export default defineConfig(({ command }) => {
   }
 
   // Dev server: look up the local network root key and backend canister ID
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
-  const server = {
-    headers: {
-      "Set-Cookie": `ic_env=${encodeURIComponent(
-        `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-      )}; SameSite=Lax;`,
-    },
-    proxy: {
-      "/api": {
-        target: proxyTarget,
-        changeOrigin: true,
-      },
-    },
-  };
-
   return {
     plugins,
-    server,
+    server: getDevServerConfig(),
   };
 });

--- a/motoko/random_maze/frontend/vite.config.js
+++ b/motoko/random_maze/frontend/vite.config.js
@@ -4,32 +4,46 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/random_maze/frontend/vite.config.js
+++ b/motoko/random_maze/frontend/vite.config.js
@@ -28,7 +28,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/random_maze/frontend/vite.config.js
+++ b/motoko/random_maze/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -37,7 +40,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/random_maze/frontend/vite.config.js
+++ b/motoko/random_maze/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/superheroes/frontend/vite.config.js
+++ b/motoko/superheroes/frontend/vite.config.js
@@ -4,33 +4,46 @@ import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import react from "@vitejs/plugin-react";
 
 function getDevServerConfig() {
-  // Try icp-cli first
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/superheroes/frontend/vite.config.js
+++ b/motoko/superheroes/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import react from "@vitejs/plugin-react";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -37,7 +40,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/superheroes/frontend/vite.config.js
+++ b/motoko/superheroes/frontend/vite.config.js
@@ -29,7 +29,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/superheroes/frontend/vite.config.js
+++ b/motoko/superheroes/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -3,32 +3,46 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => ({

--- a/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -2,18 +2,21 @@ import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -21,14 +24,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -36,7 +39,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/motoko/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -27,7 +27,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -18,11 +18,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -7,32 +7,46 @@ import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
 function getDevServerConfig() {
+    let networkStatus;
     try {
-        const canisterId = execSync("icp canister status backend -e local -i", {
-            encoding: "utf-8",
-            stdio: "pipe",
-        }).trim();
-        const networkStatus = JSON.parse(
-            execSync("icp network status --json", {
+        networkStatus = JSON.parse(
+            execSync("icp network status -e local --json", {
                 encoding: "utf-8",
                 stdio: "pipe",
             })
         );
-        return {
-            headers: {
-                "Set-Cookie": `ic_env=${encodeURIComponent(
-                    `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-                )}; SameSite=Lax;`,
-            },
-            proxy: {
-                "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-            },
-        };
-    } catch {}
+    } catch {
+        console.error(
+            "No local network running. Start it and deploy first:\n" +
+                "  icp network start -d && icp deploy"
+        );
+        process.exit(1);
+    }
 
-    throw new Error(
-        "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-    );
+    let canisterId;
+    try {
+        canisterId = execSync("icp canister status backend -e local -i", {
+            encoding: "utf-8",
+            stdio: "pipe",
+        }).trim();
+    } catch {
+        console.error(
+            "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+                "  icp deploy backend"
+        );
+        process.exit(1);
+    }
+
+    return {
+        headers: {
+            "Set-Cookie": `ic_env=${encodeURIComponent(
+                `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+            )}; SameSite=Lax;`,
+        },
+        proxy: {
+            "/api": { target: networkStatus.api_url, changeOrigin: true },
+        },
+    };
 }
 
 export default defineConfig(({ command }) => ({

--- a/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -31,7 +31,7 @@ function getDevServerConfig() {
     } catch {}
 
     throw new Error(
-        "No local network running. Start with:\n  icp network start -d && icp deploy"
+        "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
     );
 }
 

--- a/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/motoko/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -6,47 +6,50 @@ import css from "rollup-plugin-css-only";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
-    let networkStatus;
-    try {
-        networkStatus = JSON.parse(
-            execSync("icp network status -e local --json", {
-                encoding: "utf-8",
-                stdio: "pipe",
-            })
-        );
-    } catch {
-        console.error(
-            "No local network running. Start it and deploy first:\n" +
-                "  icp network start -d && icp deploy"
-        );
-        process.exit(1);
-    }
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-    let canisterId;
-    try {
-        canisterId = execSync("icp canister status backend -e local -i", {
-            encoding: "utf-8",
-            stdio: "pipe",
-        }).trim();
-    } catch {
-        console.error(
-            "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-                "  icp deploy backend"
-        );
-        process.exit(1);
-    }
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
 
-    return {
-        headers: {
-            "Set-Cookie": `ic_env=${encodeURIComponent(
-                `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-            )}; SameSite=Lax;`,
-        },
-        proxy: {
-            "/api": { target: networkStatus.api_url, changeOrigin: true },
-        },
-    };
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => ({

--- a/motoko/who_am_i/src/frontend/src/actor.js
+++ b/motoko/who_am_i/src/frontend/src/actor.js
@@ -3,9 +3,7 @@ import { createActor } from "./bindings/backend";
 
 const canisterEnv = safeGetCanisterEnv();
 
-const canisterId =
-  canisterEnv?.["PUBLIC_CANISTER_ID:backend"] ??
-  process.env.CANISTER_ID_BACKEND;
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
 
 if (!canisterId) {
   throw new Error(

--- a/motoko/who_am_i/src/frontend/vite.config.js
+++ b/motoko/who_am_i/src/frontend/vite.config.js
@@ -4,33 +4,47 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      replicaPort: "8000",
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    replicaPort: new URL(networkStatus.api_url).port,
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/motoko/who_am_i/src/frontend/vite.config.js
+++ b/motoko/who_am_i/src/frontend/vite.config.js
@@ -29,7 +29,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/motoko/who_am_i/src/frontend/vite.config.js
+++ b/motoko/who_am_i/src/frontend/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
@@ -33,8 +33,7 @@ function getDevServerConfig() {
   );
 }
 
-export default defineConfig(({ command, mode }) => {
-  const env = loadEnv(mode, "../..", ["CANISTER_"]);
+export default defineConfig(({ command }) => {
   const devConfig = command === "serve" ? getDevServerConfig() : undefined;
 
   return {
@@ -47,9 +46,6 @@ export default defineConfig(({ command, mode }) => {
       }),
     ],
     define: {
-      "process.env.CANISTER_ID_BACKEND": JSON.stringify(
-        env.CANISTER_ID_BACKEND
-      ),
       "process.env.REPLICA_PORT": JSON.stringify(devConfig?.replicaPort ?? ""),
     },
     optimizeDeps: {
@@ -59,7 +55,6 @@ export default defineConfig(({ command, mode }) => {
       ? {
           headers: devConfig.headers,
           proxy: devConfig.proxy,
-          host: devConfig.host,
         }
       : undefined,
   };

--- a/motoko/who_am_i/src/frontend/vite.config.js
+++ b/motoko/who_am_i/src/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -38,7 +41,7 @@ function getDevServerConfig() {
     replicaPort: new URL(networkStatus.api_url).port,
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/motoko/who_am_i/src/frontend/vite.config.js
+++ b/motoko/who_am_i/src/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/basic_ethereum/backend/lib.rs
+++ b/rust/basic_ethereum/backend/lib.rs
@@ -256,9 +256,9 @@ fn estimate_transaction_fees() -> (u128, u128, u128) {
 #[derive(CandidType, Deserialize, Debug, Default, PartialEq, Eq)]
 pub struct InitArg {
     pub ethereum_network: Option<EthereumNetwork>,
-    /// ECDSA key name as used by the IC management canister: "dfx_test_key" (local dfx),
-    /// "test_key_1" (ICP mainnet testing), or "key_1" (ICP mainnet production).
-    /// Defaults to "test_key_1".
+    /// ECDSA key name as used by the IC management canister: "test_key_1" (test key,
+    /// works on both the local network and ICP mainnet) or "key_1" (ICP mainnet
+    /// production). Defaults to "test_key_1".
     pub ecdsa_key_name: Option<String>,
 }
 

--- a/rust/daily_planner/frontend/vite.config.js
+++ b/rust/daily_planner/frontend/vite.config.js
@@ -4,32 +4,46 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/rust/daily_planner/frontend/vite.config.js
+++ b/rust/daily_planner/frontend/vite.config.js
@@ -28,7 +28,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/rust/daily_planner/frontend/vite.config.js
+++ b/rust/daily_planner/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -37,7 +40,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/rust/daily_planner/frontend/vite.config.js
+++ b/rust/daily_planner/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/evm_block_explorer/frontend/vite.config.js
+++ b/rust/evm_block_explorer/frontend/vite.config.js
@@ -3,6 +3,52 @@ import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import react from "@vitejs/plugin-react";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     react(),
@@ -16,52 +62,8 @@ export default defineConfig(({ command }) => {
     return { plugins };
   }
 
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
   return {
     plugins,
-    server: {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: proxyTarget, changeOrigin: true },
-      },
-    },
+    server: getDevServerConfig(),
   };
 });

--- a/rust/evm_block_explorer/frontend/vite.config.js
+++ b/rust/evm_block_explorer/frontend/vite.config.js
@@ -19,9 +19,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, { encoding: "utf-8" })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -29,16 +41,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/rust/evm_block_explorer/frontend/vite.config.js
+++ b/rust/evm_block_explorer/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/face-recognition/frontend/vite.config.js
+++ b/rust/face-recognition/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/face-recognition/frontend/vite.config.js
+++ b/rust/face-recognition/frontend/vite.config.js
@@ -20,11 +20,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, {
-      encoding: "utf-8",
-    })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -33,16 +43,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/rust/face-recognition/frontend/vite.config.js
+++ b/rust/face-recognition/frontend/vite.config.js
@@ -2,6 +2,52 @@ import { defineConfig } from "vite";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     icpBindgen({
@@ -15,60 +61,8 @@ export default defineConfig(({ command }) => {
     return { plugins };
   }
 
-  // If we're running the local npm dev server, we're going to look up the
-  // local network's root key and the relevant canister ids.
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  // Backend must be deployed before starting dev server
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
-  const server = {
-    headers: {
-      "Set-Cookie": `ic_env=${encodeURIComponent(
-        `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-      )}; SameSite=Lax;`,
-    },
-    proxy: {
-      "/api": {
-        target: proxyTarget,
-        changeOrigin: true,
-      },
-    },
-  };
-
   return {
     plugins,
-    server,
+    server: getDevServerConfig(),
   };
 });

--- a/rust/flying_ninja/frontend/src/actor.js
+++ b/rust/flying_ninja/frontend/src/actor.js
@@ -7,14 +7,11 @@ import { createActor } from "./bindings/backend";
 // via Set-Cookie header (see vite.config.js).
 const canisterEnv = safeGetCanisterEnv();
 
-// Resolve canister ID: cookie (icp-cli + dev server) → env var (dfx build-time)
-const canisterId =
-  canisterEnv?.["PUBLIC_CANISTER_ID:backend"] ??
-  process.env.CANISTER_ID_BACKEND;
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
 
 if (!canisterId) {
   throw new Error(
-    "Canister ID for 'backend' not found. Run 'icp deploy' or 'dfx deploy' first."
+    "Canister ID for 'backend' not found. Run 'icp deploy' first."
   );
 }
 

--- a/rust/flying_ninja/frontend/vite.config.js
+++ b/rust/flying_ninja/frontend/vite.config.js
@@ -1,10 +1,9 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
-  // Try icp-cli first
   try {
     const canisterId = execSync("icp canister status backend -e local -i", {
       encoding: "utf-8",
@@ -28,44 +27,13 @@ function getDevServerConfig() {
     };
   } catch {}
 
-  // Try dfx
-  try {
-    const pingResult = JSON.parse(
-      execSync("dfx ping", { encoding: "utf-8", stdio: "pipe" })
-    );
-    const rootKeyHex = Buffer.from(pingResult.root_key).toString("hex");
-    const canisterId = execSync("dfx canister id backend", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${rootKeyHex}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": {
-          target: "http://127.0.0.1:4943",
-          changeOrigin: true,
-        },
-      },
-      host: "127.0.0.1",
-    };
-  } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy\nor:\n  dfx start --background && dfx deploy"
+    "No local network running. Start with:\n  icp network start -d && icp deploy"
   );
 }
 
-export default defineConfig(({ command, mode }) => {
-  // dfx generates ../.env with CANISTER_ID_* vars on deploy. Bake them into the
-  // bundle so actor.js can fall back to them when the ic_env cookie does not
-  // contain canister IDs (dfx does not inject PUBLIC_CANISTER_ID:* env vars
-  // into the asset canister, unlike icp-cli).
-  const env = loadEnv(mode, "..", ["CANISTER_"]);
-
+export default defineConfig(({ command }) => {
   return {
     base: "./",
     plugins: [
@@ -75,11 +43,6 @@ export default defineConfig(({ command, mode }) => {
         outDir: "./src/bindings",
       }),
     ],
-    define: {
-      "process.env.CANISTER_ID_BACKEND": JSON.stringify(
-        env.CANISTER_ID_BACKEND
-      ),
-    },
     optimizeDeps: {
       esbuildOptions: { define: { global: "globalThis" } },
     },

--- a/rust/flying_ninja/frontend/vite.config.js
+++ b/rust/flying_ninja/frontend/vite.config.js
@@ -3,18 +3,21 @@ import react from "@vitejs/plugin-react";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -37,7 +40,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/rust/flying_ninja/frontend/vite.config.js
+++ b/rust/flying_ninja/frontend/vite.config.js
@@ -27,9 +27,8 @@ function getDevServerConfig() {
     };
   } catch {}
 
-
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/rust/flying_ninja/frontend/vite.config.js
+++ b/rust/flying_ninja/frontend/vite.config.js
@@ -4,32 +4,46 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/rust/flying_ninja/frontend/vite.config.js
+++ b/rust/flying_ninja/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/hello_world/frontend/vite.config.js
+++ b/rust/hello_world/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/hello_world/frontend/vite.config.js
+++ b/rust/hello_world/frontend/vite.config.js
@@ -20,11 +20,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, {
-      encoding: "utf-8",
-    })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -33,16 +43,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/rust/hello_world/frontend/vite.config.js
+++ b/rust/hello_world/frontend/vite.config.js
@@ -2,6 +2,52 @@ import { defineConfig } from "vite";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     icpBindgen({
@@ -15,60 +61,8 @@ export default defineConfig(({ command }) => {
     return { plugins };
   }
 
-  // If we're running the local npm dev server, we're going to look up the
-  // local network's root key and the relevant canister ids.
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  // Backend must be deployed before starting dev server
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
-  const server = {
-    headers: {
-      "Set-Cookie": `ic_env=${encodeURIComponent(
-        `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-      )}; SameSite=Lax;`,
-    },
-    proxy: {
-      "/api": {
-        target: proxyTarget,
-        changeOrigin: true,
-      },
-    },
-  };
-
   return {
     plugins,
-    server,
+    server: getDevServerConfig(),
   };
 });

--- a/rust/image-classification/frontend/vite.config.js
+++ b/rust/image-classification/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/image-classification/frontend/vite.config.js
+++ b/rust/image-classification/frontend/vite.config.js
@@ -20,11 +20,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, {
-      encoding: "utf-8",
-    })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -33,16 +43,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/rust/image-classification/frontend/vite.config.js
+++ b/rust/image-classification/frontend/vite.config.js
@@ -2,6 +2,52 @@ import { defineConfig } from "vite";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     icpBindgen({
@@ -15,60 +61,8 @@ export default defineConfig(({ command }) => {
     return { plugins };
   }
 
-  // If we're running the local npm dev server, we're going to look up the
-  // local network's root key and the relevant canister ids.
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  // Backend must be deployed before starting dev server
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
-  const server = {
-    headers: {
-      "Set-Cookie": `ic_env=${encodeURIComponent(
-        `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-      )}; SameSite=Lax;`,
-    },
-    proxy: {
-      "/api": {
-        target: proxyTarget,
-        changeOrigin: true,
-      },
-    },
-  };
-
   return {
     plugins,
-    server,
+    server: getDevServerConfig(),
   };
 });

--- a/rust/llm_chatbot/frontend/vite.config.js
+++ b/rust/llm_chatbot/frontend/vite.config.js
@@ -21,11 +21,21 @@ export default defineConfig(({ command }) => {
   const environment = process.env.ICP_ENVIRONMENT || "local";
   const CANISTER_NAME = "backend";
 
-  const networkStatus = JSON.parse(
-    execSync(`icp network status -e ${environment} --json`, {
-      encoding: "utf-8",
-    })
-  );
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${environment} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No local network running for environment "${environment}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
   const rootKey = networkStatus.root_key;
   const proxyTarget = networkStatus.api_url;
 
@@ -33,16 +43,13 @@ export default defineConfig(({ command }) => {
   try {
     canisterId = execSync(
       `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8" }
+      { encoding: "utf-8", stdio: "pipe" }
     ).trim();
   } catch {
-    console.error(`
-     Backend canister "${CANISTER_NAME}" not found in environment "${environment}"
-
-     Before running the dev server, deploy the backend canister:
-
-       icp deploy ${CANISTER_NAME} -e ${environment}
-    `);
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${environment}`
+    );
     process.exit(1);
   }
 

--- a/rust/llm_chatbot/frontend/vite.config.js
+++ b/rust/llm_chatbot/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/llm_chatbot/frontend/vite.config.js
+++ b/rust/llm_chatbot/frontend/vite.config.js
@@ -3,6 +3,52 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
+function getDevServerConfig() {
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
+
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const plugins = [
     react(),
@@ -18,57 +64,8 @@ export default defineConfig(({ command }) => {
   }
 
   // Dev server: look up the local network root key and backend canister ID
-  const environment = process.env.ICP_ENVIRONMENT || "local";
-  const CANISTER_NAME = "backend";
-
-  let networkStatus;
-  try {
-    networkStatus = JSON.parse(
-      execSync(`icp network status -e ${environment} --json`, {
-        encoding: "utf-8",
-        stdio: "pipe",
-      })
-    );
-  } catch {
-    console.error(
-      `No local network running for environment "${environment}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
-    process.exit(1);
-  }
-  const rootKey = networkStatus.root_key;
-  const proxyTarget = networkStatus.api_url;
-
-  let canisterId;
-  try {
-    canisterId = execSync(
-      `icp canister status ${CANISTER_NAME} -e ${environment} -i`,
-      { encoding: "utf-8", stdio: "pipe" }
-    ).trim();
-  } catch {
-    console.error(
-      `Canister "${CANISTER_NAME}" is not deployed in environment "${environment}". Deploy it first:\n` +
-        `  icp deploy ${CANISTER_NAME} -e ${environment}`
-    );
-    process.exit(1);
-  }
-
-  const server = {
-    headers: {
-      "Set-Cookie": `ic_env=${encodeURIComponent(
-        `PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}&ic_root_key=${rootKey}`
-      )}; SameSite=Lax;`,
-    },
-    proxy: {
-      "/api": {
-        target: proxyTarget,
-        changeOrigin: true,
-      },
-    },
-  };
-
   return {
     plugins,
-    server,
+    server: getDevServerConfig(),
   };
 });

--- a/rust/qrcode/frontend/src/actor.js
+++ b/rust/qrcode/frontend/src/actor.js
@@ -7,10 +7,7 @@ import { createActor } from "./bindings/backend";
 // via Set-Cookie header (see vite.config.js).
 const canisterEnv = safeGetCanisterEnv();
 
-// Resolve canister ID: cookie (icp-cli + dev server) → env var (dfx build-time)
-const canisterId =
-  canisterEnv?.["PUBLIC_CANISTER_ID:backend"] ??
-  process.env.CANISTER_ID_BACKEND;
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
 
 if (!canisterId) {
   throw new Error(

--- a/rust/qrcode/frontend/vite.config.js
+++ b/rust/qrcode/frontend/vite.config.js
@@ -2,18 +2,21 @@ import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -21,14 +24,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -36,7 +39,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/rust/qrcode/frontend/vite.config.js
+++ b/rust/qrcode/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/qrcode/frontend/vite.config.js
+++ b/rust/qrcode/frontend/vite.config.js
@@ -3,32 +3,46 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/rust/qrcode/frontend/vite.config.js
+++ b/rust/qrcode/frontend/vite.config.js
@@ -1,9 +1,8 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
-  // Try icp-cli first
   try {
     const canisterId = execSync("icp canister status backend -e local -i", {
       encoding: "utf-8",
@@ -32,9 +31,7 @@ function getDevServerConfig() {
   );
 }
 
-export default defineConfig(({ command, mode }) => {
-  const env = loadEnv(mode, "..", ["CANISTER_"]);
-
+export default defineConfig(({ command }) => {
   return {
     base: "./",
     plugins: [
@@ -43,11 +40,6 @@ export default defineConfig(({ command, mode }) => {
         outDir: "./src/bindings",
       }),
     ],
-    define: {
-      "process.env.CANISTER_ID_BACKEND": JSON.stringify(
-        env.CANISTER_ID_BACKEND
-      ),
-    },
     optimizeDeps: {
       esbuildOptions: { define: { global: "globalThis" } },
     },

--- a/rust/qrcode/frontend/vite.config.js
+++ b/rust/qrcode/frontend/vite.config.js
@@ -27,7 +27,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/rust/threshold-schnorr/backend/tests/integration_tests.rs
+++ b/rust/threshold-schnorr/backend/tests/integration_tests.rs
@@ -8,8 +8,7 @@ use serde::Deserialize;
 /// (absent, empty, invalid length, valid 32 bytes) for sign+verify, plus negative cases.
 ///
 /// The PocketIC instance is reused across iterations for speed.
-/// The test threshold keys subnet provides `test_key_1` and `dfx_test_key`, matching
-/// the canister's default key (`test_key_1`).
+/// The test threshold keys subnet provides `test_key_1`, the canister's default key.
 #[test]
 fn signing_and_verification_should_work_correctly() {
     const ALGORITHMS: [SchnorrAlgorithm; 2] =

--- a/rust/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/rust/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -3,32 +3,46 @@ import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => ({

--- a/rust/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/rust/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -2,18 +2,21 @@ import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -21,14 +24,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -36,7 +39,7 @@ function getDevServerConfig() {
   return {
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/rust/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/rust/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -14,11 +14,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/vetkeys/basic_vetkd/frontend/vite.config.js
+++ b/rust/vetkeys/basic_vetkd/frontend/vite.config.js
@@ -27,7 +27,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -18,11 +18,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -7,32 +7,46 @@ import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
 function getDevServerConfig() {
+    let networkStatus;
     try {
-        const canisterId = execSync("icp canister status backend -e local -i", {
-            encoding: "utf-8",
-            stdio: "pipe",
-        }).trim();
-        const networkStatus = JSON.parse(
-            execSync("icp network status --json", {
+        networkStatus = JSON.parse(
+            execSync("icp network status -e local --json", {
                 encoding: "utf-8",
                 stdio: "pipe",
             })
         );
-        return {
-            headers: {
-                "Set-Cookie": `ic_env=${encodeURIComponent(
-                    `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-                )}; SameSite=Lax;`,
-            },
-            proxy: {
-                "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-            },
-        };
-    } catch {}
+    } catch {
+        console.error(
+            "No local network running. Start it and deploy first:\n" +
+                "  icp network start -d && icp deploy"
+        );
+        process.exit(1);
+    }
 
-    throw new Error(
-        "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-    );
+    let canisterId;
+    try {
+        canisterId = execSync("icp canister status backend -e local -i", {
+            encoding: "utf-8",
+            stdio: "pipe",
+        }).trim();
+    } catch {
+        console.error(
+            "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+                "  icp deploy backend"
+        );
+        process.exit(1);
+    }
+
+    return {
+        headers: {
+            "Set-Cookie": `ic_env=${encodeURIComponent(
+                `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+            )}; SameSite=Lax;`,
+        },
+        proxy: {
+            "/api": { target: networkStatus.api_url, changeOrigin: true },
+        },
+    };
 }
 
 export default defineConfig(({ command }) => ({

--- a/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -31,7 +31,7 @@ function getDevServerConfig() {
     } catch {}
 
     throw new Error(
-        "No local network running. Start with:\n  icp network start -d && icp deploy"
+        "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
     );
 }
 

--- a/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
+++ b/rust/vetkeys/password_manager_with_metadata/frontend/vite.config.js
@@ -6,47 +6,50 @@ import css from "rollup-plugin-css-only";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 import { execSync } from "child_process";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
-    let networkStatus;
-    try {
-        networkStatus = JSON.parse(
-            execSync("icp network status -e local --json", {
-                encoding: "utf-8",
-                stdio: "pipe",
-            })
-        );
-    } catch {
-        console.error(
-            "No local network running. Start it and deploy first:\n" +
-                "  icp network start -d && icp deploy"
-        );
-        process.exit(1);
-    }
+  let networkStatus;
+  try {
+    networkStatus = JSON.parse(
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
+        encoding: "utf-8",
+        stdio: "pipe",
+      })
+    );
+  } catch {
+    console.error(
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-    let canisterId;
-    try {
-        canisterId = execSync("icp canister status backend -e local -i", {
-            encoding: "utf-8",
-            stdio: "pipe",
-        }).trim();
-    } catch {
-        console.error(
-            "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-                "  icp deploy backend"
-        );
-        process.exit(1);
-    }
+  let canisterId;
+  try {
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    console.error(
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
+    );
+    process.exit(1);
+  }
 
-    return {
-        headers: {
-            "Set-Cookie": `ic_env=${encodeURIComponent(
-                `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-            )}; SameSite=Lax;`,
-        },
-        proxy: {
-            "/api": { target: networkStatus.api_url, changeOrigin: true },
-        },
-    };
+  return {
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => ({

--- a/rust/who_am_i/src/frontend/src/actor.js
+++ b/rust/who_am_i/src/frontend/src/actor.js
@@ -3,9 +3,7 @@ import { createActor } from "./bindings/backend";
 
 const canisterEnv = safeGetCanisterEnv();
 
-const canisterId =
-  canisterEnv?.["PUBLIC_CANISTER_ID:backend"] ??
-  process.env.CANISTER_ID_BACKEND;
+const canisterId = canisterEnv?.["PUBLIC_CANISTER_ID:backend"];
 
 if (!canisterId) {
   throw new Error(

--- a/rust/who_am_i/src/frontend/vite.config.js
+++ b/rust/who_am_i/src/frontend/vite.config.js
@@ -4,33 +4,47 @@ import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
 function getDevServerConfig() {
+  let networkStatus;
   try {
-    const canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
-    const networkStatus = JSON.parse(
-      execSync("icp network status --json", {
+    networkStatus = JSON.parse(
+      execSync("icp network status -e local --json", {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
-    return {
-      replicaPort: "8000",
-      headers: {
-        "Set-Cookie": `ic_env=${encodeURIComponent(
-          `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
-        )}; SameSite=Lax;`,
-      },
-      proxy: {
-        "/api": { target: "http://127.0.0.1:8000", changeOrigin: true },
-      },
-    };
-  } catch {}
+  } catch {
+    console.error(
+      "No local network running. Start it and deploy first:\n" +
+        "  icp network start -d && icp deploy"
+    );
+    process.exit(1);
+  }
 
-  throw new Error(
-    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
-  );
+  let canisterId;
+  try {
+    canisterId = execSync("icp canister status backend -e local -i", {
+      encoding: "utf-8",
+      stdio: "pipe",
+    }).trim();
+  } catch {
+    console.error(
+      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
+        "  icp deploy backend"
+    );
+    process.exit(1);
+  }
+
+  return {
+    replicaPort: new URL(networkStatus.api_url).port,
+    headers: {
+      "Set-Cookie": `ic_env=${encodeURIComponent(
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+      )}; SameSite=Lax;`,
+    },
+    proxy: {
+      "/api": { target: networkStatus.api_url, changeOrigin: true },
+    },
+  };
 }
 
 export default defineConfig(({ command }) => {

--- a/rust/who_am_i/src/frontend/vite.config.js
+++ b/rust/who_am_i/src/frontend/vite.config.js
@@ -29,7 +29,7 @@ function getDevServerConfig() {
   } catch {}
 
   throw new Error(
-    "No local network running. Start with:\n  icp network start -d && icp deploy"
+    "No local network running, or 'backend' is not deployed yet. Run:\n  icp network start -d && icp deploy"
   );
 }
 

--- a/rust/who_am_i/src/frontend/vite.config.js
+++ b/rust/who_am_i/src/frontend/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
@@ -33,8 +33,7 @@ function getDevServerConfig() {
   );
 }
 
-export default defineConfig(({ command, mode }) => {
-  const env = loadEnv(mode, "../..", ["CANISTER_"]);
+export default defineConfig(({ command }) => {
   const devConfig = command === "serve" ? getDevServerConfig() : undefined;
 
   return {
@@ -47,9 +46,6 @@ export default defineConfig(({ command, mode }) => {
       }),
     ],
     define: {
-      "process.env.CANISTER_ID_BACKEND": JSON.stringify(
-        env.CANISTER_ID_BACKEND
-      ),
       "process.env.REPLICA_PORT": JSON.stringify(devConfig?.replicaPort ?? ""),
     },
     optimizeDeps: {
@@ -59,7 +55,6 @@ export default defineConfig(({ command, mode }) => {
       ? {
           headers: devConfig.headers,
           proxy: devConfig.proxy,
-          host: devConfig.host,
         }
       : undefined,
   };

--- a/rust/who_am_i/src/frontend/vite.config.js
+++ b/rust/who_am_i/src/frontend/vite.config.js
@@ -3,18 +3,21 @@ import { execSync } from "child_process";
 import react from "@vitejs/plugin-react";
 import { icpBindgen } from "@icp-sdk/bindgen/plugins/vite";
 
+const CANISTER_NAME = "backend";
+const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
+
 function getDevServerConfig() {
   let networkStatus;
   try {
     networkStatus = JSON.parse(
-      execSync("icp network status -e local --json", {
+      execSync(`icp network status -e ${ENVIRONMENT} --json`, {
         encoding: "utf-8",
         stdio: "pipe",
       })
     );
   } catch {
     console.error(
-      "No local network running. Start it and deploy first:\n" +
+      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
         "  icp network start -d && icp deploy"
     );
     process.exit(1);
@@ -22,14 +25,14 @@ function getDevServerConfig() {
 
   let canisterId;
   try {
-    canisterId = execSync("icp canister status backend -e local -i", {
-      encoding: "utf-8",
-      stdio: "pipe",
-    }).trim();
+    canisterId = execSync(
+      `icp canister status ${CANISTER_NAME} -e ${ENVIRONMENT} -i`,
+      { encoding: "utf-8", stdio: "pipe" }
+    ).trim();
   } catch {
     console.error(
-      "Canister 'backend' is not deployed on the local network. Deploy it first:\n" +
-        "  icp deploy backend"
+      `Canister "${CANISTER_NAME}" is not deployed in environment "${ENVIRONMENT}". Deploy it first:\n` +
+        `  icp deploy ${CANISTER_NAME} -e ${ENVIRONMENT}`
     );
     process.exit(1);
   }
@@ -38,7 +41,7 @@ function getDevServerConfig() {
     replicaPort: new URL(networkStatus.api_url).port,
     headers: {
       "Set-Cookie": `ic_env=${encodeURIComponent(
-        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:backend=${canisterId}`
+        `ic_root_key=${networkStatus.root_key}&PUBLIC_CANISTER_ID:${CANISTER_NAME}=${canisterId}`
       )}; SameSite=Lax;`,
     },
     proxy: {

--- a/rust/who_am_i/src/frontend/vite.config.js
+++ b/rust/who_am_i/src/frontend/vite.config.js
@@ -15,11 +15,17 @@ function getDevServerConfig() {
         stdio: "pipe",
       })
     );
-  } catch {
-    console.error(
-      `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
-        "  icp network start -d && icp deploy"
-    );
+  } catch (error) {
+    if (String(error.stderr).includes("does not contain an environment named")) {
+      console.error(
+        `Unknown environment "${ENVIRONMENT}". Check ICP_ENVIRONMENT against the environments in icp.yaml.`
+      );
+    } else {
+      console.error(
+        `No network running for environment "${ENVIRONMENT}". Start it and deploy first:\n` +
+          `  icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}`
+      );
+    }
     process.exit(1);
   }
 

--- a/rust/x509/backend/tests/integration_tests.rs
+++ b/rust/x509/backend/tests/integration_tests.rs
@@ -19,7 +19,7 @@ fn load_wasm() -> Vec<u8> {
 }
 
 fn pic_and_canister_id(ca_key_information: CaKeyInformation) -> (pocket_ic::PocketIc, Principal) {
-    // with_test_threshold_keys_subnet provides test_key_1 and dfx_test_key for all algorithms.
+    // with_test_threshold_keys_subnet provides test_key_1 for all algorithms.
     let pic = PocketIcBuilder::new()
         .with_application_subnet()
         .with_test_threshold_keys_subnet()


### PR DESCRIPTION
AGENTS.md:49 says to always use icp-cli and never dfx, but the repo still carried dfx-era plumbing in six frontends and three key-name comments. This removes all of it.

### 1. The dfx fallback branch (`cert-var`, `flying_ninja`)

Both `vite.config.js` files had a full `// Try dfx` branch — `dfx ping` + `dfx canister id backend`, proxying `/api` to the dfx replica port `4943` — reached only when the icp-cli branch throws. Removed, along with:

- the `or:\n  dfx start --background && dfx deploy` half of the no-network error
- the `or 'dfx deploy'` half of `actor.js`'s missing-canister-ID error

They now match `rust/qrcode`, which was already icp-cli-only.

### 2. The dead `CANISTER_ID_*` env path (all six frontends)

Every one of the six baked a dfx-only canister-ID fallback into the bundle: `loadEnv(mode, "..", ["CANISTER_"])` feeding a `process.env.CANISTER_ID_BACKEND` define, which `actor.js` consulted when the `ic_env` cookie carried no canister ID.

Those vars come from the `.env` that dfx writes on deploy — a file AGENTS.md:91 forbids committing — so **the fallback could never fire in this repo**. Canister IDs now come from the cookie alone, which is what icp-cli populates in both `icp deploy` and `vite dev`.

Six examples, not the three first spotted: `motoko/cert-var`, `motoko/filevault`, `motoko/who_am_i`, `rust/flying_ninja`, `rust/qrcode`, `rust/who_am_i`.

### 3. `dfx_test_key` is no longer advertised

The local network (PocketIC) provisions `test_key_1` and `key_1` to mimic mainnet, so `dfx_test_key` buys nothing locally — and the repo already used `test_key_1` everywhere it actually names a key (`threshold-ecdsa`, `threshold-schnorr`, `x509`, `basic_bitcoin`, all the vetkeys examples). The three remaining mentions were comments, not usage:

- `rust/basic_ethereum/backend/lib.rs` — the `InitArg` doc comment offered `"dfx_test_key"` (local dfx) as *the* local-development choice. Now names only `test_key_1` (test key, works on the local network and ICP mainnet) and `key_1` (mainnet production), matching how `threshold-ecdsa` and `x509` already phrase it.
- `rust/threshold-schnorr` and `rust/x509` integration tests — comments noting that `with_test_threshold_keys_subnet()` also provides `dfx_test_key`. True, but beside the point: both tests use `test_key_1`.

`grep` for `dfx_test_key` (and "local dfx") across the repo now returns nothing.

### 4. Incidental

`host: devConfig.host` in both `who_am_i` configs — always `undefined`, since `getDevServerConfig()` never returns a `host`. It was the dfx branch that set one.

### 5. One dev-server preflight shape across all 23 configs (from review)

Copilot flagged the `getDevServerConfig()` throw on the two configs this branch already touched, and it was right — the failure is broader than the review said. `icp canister status backend -e local -i` is the **first** call in the try block and it fails on a *canister-ID lookup*, before it ever reaches the network:

```
$ icp canister status frontend -e local -i     # network DOWN
Error: failed to lookup canister ID for canister 'frontend' in environment 'local'

$ icp canister status frontend -e local -i     # network UP, not deployed
Error: failed to lookup canister ID for canister 'frontend' in environment 'local'
```

Identical either way (verified locally against a running network), so a running-but-undeployed project got told its network was down. The suggested remedy already covered both cases; only the diagnosis was wrong.

Rewording turned out to paper over a structural problem — two distinct causes sharing one try/catch means no wording can be accurate — so **all 23 dev-server configs were converged on one preflight shape instead.**

`hello_world`'s shape was closer but not correct either: it splits the canister lookup into its own try/catch with a precise message, but leaves `icp network status` unguarded, so a down network surfaces a raw `Command failed: icp network status ...` plus a vite stack instead of a remedy. It also reads the proxy target from `networkStatus.api_url` rather than hardcoding a port, which the other 15 did not.

Every config now does the same two-step preflight, each step guarded separately, each failing with its own message and `exit 1`:

```
No local network running. Start it and deploy first:
  icp network start -d && icp deploy

Canister 'backend' is not deployed on the local network. Deploy it first:
  icp deploy backend
```

Both `execSync` calls take `stdio: "pipe"`, so the raw CLI error is suppressed and only the actionable message shows.

**The proxy target is now `networkStatus.api_url` everywhere**, replacing hardcoded `http://127.0.0.1:8000` in 15 configs. Not cosmetic: on a project configured for another port — or `gateway.port: 0` for parallel worktrees — the dev server was silently proxying to whatever sat on 8000, possibly *another project's network*. `replicaPort` in `filevault` and both `who_am_i` is likewise derived from `api_url` instead of the `"8000"` literal, so the Internet Identity URL they build is correct on any port.

Verified end-to-end on `rust/qrcode` against a network on port 8125:

| case | result |
| --- | --- |
| no network | network message, no stack, no raw CLI error |
| network up, not deployed | deploy message — the case flagged here |
| deployed | dev server starts; `GET /api/v2/status` through the proxy returns byte-identical output to a direct call on 8125, confirming it follows `api_url` and not 8000 |

All 23 files parse; each has both guards and none hardcodes a port.

### 6. Environment-agnostic and identical

Unifying the error handling still left two shapes: 15 configs hardcoded `-e local` and the canister name inline, while the other 8 read `ICP_ENVIRONMENT` and used a `CANISTER_NAME` constant. Only the latter could target anything but the local network.

All 23 now share the same two module-level constants and a **byte-identical** `getDevServerConfig()` — verified as one md5 across all 23, modulo indentation and the optional `replicaPort` line:

```js
const CANISTER_NAME = "backend";
const ENVIRONMENT = process.env.ICP_ENVIRONMENT || "local";
```

Every `icp` invocation and every message interpolates them, so the printed remedy is the one that actually applies:

```
Canister "backend" is not deployed in environment "local". Deploy it first:
  icp deploy backend -e local
```

The 8 inline configs were refactored to call the helper instead of open-coding the preflight, so their `defineConfig` bodies collapse to the build early-return plus `server: getDevServerConfig()`. Cookie key order is uniform too (`ic_root_key` first). No config hardcodes `-e local`, `127.0.0.1:8000`, or a canister name any more.

A follow-up review caught the one command that still dropped the environment — the network guard's `icp network start -d && icp deploy`, while the other three (`network status`, `canister status`, `deploy <name>`) already carried `-e ${ENVIRONMENT}`. Now:

```
icp network start -d -e ${ENVIRONMENT} && icp deploy -e ${ENVIRONMENT}
```

That check surfaced a second case worth separating: `icp network status -e <env>` fails for two different reasons, and only one is "network not running".

```
$ icp network status -e nope --json
Error: project does not contain an environment named 'nope'
```

A typo'd or undefined `ICP_ENVIRONMENT` was reported as a stopped network, with a remedy that cannot work (`icp network start -e nope` fails identically). The guard now branches on that stderr and says `Unknown environment "nope". Check ICP_ENVIRONMENT against the environments in icp.yaml.` instead. For a genuinely non-local environment the assumption holds with no special case: `icp network status -e ic --json` succeeds even without an `environments:` block, returning the mainnet `api_url`, so the guard passes and the dev server proxies to mainnet.

Re-verified on `rust/qrcode` (helper group) against a network on port 8127 — no network, unknown environment, network-up-not-deployed, and the deployed happy path with a byte-identical proxied `/api/v2/status` — and on `rust/hello_world` (converted inline group), where `npm run build` succeeds without invoking `icp` and the dev server prints the network guard.

### Kept deliberately

- **`REPLICA_PORT`** — live, not dead. `filevault` and both `who_am_i` need it to reach II on the network port rather than the dev-server port. The `define` block stays in those three for it.
- **`.github/workflows/ninja_pr_checks.yml`** — pins dfx 0.31.0 on purpose; ICP Ninja genuinely runs dfx, and it's `@dfinity/ninja-devs`-owned.

### Verification

32 files. All changed JS files parse. `npm run build` succeeds for `rust/qrcode` (define removed entirely) and `motoko/who_am_i` (define retained for `REPLICA_PORT`); neither bundle has an unresolved `process.env` reference from our code. `cargo check --target wasm32-unknown-unknown` passes for `basic_ethereum`.
