### PR TITLE
docs: default to icp.net, drop the last icp0.io / ic0.app references

### DIFF
--- a/hosting/oisy-signer-demo/frontend/public/_headers
+++ b/hosting/oisy-signer-demo/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/hosting/oisy-signer-demo/frontend/src/hooks/useOisyWallet.js
+++ b/hosting/oisy-signer-demo/frontend/src/hooks/useOisyWallet.js
@@ -20,7 +20,9 @@ const oisySigner = new Signer({
 async function initFromPrincipal(principalText) {
   const principal = Principal.fromText(principalText);
   const accountIdentifier = AccountIdentifier.fromPrincipal({ principal });
-  const defaultAgent = await HttpAgent.create({ host: 'https://icp0.io' });
+  // `host` is the API endpoint calls go to, not the gateway the app is served
+  // from. Mainnet API boundary nodes live at icp-api.io.
+  const defaultAgent = await HttpAgent.create({ host: 'https://icp-api.io' });
   return { principal, accountIdentifier, defaultAgent };
 }
 

--- a/motoko/daily_planner/backend/main.mo
+++ b/motoko/daily_planner/backend/main.mo
@@ -136,7 +136,7 @@ actor DailyPlanner {
       };
 
       // Perform HTTPS outcall using roughly 100B cycles.
-      // See https outcall cost calculator: https://7joko-hiaaa-aaaal-ajz7a-cai.icp0.io.
+      // See https outcall cost calculator: https://7joko-hiaaa-aaaal-ajz7a-cai.icp.net.
       // Unused cycles are returned.
       let http_response : IC.HttpRequestResult = await (with cycles = 100_000_000_000) ic.http_request(http_request);
 

--- a/motoko/vetkeys/basic_bls_signing/frontend/public/_headers
+++ b/motoko/vetkeys/basic_bls_signing/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/motoko/vetkeys/basic_ibe/frontend/public/_headers
+++ b/motoko/vetkeys/basic_ibe/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/motoko/vetkeys/encrypted_notes_app_vetkd/frontend/public/_headers
+++ b/motoko/vetkeys/encrypted_notes_app_vetkd/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/motoko/vetkeys/password_manager/frontend/public/_headers
+++ b/motoko/vetkeys/password_manager/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/motoko/vetkeys/password_manager_with_metadata/frontend/public/_headers
+++ b/motoko/vetkeys/password_manager_with_metadata/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/native-apps/unity_ii_deeplink/README.md
+++ b/native-apps/unity_ii_deeplink/README.md
@@ -152,7 +152,7 @@ Change the scheme constants and add `pathPrefix` and `autoVerify`:
 
 ```csharp
 const string kAndroidScheme = "https";
-const string kAndroidHost = "<your-canister-id>.icp0.io";
+const string kAndroidHost = "<your-canister-id>.icp.net";
 ```
 
 In `AppendAndroidIntentFilter`, add `autoVerify` to the intent filter and `pathPrefix` to the data node:
@@ -189,10 +189,10 @@ The static-site canister uploads `.well-known/` automatically and serves `assetl
 **4. Update the callback URL in `ii-bridge/src/main.js`:**
 
 ```js
-const url = "https://<your-canister-id>.icp0.io/authorize#delegation=" + ...
+const url = "https://<your-canister-id>.icp.net/authorize#delegation=" + ...
 ```
 
-After redeployment, Android verifies `assetlinks.json` during app install. The OS routes `https://<your-canister-id>.icp0.io/authorize#delegation=…` exclusively to your app without showing a chooser dialog.
+After redeployment, Android verifies `assetlinks.json` during app install. The OS routes `https://<your-canister-id>.icp.net/authorize#delegation=…` exclusively to your app without showing a chooser dialog.
 
 ### iOS Universal Links (HTTPS, mainnet only)
 
@@ -213,7 +213,7 @@ using UnityEditor.iOS.Xcode;
 
 public class iOSPostBuildProcessor
 {
-    const string kDomain = "<your-canister-id>.icp0.io";
+    const string kDomain = "<your-canister-id>.icp.net";
 
     [PostProcessBuild]
     public static void OnPostprocessBuild(BuildTarget buildTarget, string path)
@@ -270,15 +270,15 @@ Find your Team ID in the Apple Developer portal. Bundle ID is the one set in Uni
   Content-Type: application/json
 ```
 
-After redeployment, verify with `curl -I https://<canister-id>.icp0.io/.well-known/apple-app-site-association` (expect `content-type: application/json`).
+After redeployment, verify with `curl -I https://<canister-id>.icp.net/.well-known/apple-app-site-association` (expect `content-type: application/json`).
 
 **5. Update the callback URL in `ii-bridge/src/main.js`:**
 
 ```js
-const url = "https://<your-canister-id>.icp0.io/authorize#delegation=" + ...
+const url = "https://<your-canister-id>.icp.net/authorize#delegation=" + ...
 ```
 
-After redeployment, iOS verifies the AASA file at app install time. The OS routes `https://<your-canister-id>.icp0.io/authorize#delegation=…` directly to your app — no other app can intercept it.
+After redeployment, iOS verifies the AASA file at app install time. The OS routes `https://<your-canister-id>.icp.net/authorize#delegation=…` directly to your app — no other app can intercept it.
 
 ## Updating the Candid interface
 

--- a/native-apps/unity_ii_deeplink/unity_project/Assets/Plugins/ICP.NET/UnityHttp.cs
+++ b/native-apps/unity_ii_deeplink/unity_project/Assets/Plugins/ICP.NET/UnityHttp.cs
@@ -40,7 +40,7 @@ public class UnityHttpClient : IHttpClient
             return absolute;
         if (!url.StartsWith("/"))
             url = "/" + url;
-        return new Uri("https://ic0.app" + url);
+        return new Uri("https://icp.net" + url);
     }
 
     private static HttpResponse ParseResponse(UnityWebRequest request)

--- a/native-apps/unity_ii_deeplink/unity_project/README.md
+++ b/native-apps/unity_ii_deeplink/unity_project/README.md
@@ -38,7 +38,7 @@ Select the `AgentAndPlugin` GameObject in the scene hierarchy and set these fiel
 
 | Field | Local (emulator) | Mainnet |
 |-------|-----------------|---------|
-| `Ii Bridge Url` | `http://ii-bridge.local.localhost:8000` | `https://<ii-bridge-canister-id>.icp0.io` |
+| `Ii Bridge Url` | `http://ii-bridge.local.localhost:8000` | `https://<ii-bridge-canister-id>.icp.net` |
 | `Greet Backend Canister` | output of `icp canister status backend -i` | output of `icp canister status backend -i -e ic` |
 | `Ic Gateway` | `http://localhost:8000` | `https://icp-api.io` (default) |
 

--- a/rust/image-classification/frontend/public/_headers
+++ b/rust/image-classification/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self' 'unsafe-eval';connect-src 'self' https://icp0.io https://*.icp0.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self' 'unsafe-eval';connect-src 'self' https://icp.net https://*.icp.net;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/rust/vetkeys/basic_bls_signing/frontend/public/_headers
+++ b/rust/vetkeys/basic_bls_signing/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/rust/vetkeys/basic_ibe/frontend/public/_headers
+++ b/rust/vetkeys/basic_ibe/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/rust/vetkeys/basic_timelock_ibe/frontend/public/_headers
+++ b/rust/vetkeys/basic_timelock_ibe/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/rust/vetkeys/encrypted_notes_app_vetkd/frontend/public/_headers
+++ b/rust/vetkeys/encrypted_notes_app_vetkd/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self';style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self';style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/rust/vetkeys/password_manager/frontend/public/_headers
+++ b/rust/vetkeys/password_manager/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*

--- a/rust/vetkeys/password_manager_with_metadata/frontend/public/_headers
+++ b/rust/vetkeys/password_manager_with_metadata/frontend/public/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp.net https://*.icp.net https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;
 
 # Fingerprinted build assets never change - cache them hard
 /assets/*


### PR DESCRIPTION
`icp.net` is the current default gateway domain for new frontend canisters, replacing `icp0.io`. All three official domains (`ic0.app`, `icp0.io`, `icp.net`) stay live and Internet Identity canonicalizes across them, so **nothing here was broken** — but the repo advertised the old default 37 times against 5 uses of the new one, including one pair of twin examples that disagreed with each other (`rust/daily_planner` already said `icp.net`; `motoko/daily_planner` said `icp0.io`).

### Swept

- **`native-apps/unity_ii_deeplink`** README (×6) + `unity_project/README.md` — the Android App Links / iOS Universal Links walkthrough. Safe as a single sweep because `assetlinks.json` and the AASA file **carry no domain of their own** (verified — they hold only app IDs and fingerprints) and are served by the same canister at every gateway domain. So `kAndroidHost`, `kDomain`, the callback URL, and the `curl` verification step all move together and stay matched. Every one is a `<your-canister-id>` placeholder, so no real URL changes.
- **`motoko/daily_planner`** — the HTTPS-outcall cost-calculator link, now matching its Rust twin.
- **`UnityHttp.cs`** — the base URI used when a relative URL reaches the adapter (`ic0.app`, the last one).
- **13 `_headers`** — `connect-src` now lists `https://icp.net https://*.icp.net` instead of the `icp0.io` pair. These apps talk to their own origin (covered by `'self'`) or to `icp-api.io` (unchanged), so this entry is belt-and-braces either way.

`grep` for `icp0.io` / `ic0.app` outside `node_modules` and `.claude/` now returns nothing.

### One thing that is *not* a domain rename

`hosting/oisy-signer-demo` built its anonymous agent with `host: 'https://icp0.io'`. `host` is the **API endpoint** calls go to, not the gateway the app is served from — so the correct value is `https://icp-api.io` (or omitting it and letting `@icp-sdk/core` resolve). Renaming it to `icp.net` would have been the same mistake in newer clothes. Fixed to `icp-api.io`, with a comment saying why.

### Note for reviewers

`UnityHttp.cs` is CRLF. The diff is the one intended line — I clobbered the line endings on a first pass and redid the edit byte-wise, so please shout if anything looks off there.
